### PR TITLE
SymBotAuth.kmAuthClient doesn't use proxy settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.symphony.platformsolutions</groupId>
     <artifactId>symphony-api-client-java</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.8-SNAPSHOT</version>
     <name>Symphony API Client</name>
     <url>https://github.com/SymphonyPlatformSolutions/symphony-api-client-java</url>
     <description>Symphony API Client provided by Symphony Platform Solutions team</description>

--- a/src/main/java/authentication/SymBotAuth.java
+++ b/src/main/java/authentication/SymBotAuth.java
@@ -34,7 +34,6 @@ public final class SymBotAuth extends APIClient implements ISymAuth {
             this.sessionAuthClient = client;
             this.kmAuthClient = client;
         } else {
-            this.kmAuthClient = client;
             ClientConfig clientConfig = new ClientConfig();
             clientConfig.connectorProvider(new ApacheConnectorProvider());
             clientConfig
@@ -49,6 +48,7 @@ public final class SymBotAuth extends APIClient implements ISymAuth {
             Client proxyClient = clientBuilder.withConfig(clientConfig)
                     .build();
             this.sessionAuthClient = proxyClient;
+            this.kmAuthClient = proxyClient;
         }
     }
 

--- a/src/main/java/clients/SymBotClient.java
+++ b/src/main/java/clients/SymBotClient.java
@@ -79,8 +79,6 @@ public final class SymBotClient implements ISymClient {
             this.agentClient = HttpClientBuilderHelper
                     .getHttpClientBuilderWithTruststore(config).build();
         } else {
-            this.agentClient = HttpClientBuilderHelper
-                    .getHttpClientBuilderWithTruststore(config).build();
             ClientConfig clientConfig = new ClientConfig();
             clientConfig.connectorProvider(new ApacheConnectorProvider());
             clientConfig.property(ClientProperties.PROXY_URI,
@@ -92,6 +90,9 @@ public final class SymBotClient implements ISymClient {
                 clientConfig.property(ClientProperties.PROXY_PASSWORD,
                         config.getProxyPassword());
             }
+            this.agentClient = HttpClientBuilderHelper
+                    .getHttpClientBuilderWithTruststore(config)
+                    .withConfig(clientConfig).build();
             this.podClient =  HttpClientBuilderHelper
                     .getHttpClientBuilderWithTruststore(config)
                     .withConfig(clientConfig).build();

--- a/src/main/java/clients/symphony/api/MessagesClient.java
+++ b/src/main/java/clients/symphony/api/MessagesClient.java
@@ -81,7 +81,7 @@ public final class MessagesClient extends APIClient {
                     }
                 }
                 Entity entity = Entity.entity(multiPart,
-                        MediaType.MULTIPART_FORM_DATA_TYPE);
+                        MultiPartMediaTypes.createFormData());
                 Response response = invocationBuilder.post(entity);
 
                 if (response.getStatus()


### PR DESCRIPTION
Apply proxy settings to both agentClient and kmAuthClient when using config.json.

I also upgraded pom.xml to SNAPSHOT.
