### PR TITLE
Changing type from UserInfo to AdminUserInfo on AdminClient

### DIFF
--- a/src/main/java/clients/symphony/api/AdminClient.java
+++ b/src/main/java/clients/symphony/api/AdminClient.java
@@ -188,7 +188,7 @@ public final class AdminClient extends APIClient {
         }
     }
 
-    public UserInfo getUser(Long uid) throws NoContentException,
+    public AdminUserInfo getUser(Long uid) throws NoContentException,
             SymClientException {
         UserInfo info;
         Response response = null;


### PR DESCRIPTION
The payload of https://rest-api.symphony.com/v1.53.1/reference#get-user-v2 must be parsed by AdminUserInfo.