### PR TITLE
Removed non existing 'description' field from Password class

### DIFF
--- a/src/main/java/model/Password.java
+++ b/src/main/java/model/Password.java
@@ -2,19 +2,10 @@ package model;
 
 public class Password {
 
-    private String description;
     private String hSalt;
     private String hPassword;
     private String khSalt;
     private String khPassword;
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
 
     public String gethSalt() {
         return hSalt;


### PR DESCRIPTION
When trying to call `createUser(...)`got the following response : 

```
Unrecognized field "description" (class com.symphony.api.pod.model.Password), not marked as ignorable (4 known properties: "khPassword", "khSalt", "hSalt", "hPassword"])
 at [Source: org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream@23c55fb9; line: 1, column: 507] (through reference chain: com.symphony.api.pod.model.V2UserCreate["password"]->com.symphony.api.pod.model.Password["description"])
```

This is because the Password POJO contains a **description** field that the pod does not expect.

This PR removes the field.