### PR TITLE
No longer use botEmailAddress to get userId of bot

### DIFF
--- a/src/main/java/clients/SymBotClient.java
+++ b/src/main/java/clients/SymBotClient.java
@@ -57,12 +57,8 @@ public final class SymBotClient implements ISymClient {
         this.podClient = ClientBuilder.newClient(podClientConfig);
         this.agentClient = ClientBuilder.newClient(agentClientConfig);
         try {
-            botUserInfo = this.getUsersClient()
-                    .getUserFromEmail(config.getBotEmailAddress(),
-                            true);
-        } catch (NoContentException e) {
-            e.printStackTrace();
-        }  catch (SymClientException e) {
+            botUserInfo = this.getUsersClient().getSessionUser();
+        } catch (SymClientException e) {
             e.printStackTrace();
         }
         SymMessageParser.createInstance(this);
@@ -98,10 +94,7 @@ public final class SymBotClient implements ISymClient {
                     .withConfig(clientConfig).build();
         }
         try {
-            botUserInfo = this.getUsersClient()
-                    .getUserFromEmail(config.getBotEmailAddress(), true);
-        } catch (NoContentException e) {
-            e.printStackTrace();
+            botUserInfo = this.getUsersClient().getSessionUser();
         }  catch (SymClientException e) {
             e.printStackTrace();
         }

--- a/src/main/java/clients/symphony/api/UsersClient.java
+++ b/src/main/java/clients/symphony/api/UsersClient.java
@@ -259,4 +259,35 @@ public class UsersClient extends APIClient{
             }
         }
     }
+
+    public UserInfo getSessionUser(){
+               UserInfo info ;
+
+        Response response = null;
+
+        try {
+            response = botClient.getPodClient()
+                .target(CommonConstants.HTTPSPREFIX + botClient.getConfig().getPodHost() + ":" + botClient.getConfig()
+                    .getPodPort())
+                .path(PodConstants.GETSESSIONUSER)
+                .request(MediaType.APPLICATION_JSON)
+                .header("sessionToken",botClient.getSymAuth().getSessionToken())
+                .get();
+            if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+                try {
+                    handleError(response, botClient);
+                } catch (UnauthorizedException ex) {
+                    return getSessionUser();
+                }
+                return null;
+            } else {
+                info = response.readEntity(UserInfo.class);
+            }
+            return info;
+        } finally {
+            if (response != null) {
+                response.close();
+            }
+        }
+    }
 }

--- a/src/main/java/clients/symphony/api/constants/PodConstants.java
+++ b/src/main/java/clients/symphony/api/constants/PodConstants.java
@@ -51,4 +51,6 @@ public class PodConstants {
     public static final String ADMINCREATEUSER =  POD +"/v2/admin/user/create";
     public static final String ADMINUPDATEUSER = POD +"/v2/admin/user/{uid}/update";
     public static final String ADMINUPDATEAVATAR = POD + "/v1/admin/user/{uid}/avatar/update";
+    
+    public static final String GETSESSIONUSER = POD+"/v2/sessioninfo";
 }


### PR DESCRIPTION
Added CONSTANT GETSESSIONUSER for v2/sessioninfo
Added function getSessionUser to UsersClient to call v2/sessioninfo
Changed SymBotClient to use getSessionUser instead of getUserFromEmail

Using botEmailAddress in config file can result in the bot processing its own messages when they come through the datafeed when user provides wrong email or no email.

Using sessioninfo guarantees to get the info of the bot