### PR TITLE
Add Essential Unit Tests from Diffblue Cover

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.6.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/src/test/java/authentication/SymBotAuthTest.java
+++ b/src/test/java/authentication/SymBotAuthTest.java
@@ -1,0 +1,35 @@
+package authentication;
+
+import authentication.SymBotAuth;
+import configuration.SymConfig;
+import org.glassfish.jersey.client.ClientConfig;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SymBotAuthTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SymBotAuthTest() throws Exception {
+    // Arrange
+    SymConfig inputConfig = new SymConfig();
+    ClientConfig sessionAuthClientConfig = new ClientConfig();
+    ClientConfig kmAuthClientConfig = new ClientConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    new SymBotAuth(inputConfig, sessionAuthClientConfig, kmAuthClientConfig);
+  }
+
+  @Test
+  public void SymBotAuthTest2() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    new SymBotAuth(config);
+  }
+}

--- a/src/test/java/authentication/SymBotRSAAuthTest.java
+++ b/src/test/java/authentication/SymBotRSAAuthTest.java
@@ -1,0 +1,171 @@
+package authentication;
+
+import static org.junit.Assert.assertEquals;
+import authentication.SymBotRSAAuth;
+import clients.SymOBOClient;
+import configuration.SymConfig;
+import exceptions.AuthenticationException;
+import java.io.InputStream;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.message.internal.OutboundJaxrsResponse;
+import org.glassfish.jersey.message.internal.OutboundMessageContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.powermock.reflect.Whitebox;
+
+public class SymBotRSAAuthTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SymBotRSAAuthTest() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+    ClientConfig sessionAuthClientConfig = new ClientConfig();
+    ClientConfig kmAuthClientConfig = new ClientConfig();
+
+    // Act
+    SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(config, sessionAuthClientConfig, kmAuthClientConfig);
+
+    // Assert
+    String sessionToken = symBotRSAAuth.getSessionToken();
+    assertEquals(null, sessionToken);
+    assertEquals(null, symBotRSAAuth.getKmToken());
+  }
+
+  @Test
+  public void SymBotRSAAuthTest2() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(symConfig);
+
+    // Assert
+    String sessionToken = symBotRSAAuth.getSessionToken();
+    assertEquals(null, sessionToken);
+    assertEquals(null, symBotRSAAuth.getKmToken());
+    assertEquals(35000, symConfig.getConnectionTimeout());
+  }
+
+  @Test
+  public void authenticateTest() throws Exception {
+    // Arrange
+    SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(new SymConfig());
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    symBotRSAAuth.authenticate();
+  }
+
+  @Test
+  public void getKmTokenTest() throws Exception {
+    // Arrange
+    SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(new SymConfig());
+
+    // Act
+    String actual = symBotRSAAuth.getKmToken();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRSAPrivateKeyFileTest() throws Exception {
+    // Arrange
+    SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(new SymConfig());
+    SymConfig config = new SymConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    symBotRSAAuth.getRSAPrivateKeyFile(config);
+  }
+
+  @Test
+  public void getSessionTokenTest() throws Exception {
+    // Arrange
+    SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(new SymConfig());
+
+    // Act
+    String actual = symBotRSAAuth.getSessionToken();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void handleErrorTest() throws Exception {
+    // Arrange
+    SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(new SymConfig());
+    Response.StatusType statusType = Whitebox.newInstance(Response.StatusType.class);
+    OutboundJaxrsResponse response = new OutboundJaxrsResponse(statusType, new OutboundMessageContext());
+    SymConfig symConfig = new SymConfig();
+    SymConfig symConfig1 = new SymConfig();
+    symConfig1.setAgentHost("aaaaa");
+    symConfig1.setAgentHost("aaaaa");
+    SymOBOClient botClient = new SymOBOClient(symConfig, null);
+
+    // Act and Assert
+    thrown.expect(IllegalStateException.class);
+    symBotRSAAuth.handleError(response, botClient);
+  }
+
+  @Test
+  public void kmAuthenticateTest() throws Exception {
+    // Arrange
+    SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(new SymConfig());
+
+    // Act and Assert
+    thrown.expect(AuthenticationException.class);
+    symBotRSAAuth.kmAuthenticate();
+  }
+
+  @Test
+  public void logoutTest() throws Exception {
+    // Arrange
+    SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(new SymConfig());
+
+    // Act and Assert
+    thrown.expect(ProcessingException.class);
+    symBotRSAAuth.logout();
+  }
+
+  @Test
+  public void sessionAuthenticateTest() throws Exception {
+    // Arrange
+    SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(new SymConfig());
+
+    // Act and Assert
+    thrown.expect(AuthenticationException.class);
+    symBotRSAAuth.sessionAuthenticate();
+  }
+
+  @Test
+  public void setKmTokenTest() throws Exception {
+    // Arrange
+    SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(new SymConfig());
+    String kmToken = "aaaaa";
+
+    // Act
+    symBotRSAAuth.setKmToken(kmToken);
+
+    // Assert
+    assertEquals("aaaaa", symBotRSAAuth.getKmToken());
+  }
+
+  @Test
+  public void setSessionTokenTest() throws Exception {
+    // Arrange
+    SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(new SymConfig());
+    String sessionToken = "aaaaa";
+
+    // Act
+    symBotRSAAuth.setSessionToken(sessionToken);
+
+    // Assert
+    assertEquals("aaaaa", symBotRSAAuth.getSessionToken());
+  }
+}

--- a/src/test/java/authentication/SymExtensionAppAuthTest.java
+++ b/src/test/java/authentication/SymExtensionAppAuthTest.java
@@ -1,0 +1,34 @@
+package authentication;
+
+import authentication.SymExtensionAppAuth;
+import configuration.SymConfig;
+import org.glassfish.jersey.client.ClientConfig;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SymExtensionAppAuthTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SymExtensionAppAuthTest() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+    ClientConfig sessionAuthClientConfig = new ClientConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    new SymExtensionAppAuth(config, sessionAuthClientConfig);
+  }
+
+  @Test
+  public void SymExtensionAppAuthTest2() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    new SymExtensionAppAuth(config);
+  }
+}

--- a/src/test/java/authentication/SymExtensionAppRSAAuthTest.java
+++ b/src/test/java/authentication/SymExtensionAppRSAAuthTest.java
@@ -1,0 +1,49 @@
+package authentication;
+
+import authentication.SymExtensionAppRSAAuth;
+import authentication.extensionapp.InMemoryTokensRepository;
+import configuration.SymConfig;
+import javax.ws.rs.ProcessingException;
+import org.glassfish.jersey.client.ClientConfig;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import sun.security.pkcs.PKCS8Key;
+
+public class SymExtensionAppRSAAuthTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SymExtensionAppRSAAuthTest() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+    PKCS8Key appPrivateKey = new PKCS8Key();
+
+    // Act and Assert
+    thrown.expect(ProcessingException.class);
+    new SymExtensionAppRSAAuth(config, appPrivateKey);
+  }
+
+  @Test
+  public void SymExtensionAppRSAAuthTest2() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+
+    // Act and Assert
+    thrown.expect(ProcessingException.class);
+    new SymExtensionAppRSAAuth(config);
+  }
+
+  @Test
+  public void SymExtensionAppRSAAuthTest3() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+    ClientConfig sessionAuthClientConfig = new ClientConfig();
+    InMemoryTokensRepository tokensRepository = new InMemoryTokensRepository();
+
+    // Act and Assert
+    thrown.expect(ProcessingException.class);
+    new SymExtensionAppRSAAuth(config, sessionAuthClientConfig, tokensRepository);
+  }
+}

--- a/src/test/java/authentication/SymOBOAuthTest.java
+++ b/src/test/java/authentication/SymOBOAuthTest.java
@@ -1,0 +1,34 @@
+package authentication;
+
+import authentication.SymOBOAuth;
+import configuration.SymConfig;
+import org.glassfish.jersey.client.ClientConfig;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SymOBOAuthTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SymOBOAuthTest() throws Exception {
+    // Arrange
+    SymConfig configuration = new SymConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    new SymOBOAuth(configuration);
+  }
+
+  @Test
+  public void SymOBOAuthTest2() throws Exception {
+    // Arrange
+    SymConfig configuration = new SymConfig();
+    ClientConfig sessionAuthClientConfig = new ClientConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    new SymOBOAuth(configuration, sessionAuthClientConfig);
+  }
+}

--- a/src/test/java/authentication/SymOBORSAAuthTest.java
+++ b/src/test/java/authentication/SymOBORSAAuthTest.java
@@ -1,0 +1,98 @@
+package authentication;
+
+import static org.junit.Assert.assertEquals;
+import authentication.SymOBORSAAuth;
+import configuration.SymConfig;
+import javax.ws.rs.ProcessingException;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.message.internal.MessageBodyProviderNotFoundException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SymOBORSAAuthTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SymOBORSAAuthTest() throws Exception {
+    // Arrange
+    SymConfig configuration = new SymConfig();
+    ClientConfig sessionAuthClientConfig = new ClientConfig();
+
+    // Act
+    SymOBORSAAuth symOBORSAAuth = new SymOBORSAAuth(configuration, sessionAuthClientConfig);
+
+    // Assert
+    assertEquals(null, symOBORSAAuth.getSessionToken());
+  }
+
+  @Test
+  public void SymOBORSAAuthTest2() throws Exception {
+    // Arrange
+    SymConfig configuration = new SymConfig();
+
+    // Act
+    SymOBORSAAuth symOBORSAAuth = new SymOBORSAAuth(configuration);
+
+    // Assert
+    assertEquals(null, symOBORSAAuth.getSessionToken());
+  }
+
+  @Test
+  public void authenticateTest() throws Exception {
+    // Arrange
+    SymOBORSAAuth symOBORSAAuth = new SymOBORSAAuth(new SymConfig());
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    symOBORSAAuth.authenticate();
+  }
+
+  @Test
+  public void getSessionTokenTest() throws Exception {
+    // Arrange
+    SymOBORSAAuth symOBORSAAuth = new SymOBORSAAuth(new SymConfig());
+
+    // Act
+    String actual = symOBORSAAuth.getSessionToken();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserAuthTest() throws Exception {
+    // Arrange
+    SymOBORSAAuth symOBORSAAuth = new SymOBORSAAuth(new SymConfig());
+    String username = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(ProcessingException.class);
+    symOBORSAAuth.getUserAuth(username);
+  }
+
+  @Test
+  public void getUserAuthTest2() throws Exception {
+    // Arrange
+    SymOBORSAAuth symOBORSAAuth = new SymOBORSAAuth(new SymConfig());
+    Long uid = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(ProcessingException.class);
+    symOBORSAAuth.getUserAuth(uid);
+  }
+
+  @Test
+  public void setSessionTokenTest() throws Exception {
+    // Arrange
+    SymOBORSAAuth symOBORSAAuth = new SymOBORSAAuth(new SymConfig());
+    String sessionToken = "aaaaa";
+
+    // Act
+    symOBORSAAuth.setSessionToken(sessionToken);
+
+    // Assert
+    assertEquals("aaaaa", symOBORSAAuth.getSessionToken());
+  }
+}

--- a/src/test/java/authentication/SymOBOUserAuthTest.java
+++ b/src/test/java/authentication/SymOBOUserAuthTest.java
@@ -1,0 +1,141 @@
+package authentication;
+
+import static org.junit.Assert.assertEquals;
+import authentication.SymOBOAuth;
+import authentication.SymOBOUserAuth;
+import configuration.SymConfig;
+import org.glassfish.jersey.client.JerseyClient;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SymOBOUserAuthTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SymOBOUserAuthTest() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+    JerseyClient sessionAuthClient = null;
+    String username = "aaaaa";
+    SymOBOAuth appAuth = null;
+
+    // Act
+    SymOBOUserAuth symOBOUserAuth = new SymOBOUserAuth(config, sessionAuthClient, username, appAuth);
+
+    // Assert
+    assertEquals(null, symOBOUserAuth.getSessionToken());
+  }
+
+  @Test
+  public void SymOBOUserAuthTest2() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+    JerseyClient sessionAuthClient = null;
+    Long uid = new Long(1L);
+    SymOBOAuth appAuth = null;
+
+    // Act
+    SymOBOUserAuth symOBOUserAuth = new SymOBOUserAuth(config, sessionAuthClient, uid, appAuth);
+
+    // Assert
+    assertEquals(null, symOBOUserAuth.getSessionToken());
+  }
+
+  @Test
+  public void authenticateTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserAuth symOBOUserAuth = new SymOBOUserAuth(symConfig, null, new Long(1L), null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    symOBOUserAuth.authenticate();
+  }
+
+  @Test
+  public void getKmTokenTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserAuth symOBOUserAuth = new SymOBOUserAuth(symConfig, null, new Long(1L), null);
+
+    // Act and Assert
+    thrown.expect(RuntimeException.class);
+    symOBOUserAuth.getKmToken();
+  }
+
+  @Test
+  public void getSessionTokenTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserAuth symOBOUserAuth = new SymOBOUserAuth(symConfig, null, new Long(1L), null);
+
+    // Act
+    String actual = symOBOUserAuth.getSessionToken();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void kmAuthenticateTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserAuth symOBOUserAuth = new SymOBOUserAuth(symConfig, null, new Long(1L), null);
+
+    // Act and Assert
+    thrown.expect(RuntimeException.class);
+    symOBOUserAuth.kmAuthenticate();
+  }
+
+  @Test
+  public void logoutTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserAuth symOBOUserAuth = new SymOBOUserAuth(symConfig, null, new Long(1L), null);
+
+    // Act
+    symOBOUserAuth.logout();
+
+    // Assert
+    assertEquals(null, symOBOUserAuth.getSessionToken());
+  }
+
+  @Test
+  public void sessionAuthenticateTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserAuth symOBOUserAuth = new SymOBOUserAuth(symConfig, null, new Long(1L), null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    symOBOUserAuth.sessionAuthenticate();
+  }
+
+  @Test
+  public void setKmTokenTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserAuth symOBOUserAuth = new SymOBOUserAuth(symConfig, null, new Long(1L), null);
+    String kmToken = "aaaak";
+
+    // Act and Assert
+    thrown.expect(RuntimeException.class);
+    symOBOUserAuth.setKmToken(kmToken);
+  }
+
+  @Test
+  public void setSessionTokenTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserAuth symOBOUserAuth = new SymOBOUserAuth(symConfig, null, new Long(1L), null);
+    String sessionToken = "aaaak";
+
+    // Act
+    symOBOUserAuth.setSessionToken(sessionToken);
+
+    // Assert
+    assertEquals("aaaak", symOBOUserAuth.getSessionToken());
+  }
+}

--- a/src/test/java/authentication/SymOBOUserRSAAuthTest.java
+++ b/src/test/java/authentication/SymOBOUserRSAAuthTest.java
@@ -1,0 +1,141 @@
+package authentication;
+
+import static org.junit.Assert.assertEquals;
+import authentication.SymOBOAuth;
+import authentication.SymOBOUserRSAAuth;
+import configuration.SymConfig;
+import org.glassfish.jersey.client.JerseyClient;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SymOBOUserRSAAuthTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SymOBOUserRSAAuthTest() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+    JerseyClient sessionAuthClient = null;
+    String username = "aaaaa";
+    SymOBOAuth appAuth = null;
+
+    // Act
+    SymOBOUserRSAAuth symOBOUserRSAAuth = new SymOBOUserRSAAuth(config, sessionAuthClient, username, appAuth);
+
+    // Assert
+    assertEquals(null, symOBOUserRSAAuth.getSessionToken());
+  }
+
+  @Test
+  public void SymOBOUserRSAAuthTest2() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+    JerseyClient sessionAuthClient = null;
+    Long uid = new Long(1L);
+    SymOBOAuth appAuth = null;
+
+    // Act
+    SymOBOUserRSAAuth symOBOUserRSAAuth = new SymOBOUserRSAAuth(config, sessionAuthClient, uid, appAuth);
+
+    // Assert
+    assertEquals(null, symOBOUserRSAAuth.getSessionToken());
+  }
+
+  @Test
+  public void authenticateTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserRSAAuth symOBOUserRSAAuth = new SymOBOUserRSAAuth(symConfig, null, new Long(1L), null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    symOBOUserRSAAuth.authenticate();
+  }
+
+  @Test
+  public void getKmTokenTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserRSAAuth symOBOUserRSAAuth = new SymOBOUserRSAAuth(symConfig, null, new Long(1L), null);
+
+    // Act and Assert
+    thrown.expect(RuntimeException.class);
+    symOBOUserRSAAuth.getKmToken();
+  }
+
+  @Test
+  public void getSessionTokenTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserRSAAuth symOBOUserRSAAuth = new SymOBOUserRSAAuth(symConfig, null, new Long(1L), null);
+
+    // Act
+    String actual = symOBOUserRSAAuth.getSessionToken();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void kmAuthenticateTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserRSAAuth symOBOUserRSAAuth = new SymOBOUserRSAAuth(symConfig, null, new Long(1L), null);
+
+    // Act and Assert
+    thrown.expect(RuntimeException.class);
+    symOBOUserRSAAuth.kmAuthenticate();
+  }
+
+  @Test
+  public void logoutTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserRSAAuth symOBOUserRSAAuth = new SymOBOUserRSAAuth(symConfig, null, new Long(1L), null);
+
+    // Act
+    symOBOUserRSAAuth.logout();
+
+    // Assert
+    assertEquals(null, symOBOUserRSAAuth.getSessionToken());
+  }
+
+  @Test
+  public void sessionAuthenticateTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserRSAAuth symOBOUserRSAAuth = new SymOBOUserRSAAuth(symConfig, null, new Long(1L), null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    symOBOUserRSAAuth.sessionAuthenticate();
+  }
+
+  @Test
+  public void setKmTokenTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserRSAAuth symOBOUserRSAAuth = new SymOBOUserRSAAuth(symConfig, null, new Long(1L), null);
+    String kmToken = "aaaak";
+
+    // Act and Assert
+    thrown.expect(RuntimeException.class);
+    symOBOUserRSAAuth.setKmToken(kmToken);
+  }
+
+  @Test
+  public void setSessionTokenTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymOBOUserRSAAuth symOBOUserRSAAuth = new SymOBOUserRSAAuth(symConfig, null, new Long(1L), null);
+    String sessionToken = "aaaak";
+
+    // Act
+    symOBOUserRSAAuth.setSessionToken(sessionToken);
+
+    // Assert
+    assertEquals("aaaak", symOBOUserRSAAuth.getSessionToken());
+  }
+}

--- a/src/test/java/authentication/extensionapp/InMemoryTokensRepositoryTest.java
+++ b/src/test/java/authentication/extensionapp/InMemoryTokensRepositoryTest.java
@@ -1,0 +1,35 @@
+package authentication.extensionapp;
+
+import authentication.extensionapp.InMemoryTokensRepository;
+import java.util.Optional;
+import model.AppAuthResponse;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class InMemoryTokensRepositoryTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void getTest() throws Exception {
+    // Arrange
+    InMemoryTokensRepository inMemoryTokensRepository = new InMemoryTokensRepository();
+    String appToken = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    inMemoryTokensRepository.get(appToken);
+  }
+
+  @Test
+  public void saveTest() throws Exception {
+    // Arrange
+    InMemoryTokensRepository inMemoryTokensRepository = new InMemoryTokensRepository();
+    AppAuthResponse appAuthResponse = new AppAuthResponse();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    inMemoryTokensRepository.save(appAuthResponse);
+  }
+}

--- a/src/test/java/authentication/jwt/JwtPayloadTest.java
+++ b/src/test/java/authentication/jwt/JwtPayloadTest.java
@@ -1,0 +1,142 @@
+package authentication.jwt;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import authentication.jwt.JwtPayload;
+import org.junit.Test;
+
+public class JwtPayloadTest {
+  @Test
+  public void JwtPayloadTest() throws Exception {
+    // Arrange and Act
+    JwtPayload jwtPayload = new JwtPayload();
+
+    // Assert
+    assertEquals(null, jwtPayload.getUser());
+  }
+
+  @Test
+  public void getApplicationIdTest() throws Exception {
+    // Arrange
+    JwtPayload jwtPayload = new JwtPayload();
+
+    // Act
+    String actual = jwtPayload.getApplicationId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCompanyNameTest() throws Exception {
+    // Arrange
+    JwtPayload jwtPayload = new JwtPayload();
+
+    // Act
+    String actual = jwtPayload.getCompanyName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getExpirationDateInSecondsTest() throws Exception {
+    // Arrange
+    JwtPayload jwtPayload = new JwtPayload();
+
+    // Act
+    Long actual = jwtPayload.getExpirationDateInSeconds();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserIdTest() throws Exception {
+    // Arrange
+    JwtPayload jwtPayload = new JwtPayload();
+
+    // Act
+    String actual = jwtPayload.getUserId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserTest() throws Exception {
+    // Arrange
+    JwtPayload jwtPayload = new JwtPayload();
+
+    // Act
+    JwtUser actual = jwtPayload.getUser();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setApplicationIdTest() throws Exception {
+    // Arrange
+    JwtPayload jwtPayload = new JwtPayload();
+    String applicationId = "aaaaa";
+
+    // Act
+    jwtPayload.setApplicationId(applicationId);
+
+    // Assert
+    assertEquals("aaaaa", jwtPayload.getApplicationId());
+  }
+
+  @Test
+  public void setCompanyNameTest() throws Exception {
+    // Arrange
+    JwtPayload jwtPayload = new JwtPayload();
+    String companyName = "aaaaa";
+
+    // Act
+    jwtPayload.setCompanyName(companyName);
+
+    // Assert
+    assertEquals("aaaaa", jwtPayload.getCompanyName());
+  }
+
+  @Test
+  public void setExpirationDateInSecondsTest() throws Exception {
+    // Arrange
+    JwtPayload jwtPayload = new JwtPayload();
+    Long expirationDateInSeconds = new Long(1L);
+
+    // Act
+    jwtPayload.setExpirationDateInSeconds(expirationDateInSeconds);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), jwtPayload.getExpirationDateInSeconds());
+  }
+
+  @Test
+  public void setUserIdTest() throws Exception {
+    // Arrange
+    JwtPayload jwtPayload = new JwtPayload();
+    String userId = "aaaaa";
+
+    // Act
+    jwtPayload.setUserId(userId);
+
+    // Assert
+    assertEquals("aaaaa", jwtPayload.getUserId());
+  }
+
+  @Test
+  public void setUserTest() throws Exception {
+    // Arrange
+    JwtPayload jwtPayload = new JwtPayload();
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    jwtPayload.setUser(jwtUser);
+
+    // Assert
+    assertSame(jwtUser, jwtPayload.getUser());
+  }
+}

--- a/src/test/java/authentication/jwt/JwtUserTest.java
+++ b/src/test/java/authentication/jwt/JwtUserTest.java
@@ -1,0 +1,316 @@
+package authentication.jwt;
+
+import static org.junit.Assert.assertEquals;
+import authentication.jwt.JwtUser;
+import org.junit.Test;
+
+public class JwtUserTest {
+  @Test
+  public void JwtUserTest() throws Exception {
+    // Arrange and Act
+    JwtUser jwtUser = new JwtUser();
+
+    // Assert
+    assertEquals(null, jwtUser.getLastName());
+  }
+
+  @Test
+  public void getAvatarSmallUrlTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    String actual = jwtUser.getAvatarSmallUrl();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAvatarUrlTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    String actual = jwtUser.getAvatarUrl();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCompanyIdTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    String actual = jwtUser.getCompanyId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCompanyTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    String actual = jwtUser.getCompany();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDisplayNameTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    String actual = jwtUser.getDisplayName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getEmailAddressTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    String actual = jwtUser.getEmailAddress();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getFirstNameTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    String actual = jwtUser.getFirstName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    String actual = jwtUser.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLastNameTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    String actual = jwtUser.getLastName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLocationTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    String actual = jwtUser.getLocation();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTitleTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    String actual = jwtUser.getTitle();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUsernameTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+
+    // Act
+    String actual = jwtUser.getUsername();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAvatarSmallUrlTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+    String avatarSmallUrl = "aaaaa";
+
+    // Act
+    jwtUser.setAvatarSmallUrl(avatarSmallUrl);
+
+    // Assert
+    assertEquals("aaaaa", jwtUser.getAvatarSmallUrl());
+  }
+
+  @Test
+  public void setAvatarUrlTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+    String avatarUrl = "aaaaa";
+
+    // Act
+    jwtUser.setAvatarUrl(avatarUrl);
+
+    // Assert
+    assertEquals("aaaaa", jwtUser.getAvatarUrl());
+  }
+
+  @Test
+  public void setCompanyIdTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+    String companyId = "aaaaa";
+
+    // Act
+    jwtUser.setCompanyId(companyId);
+
+    // Assert
+    assertEquals("aaaaa", jwtUser.getCompanyId());
+  }
+
+  @Test
+  public void setCompanyTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+    String company = "aaaaa";
+
+    // Act
+    jwtUser.setCompany(company);
+
+    // Assert
+    assertEquals("aaaaa", jwtUser.getCompany());
+  }
+
+  @Test
+  public void setDisplayNameTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+    String displayName = "aaaaa";
+
+    // Act
+    jwtUser.setDisplayName(displayName);
+
+    // Assert
+    assertEquals("aaaaa", jwtUser.getDisplayName());
+  }
+
+  @Test
+  public void setEmailAddressTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+    String emailAddress = "aaaaa";
+
+    // Act
+    jwtUser.setEmailAddress(emailAddress);
+
+    // Assert
+    assertEquals("aaaaa", jwtUser.getEmailAddress());
+  }
+
+  @Test
+  public void setFirstNameTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+    String firstName = "aaaaa";
+
+    // Act
+    jwtUser.setFirstName(firstName);
+
+    // Assert
+    assertEquals("aaaaa", jwtUser.getFirstName());
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+    String id = "aaaaa";
+
+    // Act
+    jwtUser.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", jwtUser.getId());
+  }
+
+  @Test
+  public void setLastNameTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+    String lastName = "aaaaa";
+
+    // Act
+    jwtUser.setLastName(lastName);
+
+    // Assert
+    assertEquals("aaaaa", jwtUser.getLastName());
+  }
+
+  @Test
+  public void setLocationTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+    String location = "aaaaa";
+
+    // Act
+    jwtUser.setLocation(location);
+
+    // Assert
+    assertEquals("aaaaa", jwtUser.getLocation());
+  }
+
+  @Test
+  public void setTitleTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+    String title = "aaaaa";
+
+    // Act
+    jwtUser.setTitle(title);
+
+    // Assert
+    assertEquals("aaaaa", jwtUser.getTitle());
+  }
+
+  @Test
+  public void setUsernameTest() throws Exception {
+    // Arrange
+    JwtUser jwtUser = new JwtUser();
+    String username = "aaaaa";
+
+    // Act
+    jwtUser.setUsername(username);
+
+    // Assert
+    assertEquals("aaaaa", jwtUser.getUsername());
+  }
+}

--- a/src/test/java/clients/SymBotClientTest.java
+++ b/src/test/java/clients/SymBotClientTest.java
@@ -1,0 +1,169 @@
+package clients;
+
+import static org.junit.Assert.assertEquals;
+import authentication.SymBotAuth;
+import clients.SymBotClient;
+import configuration.SymConfig;
+import configuration.SymLoadBalancedConfig;
+import org.glassfish.jersey.client.ClientConfig;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SymBotClientTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void clearBotClientTest() throws Exception {
+    // Arrange and Act
+    SymBotClient.clearBotClient();
+  }
+
+  @Test
+  public void getBotClientTest() throws Exception {
+    // Arrange and Act
+    SymBotClient actual = SymBotClient.getBotClient();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void initBotLoadBalancedRsaTest() throws Exception {
+    // Arrange
+    String configPath = "aaaaa";
+    String lbConfigPath = "aaaaa";
+    Class<SymConfig> clazz = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymBotClient.<SymConfig>initBotLoadBalancedRsa(configPath, lbConfigPath, clazz);
+  }
+
+  @Test
+  public void initBotLoadBalancedRsaTest2() throws Exception {
+    // Arrange
+    String configPath = "aaaaa";
+    String lbConfigPath = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymBotClient.initBotLoadBalancedRsa(configPath, lbConfigPath);
+  }
+
+  @Test
+  public void initBotLoadBalancedTest() throws Exception {
+    // Arrange
+    String configPath = "aaaaa";
+    String lbConfigPath = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymBotClient.initBotLoadBalanced(configPath, lbConfigPath);
+  }
+
+  @Test
+  public void initBotLoadBalancedTest2() throws Exception {
+    // Arrange
+    String configPath = "aaaaa";
+    String lbConfigPath = "aaaaa";
+    Class<SymConfig> clazz = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymBotClient.<SymConfig>initBotLoadBalanced(configPath, lbConfigPath, clazz);
+  }
+
+  @Test
+  public void initBotRsaTest() throws Exception {
+    // Arrange
+    String configPath = "aaaaa";
+    Class<SymConfig> clazz = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymBotClient.<SymConfig>initBotRsa(configPath, clazz);
+  }
+
+  @Test
+  public void initBotRsaTest2() throws Exception {
+    // Arrange
+    String configPath = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymBotClient.initBotRsa(configPath);
+  }
+
+  @Test
+  public void initBotTest() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+    SymBotAuth botAuth = null;
+    ClientConfig podClientConfig = new ClientConfig();
+    ClientConfig agentClientConfig = new ClientConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    SymBotClient.initBot(config, botAuth, podClientConfig, agentClientConfig);
+  }
+
+  @Test
+  public void initBotTest2() throws Exception {
+    // Arrange
+    String configPath = "aaaaa";
+    Class<SymConfig> clazz = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymBotClient.<SymConfig>initBot(configPath, clazz);
+  }
+
+  @Test
+  public void initBotTest3() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+    SymBotAuth botAuth = null;
+    ClientConfig podClientConfig = new ClientConfig();
+    ClientConfig agentClientConfig = new ClientConfig();
+    SymLoadBalancedConfig lbConfig = new SymLoadBalancedConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    SymBotClient.initBot(config, botAuth, podClientConfig, agentClientConfig, lbConfig);
+  }
+
+  @Test
+  public void initBotTest4() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+    SymBotAuth botAuth = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    SymBotClient.initBot(config, botAuth);
+  }
+
+  @Test
+  public void initBotTest5() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+    SymBotAuth botAuth = null;
+    SymLoadBalancedConfig lbConfig = new SymLoadBalancedConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    SymBotClient.initBot(config, botAuth, lbConfig);
+  }
+
+  @Test
+  public void initBotTest6() throws Exception {
+    // Arrange
+    String configPath = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymBotClient.initBot(configPath);
+  }
+}

--- a/src/test/java/clients/SymOBOClientTest.java
+++ b/src/test/java/clients/SymOBOClientTest.java
@@ -1,0 +1,210 @@
+package clients;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import authentication.ISymAuth;
+import authentication.SymBotAuth;
+import clients.SymOBOClient;
+import clients.symphony.api.ConnectionsClient;
+import clients.symphony.api.MessagesClient;
+import clients.symphony.api.PresenceClient;
+import clients.symphony.api.SignalsClient;
+import clients.symphony.api.StreamsClient;
+import clients.symphony.api.UsersClient;
+import configuration.SymConfig;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
+import org.glassfish.jersey.client.JerseyClient;
+import org.junit.Test;
+
+public class SymOBOClientTest {
+  @Test
+  public void SymOBOClientTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    SymBotAuth symAuth = null;
+
+    // Act
+    SymOBOClient symOBOClient = new SymOBOClient(symConfig, symAuth);
+
+    // Assert
+    SymConfig config = symOBOClient.getConfig();
+    Client podClient = symOBOClient.getPodClient();
+    ISymAuth symAuth1 = symOBOClient.getSymAuth();
+    Client agentClient = symOBOClient.getAgentClient();
+    assertTrue(agentClient instanceof JerseyClient);
+    boolean isDefaultSslContextResult = ((JerseyClient) agentClient).isDefaultSslContext();
+    ScheduledExecutorService scheduledExecutorService = ((JerseyClient) agentClient).getScheduledExecutorService();
+    ExecutorService executorService = ((JerseyClient) agentClient).getExecutorService();
+    HostnameVerifier hostnameVerifier = agentClient.getHostnameVerifier();
+    boolean isClosedResult = ((JerseyClient) agentClient).isClosed();
+    assertTrue(podClient instanceof JerseyClient);
+    assertEquals(null, symAuth1);
+    boolean isDefaultSslContextResult1 = ((JerseyClient) podClient).isDefaultSslContext();
+    ScheduledExecutorService scheduledExecutorService1 = ((JerseyClient) podClient).getScheduledExecutorService();
+    ExecutorService executorService1 = ((JerseyClient) podClient).getExecutorService();
+    HostnameVerifier hostnameVerifier1 = podClient.getHostnameVerifier();
+    assertSame(symConfig, config);
+    assertEquals(null, hostnameVerifier1);
+    assertEquals(null, executorService1);
+    assertEquals(null, scheduledExecutorService1);
+    assertTrue(isDefaultSslContextResult1);
+    assertEquals(null, scheduledExecutorService);
+    assertTrue(isDefaultSslContextResult);
+    assertEquals(null, executorService);
+    assertEquals(null, hostnameVerifier);
+    assertFalse(isClosedResult);
+    assertFalse(((JerseyClient) podClient).isClosed());
+  }
+
+  @Test
+  public void getAgentClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    Client actual = symOBOClient.getAgentClient();
+
+    // Assert
+    assertEquals("TLS", (actual.getSslContext()).getProtocol());
+  }
+
+  @Test
+  public void getConfigTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    SymConfig actual = symOBOClient.getConfig();
+
+    // Assert
+    assertEquals(null, actual.getAppCertName());
+  }
+
+  @Test
+  public void getConnectionsClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    symOBOClient.getConnectionsClient();
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void getMessagesClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    symOBOClient.getMessagesClient();
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void getPodClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    Client actual = symOBOClient.getPodClient();
+
+    // Assert
+    assertEquals("TLS", (actual.getSslContext()).getProtocol());
+  }
+
+  @Test
+  public void getPresenceClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    symOBOClient.getPresenceClient();
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void getSignalsClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    symOBOClient.getSignalsClient();
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void getStreamsClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    symOBOClient.getStreamsClient();
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void getSymAuthTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    ISymAuth actual = symOBOClient.getSymAuth();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUsersClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    symOBOClient.getUsersClient();
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void setAgentClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+    JerseyClient agentClient = null;
+
+    // Act
+    symOBOClient.setAgentClient(agentClient);
+
+    // Assert
+    assertEquals(null, symOBOClient.getAgentClient());
+  }
+
+  @Test
+  public void setPodClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+    JerseyClient podClient = null;
+
+    // Act
+    symOBOClient.setPodClient(podClient);
+
+    // Assert
+    assertEquals(null, symOBOClient.getPodClient());
+  }
+}

--- a/src/test/java/clients/symphony/api/AdminClientTest.java
+++ b/src/test/java/clients/symphony/api/AdminClientTest.java
@@ -1,0 +1,254 @@
+package clients.symphony.api;
+
+import static org.junit.Assert.assertEquals;
+import authentication.ISymAuth;
+import authentication.SymBotAuth;
+import clients.SymOBOClient;
+import clients.symphony.api.AdminClient;
+import configuration.SymConfig;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import model.AdminNewUser;
+import model.AdminStreamFilter;
+import model.AdminUserAttributes;
+import model.AdminUserInfo;
+import model.ApplicationEntitlement;
+import model.Avatar;
+import model.FeatureEntitlement;
+import model.InboundImportMessageList;
+import model.OutboundImportMessage;
+import model.OutboundImportMessageList;
+import model.SuppressionResult;
+import model.UserStatus;
+import model.events.AdminStreamInfoList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class AdminClientTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AdminClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    new AdminClient(symOBOClient);
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void createIMTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.createIM(arrayList);
+  }
+
+  @Test
+  public void createUserTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    AdminNewUser newUser = new AdminNewUser();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.createUser(newUser);
+  }
+
+  @Test
+  public void getAvatarTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    Long uid = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.getAvatar(uid);
+  }
+
+  @Test
+  public void getUserApplicationEntitlementsTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    Long uid = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.getUserApplicationEntitlements(uid);
+  }
+
+  @Test
+  public void getUserFeaturesTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    Long uid = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.getUserFeatures(uid);
+  }
+
+  @Test
+  public void getUserStatusTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    Long uid = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.getUserStatus(uid);
+  }
+
+  @Test
+  public void getUserTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    Long uid = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.getUser(uid);
+  }
+
+  @Test
+  public void importMessagesTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    OutboundImportMessageList outboundImportMessageList = new OutboundImportMessageList();
+    outboundImportMessageList.add(new OutboundImportMessage());
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.importMessages(outboundImportMessageList);
+  }
+
+  @Test
+  public void listEnterpriseStreamsTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    AdminStreamFilter filter = new AdminStreamFilter();
+    int skip = 1;
+    int limit = 1;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.listEnterpriseStreams(filter, skip, limit);
+  }
+
+  @Test
+  public void listPodFeaturesTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.listPodFeatures();
+  }
+
+  @Test
+  public void listUsersTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    int skip = 1;
+    int limit = 1;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.listUsers(skip, limit);
+  }
+
+  @Test
+  public void suppressMessageTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    String id = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.suppressMessage(id);
+  }
+
+  @Test
+  public void updateAvatarTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    Long userId = new Long(1L);
+    String filePath = "aakaa";
+
+    // Act and Assert
+    thrown.expect(FileNotFoundException.class);
+    adminClient.updateAvatar(userId, filePath);
+  }
+
+  @Test
+  public void updateUserApplicationEntitlementsTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    Long uid = new Long(1L);
+    ArrayList<ApplicationEntitlement> arrayList = new ArrayList<ApplicationEntitlement>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.updateUserApplicationEntitlements(uid, arrayList);
+  }
+
+  @Test
+  public void updateUserFeaturesTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    Long uid = new Long(1L);
+    ArrayList<FeatureEntitlement> arrayList = new ArrayList<FeatureEntitlement>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.updateUserFeatures(uid, arrayList);
+  }
+
+  @Test
+  public void updateUserStatusTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    Long uid = new Long(1L);
+    String status = "aakaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.updateUserStatus(uid, status);
+  }
+
+  @Test
+  public void updateUserStatusTest2() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    Long uid = new Long(1L);
+    UserStatus status = UserStatus.ENABLED;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.updateUserStatus(uid, status);
+  }
+
+  @Test
+  public void updateUserTest() throws Exception {
+    // Arrange
+    AdminClient adminClient = new AdminClient(new SymOBOClient(new SymConfig(), null));
+    Long userId = new Long(1L);
+    AdminUserAttributes userAttributes = new AdminUserAttributes();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    adminClient.updateUser(userId, userAttributes);
+  }
+}

--- a/src/test/java/clients/symphony/api/ConnectionsClientTest.java
+++ b/src/test/java/clients/symphony/api/ConnectionsClientTest.java
@@ -1,0 +1,149 @@
+package clients.symphony.api;
+
+import static org.junit.Assert.assertEquals;
+import authentication.ISymAuth;
+import authentication.SymBotAuth;
+import clients.SymOBOClient;
+import clients.symphony.api.ConnectionsClient;
+import configuration.SymConfig;
+import java.util.ArrayList;
+import java.util.List;
+import model.InboundConnectionRequest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ConnectionsClientTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ConnectionsClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    new ConnectionsClient(symOBOClient);
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void acceptConnectionRequestTest() throws Exception {
+    // Arrange
+    ConnectionsClient connectionsClient = new ConnectionsClient(new SymOBOClient(new SymConfig(), null));
+    Long userId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    connectionsClient.acceptConnectionRequest(userId);
+  }
+
+  @Test
+  public void getAcceptedConnectionsTest() throws Exception {
+    // Arrange
+    ConnectionsClient connectionsClient = new ConnectionsClient(new SymOBOClient(new SymConfig(), null));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    connectionsClient.getAcceptedConnections();
+  }
+
+  @Test
+  public void getAllConnectionsTest() throws Exception {
+    // Arrange
+    ConnectionsClient connectionsClient = new ConnectionsClient(new SymOBOClient(new SymConfig(), null));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    connectionsClient.getAllConnections();
+  }
+
+  @Test
+  public void getConnectionRequestStatusTest() throws Exception {
+    // Arrange
+    ConnectionsClient connectionsClient = new ConnectionsClient(new SymOBOClient(new SymConfig(), null));
+    Long userId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    connectionsClient.getConnectionRequestStatus(userId);
+  }
+
+  @Test
+  public void getConnectionsTest() throws Exception {
+    // Arrange
+    ConnectionsClient connectionsClient = new ConnectionsClient(new SymOBOClient(new SymConfig(), null));
+    String status = "aaaaa";
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    connectionsClient.getConnections(status, arrayList);
+  }
+
+  @Test
+  public void getInboundPendingConnectionsTest() throws Exception {
+    // Arrange
+    ConnectionsClient connectionsClient = new ConnectionsClient(new SymOBOClient(new SymConfig(), null));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    connectionsClient.getInboundPendingConnections();
+  }
+
+  @Test
+  public void getPendingConnectionsTest() throws Exception {
+    // Arrange
+    ConnectionsClient connectionsClient = new ConnectionsClient(new SymOBOClient(new SymConfig(), null));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    connectionsClient.getPendingConnections();
+  }
+
+  @Test
+  public void getRejectedConnectionsTest() throws Exception {
+    // Arrange
+    ConnectionsClient connectionsClient = new ConnectionsClient(new SymOBOClient(new SymConfig(), null));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    connectionsClient.getRejectedConnections();
+  }
+
+  @Test
+  public void rejectConnectionRequestTest() throws Exception {
+    // Arrange
+    ConnectionsClient connectionsClient = new ConnectionsClient(new SymOBOClient(new SymConfig(), null));
+    Long userId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    connectionsClient.rejectConnectionRequest(userId);
+  }
+
+  @Test
+  public void removeConnectionTest() throws Exception {
+    // Arrange
+    ConnectionsClient connectionsClient = new ConnectionsClient(new SymOBOClient(new SymConfig(), null));
+    Long userId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    connectionsClient.removeConnection(userId);
+  }
+
+  @Test
+  public void sendConnectionRequestTest() throws Exception {
+    // Arrange
+    ConnectionsClient connectionsClient = new ConnectionsClient(new SymOBOClient(new SymConfig(), null));
+    Long userId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    connectionsClient.sendConnectionRequest(userId);
+  }
+}

--- a/src/test/java/clients/symphony/api/DatafeedClientTest.java
+++ b/src/test/java/clients/symphony/api/DatafeedClientTest.java
@@ -1,0 +1,22 @@
+package clients.symphony.api;
+
+import clients.SymBotClient;
+import clients.symphony.api.DatafeedClient;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class DatafeedClientTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void DatafeedClientTest() throws Exception {
+    // Arrange
+    SymBotClient client = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    new DatafeedClient(client);
+  }
+}

--- a/src/test/java/clients/symphony/api/FirehoseClientTest.java
+++ b/src/test/java/clients/symphony/api/FirehoseClientTest.java
@@ -1,0 +1,35 @@
+package clients.symphony.api;
+
+import clients.SymBotClient;
+import clients.symphony.api.FirehoseClient;
+import java.util.List;
+import model.DatafeedEvent;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class FirehoseClientTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void createFirehoseTest() throws Exception {
+    // Arrange
+    FirehoseClient firehoseClient = new FirehoseClient(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    firehoseClient.createFirehose();
+  }
+
+  @Test
+  public void readFirehoseTest() throws Exception {
+    // Arrange
+    FirehoseClient firehoseClient = new FirehoseClient(null);
+    String id = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    firehoseClient.readFirehose(id);
+  }
+}

--- a/src/test/java/clients/symphony/api/HealthcheckClientTest.java
+++ b/src/test/java/clients/symphony/api/HealthcheckClientTest.java
@@ -1,0 +1,39 @@
+package clients.symphony.api;
+
+import static org.junit.Assert.assertEquals;
+import authentication.ISymAuth;
+import authentication.SymBotAuth;
+import clients.SymOBOClient;
+import clients.symphony.api.HealthcheckClient;
+import configuration.SymConfig;
+import model.HealthcheckResponse;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class HealthcheckClientTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void HealthcheckClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    new HealthcheckClient(symOBOClient);
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void performHealthCheckTest() throws Exception {
+    // Arrange
+    HealthcheckClient healthcheckClient = new HealthcheckClient(new SymOBOClient(new SymConfig(), null));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    healthcheckClient.performHealthCheck();
+  }
+}

--- a/src/test/java/clients/symphony/api/InformationBarriersClientTest.java
+++ b/src/test/java/clients/symphony/api/InformationBarriersClientTest.java
@@ -1,0 +1,95 @@
+package clients.symphony.api;
+
+import static org.junit.Assert.assertEquals;
+import authentication.ISymAuth;
+import authentication.SymBotAuth;
+import clients.SymOBOClient;
+import clients.symphony.api.InformationBarriersClient;
+import configuration.SymConfig;
+import java.util.ArrayList;
+import java.util.List;
+import model.InformationBarrierGroup;
+import model.InformationBarrierGroupStatus;
+import model.Policy;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class InformationBarriersClientTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void InformationBarriersClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    new InformationBarriersClient(symOBOClient);
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void addGroupMembersTest() throws Exception {
+    // Arrange
+    InformationBarriersClient informationBarriersClient = new InformationBarriersClient(
+        new SymOBOClient(new SymConfig(), null));
+    String groupId = "aaaaa";
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    informationBarriersClient.addGroupMembers(groupId, arrayList);
+  }
+
+  @Test
+  public void listGroupMembersTest() throws Exception {
+    // Arrange
+    InformationBarriersClient informationBarriersClient = new InformationBarriersClient(
+        new SymOBOClient(new SymConfig(), null));
+    String groupId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    informationBarriersClient.listGroupMembers(groupId);
+  }
+
+  @Test
+  public void listGroupsTest() throws Exception {
+    // Arrange
+    InformationBarriersClient informationBarriersClient = new InformationBarriersClient(
+        new SymOBOClient(new SymConfig(), null));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    informationBarriersClient.listGroups();
+  }
+
+  @Test
+  public void listPoliciesTest() throws Exception {
+    // Arrange
+    InformationBarriersClient informationBarriersClient = new InformationBarriersClient(
+        new SymOBOClient(new SymConfig(), null));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    informationBarriersClient.listPolicies();
+  }
+
+  @Test
+  public void removeGroupMembersTest() throws Exception {
+    // Arrange
+    InformationBarriersClient informationBarriersClient = new InformationBarriersClient(
+        new SymOBOClient(new SymConfig(), null));
+    String groupId = "aaaaa";
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    informationBarriersClient.removeGroupMembers(groupId, arrayList);
+  }
+}

--- a/src/test/java/clients/symphony/api/MessagesClientTest.java
+++ b/src/test/java/clients/symphony/api/MessagesClientTest.java
@@ -1,0 +1,151 @@
+package clients.symphony.api;
+
+import static org.junit.Assert.assertEquals;
+import authentication.ISymAuth;
+import authentication.SymBotAuth;
+import clients.SymOBOClient;
+import clients.symphony.api.MessagesClient;
+import configuration.SymConfig;
+import java.util.HashMap;
+import java.util.List;
+import model.FileAttachment;
+import model.InboundMessage;
+import model.InboundMessageList;
+import model.InboundShare;
+import model.MessageStatus;
+import model.OutboundMessage;
+import model.OutboundShare;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class MessagesClientTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void MessagesClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    new MessagesClient(symOBOClient);
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void forwardMessageTest() throws Exception {
+    // Arrange
+    MessagesClient messagesClient = new MessagesClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+    InboundMessage message = new InboundMessage();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    messagesClient.forwardMessage(streamId, message);
+  }
+
+  @Test
+  public void getAttachmentTest() throws Exception {
+    // Arrange
+    MessagesClient messagesClient = new MessagesClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+    String attachmentId = "aaaka";
+    String messageId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    messagesClient.getAttachment(streamId, attachmentId, messageId);
+  }
+
+  @Test
+  public void getMessageAttachmentsTest() throws Exception {
+    // Arrange
+    MessagesClient messagesClient = new MessagesClient(new SymOBOClient(new SymConfig(), null));
+    InboundMessage message = new InboundMessage();
+
+    // Act
+    List<FileAttachment> actual = messagesClient.getMessageAttachments(message);
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+
+  @Test
+  public void getMessageStatusTest() throws Exception {
+    // Arrange
+    MessagesClient messagesClient = new MessagesClient(new SymOBOClient(new SymConfig(), null));
+    String messageId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    messagesClient.getMessageStatus(messageId);
+  }
+
+  @Test
+  public void getMessagesFromStreamTest() throws Exception {
+    // Arrange
+    MessagesClient messagesClient = new MessagesClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+    long since = 1L;
+    int skip = 2561;
+    int limit = 1;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    messagesClient.getMessagesFromStream(streamId, since, skip, limit);
+  }
+
+  @Test
+  public void messageSearchTest() throws Exception {
+    // Arrange
+    MessagesClient messagesClient = new MessagesClient(new SymOBOClient(new SymConfig(), null));
+    HashMap<String, String> hashMap = new HashMap<String, String>();
+    hashMap.put("aaaaa", "kaaaa");
+    int skip = 1;
+    int limit = 1;
+    boolean orderAscending = true;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    messagesClient.messageSearch(hashMap, skip, limit, orderAscending);
+  }
+
+  @Test
+  public void sendMessageTest() throws Exception {
+    // Arrange
+    MessagesClient messagesClient = new MessagesClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+    OutboundMessage message = new OutboundMessage();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    messagesClient.sendMessage(streamId, message);
+  }
+
+  @Test
+  public void sendTaggedMessageTest() throws Exception {
+    // Arrange
+    MessagesClient messagesClient = new MessagesClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+    OutboundMessage message = new OutboundMessage();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    messagesClient.sendTaggedMessage(streamId, message);
+  }
+
+  @Test
+  public void shareContentTest() throws Exception {
+    // Arrange
+    MessagesClient messagesClient = new MessagesClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+    OutboundShare shareContent = new OutboundShare();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    messagesClient.shareContent(streamId, shareContent);
+  }
+}

--- a/src/test/java/clients/symphony/api/PresenceClientTest.java
+++ b/src/test/java/clients/symphony/api/PresenceClientTest.java
@@ -1,0 +1,77 @@
+package clients.symphony.api;
+
+import static org.junit.Assert.assertEquals;
+import authentication.ISymAuth;
+import authentication.SymBotAuth;
+import clients.SymOBOClient;
+import clients.symphony.api.PresenceClient;
+import configuration.SymConfig;
+import java.util.ArrayList;
+import model.Presence;
+import model.UserPresence;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PresenceClientTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PresenceClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    new PresenceClient(symOBOClient);
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void getUserPresenceTest() throws Exception {
+    // Arrange
+    PresenceClient presenceClient = new PresenceClient(new SymOBOClient(new SymConfig(), null));
+    Long userId = new Long(1L);
+    boolean local = true;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    presenceClient.getUserPresence(userId, local);
+  }
+
+  @Test
+  public void registerInterestExtUserTest() throws Exception {
+    // Arrange
+    PresenceClient presenceClient = new PresenceClient(new SymOBOClient(new SymConfig(), null));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    presenceClient.registerInterestExtUser(arrayList);
+  }
+
+  @Test
+  public void setPresenceTest() throws Exception {
+    // Arrange
+    PresenceClient presenceClient = new PresenceClient(new SymOBOClient(new SymConfig(), null));
+    Presence status = Presence.AVAILABLE;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    presenceClient.setPresence(status);
+  }
+
+  @Test
+  public void setPresenceTest2() throws Exception {
+    // Arrange
+    PresenceClient presenceClient = new PresenceClient(new SymOBOClient(new SymConfig(), null));
+    String status = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    presenceClient.setPresence(status);
+  }
+}

--- a/src/test/java/clients/symphony/api/SignalsClientTest.java
+++ b/src/test/java/clients/symphony/api/SignalsClientTest.java
@@ -1,0 +1,131 @@
+package clients.symphony.api;
+
+import static org.junit.Assert.assertEquals;
+import authentication.ISymAuth;
+import authentication.SymBotAuth;
+import clients.SymOBOClient;
+import clients.symphony.api.SignalsClient;
+import configuration.SymConfig;
+import java.util.ArrayList;
+import java.util.List;
+import model.Signal;
+import model.SignalSubscriberList;
+import model.SignalSubscriptionResult;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SignalsClientTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SignalsClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    new SignalsClient(symOBOClient);
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void createSignalTest() throws Exception {
+    // Arrange
+    SignalsClient signalsClient = new SignalsClient(new SymOBOClient(new SymConfig(), null));
+    Signal signal = new Signal();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    signalsClient.createSignal(signal);
+  }
+
+  @Test
+  public void deleteSignalTest() throws Exception {
+    // Arrange
+    SignalsClient signalsClient = new SignalsClient(new SymOBOClient(new SymConfig(), null));
+    String id = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    signalsClient.deleteSignal(id);
+  }
+
+  @Test
+  public void getSignalSubscribersTest() throws Exception {
+    // Arrange
+    SignalsClient signalsClient = new SignalsClient(new SymOBOClient(new SymConfig(), null));
+    String id = "aaaaa";
+    int skip = 1;
+    int limit = 2561;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    signalsClient.getSignalSubscribers(id, skip, limit);
+  }
+
+  @Test
+  public void getSignalTest() throws Exception {
+    // Arrange
+    SignalsClient signalsClient = new SignalsClient(new SymOBOClient(new SymConfig(), null));
+    String id = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    signalsClient.getSignal(id);
+  }
+
+  @Test
+  public void listSignalsTest() throws Exception {
+    // Arrange
+    SignalsClient signalsClient = new SignalsClient(new SymOBOClient(new SymConfig(), null));
+    int skip = 1;
+    int limit = 1;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    signalsClient.listSignals(skip, limit);
+  }
+
+  @Test
+  public void subscribeSignalTest() throws Exception {
+    // Arrange
+    SignalsClient signalsClient = new SignalsClient(new SymOBOClient(new SymConfig(), null));
+    String id = "aaaaa";
+    boolean self = true;
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(null);
+    boolean pushed = true;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    signalsClient.subscribeSignal(id, self, arrayList, pushed);
+  }
+
+  @Test
+  public void unsubscribeSignalTest() throws Exception {
+    // Arrange
+    SignalsClient signalsClient = new SignalsClient(new SymOBOClient(new SymConfig(), null));
+    String id = "aaaaa";
+    boolean self = true;
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    signalsClient.unsubscribeSignal(id, self, arrayList);
+  }
+
+  @Test
+  public void updateSignalTest() throws Exception {
+    // Arrange
+    SignalsClient signalsClient = new SignalsClient(new SymOBOClient(new SymConfig(), null));
+    Signal signal = new Signal();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    signalsClient.updateSignal(signal);
+  }
+}

--- a/src/test/java/clients/symphony/api/StreamsClientTest.java
+++ b/src/test/java/clients/symphony/api/StreamsClientTest.java
@@ -1,0 +1,222 @@
+package clients.symphony.api;
+
+import static org.junit.Assert.assertEquals;
+import authentication.ISymAuth;
+import authentication.SymBotAuth;
+import clients.SymOBOClient;
+import clients.symphony.api.StreamsClient;
+import configuration.SymConfig;
+import java.util.ArrayList;
+import java.util.List;
+import model.Room;
+import model.RoomInfo;
+import model.RoomMember;
+import model.RoomSearchQuery;
+import model.RoomSearchResult;
+import model.StreamInfo;
+import model.StreamListItem;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class StreamsClientTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void StreamsClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    new StreamsClient(symOBOClient);
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void activateRoomTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.activateRoom(streamId);
+  }
+
+  @Test
+  public void addMemberToRoomTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+    Long userId = new Long(655361L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.addMemberToRoom(streamId, userId);
+  }
+
+  @Test
+  public void createRoomTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    Room room = new Room();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.createRoom(room);
+  }
+
+  @Test
+  public void deactivateRoomTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.deactivateRoom(streamId);
+  }
+
+  @Test
+  public void demoteUserFromOwnerTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+    Long userId = new Long(655361L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.demoteUserFromOwner(streamId, userId);
+  }
+
+  @Test
+  public void getRoomInfoTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.getRoomInfo(streamId);
+  }
+
+  @Test
+  public void getRoomMembersTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.getRoomMembers(streamId);
+  }
+
+  @Test
+  public void getStreamInfoTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.getStreamInfo(streamId);
+  }
+
+  @Test
+  public void getUserIMStreamIdTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    Long userId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.getUserIMStreamId(userId);
+  }
+
+  @Test
+  public void getUserListIMTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.getUserListIM(arrayList);
+  }
+
+  @Test
+  public void getUserStreamsTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+    boolean includeInactiveStreams = true;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.getUserStreams(arrayList, includeInactiveStreams);
+  }
+
+  @Test
+  public void getUserWallStreamTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.getUserWallStream();
+  }
+
+  @Test
+  public void promoteUserToOwnerTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+    Long userId = new Long(655361L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.promoteUserToOwner(streamId, userId);
+  }
+
+  @Test
+  public void removeMemberFromRoomTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+    Long userId = new Long(655361L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.removeMemberFromRoom(streamId, userId);
+  }
+
+  @Test
+  public void searchRoomsTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    RoomSearchQuery query = new RoomSearchQuery();
+    int skip = 1;
+    int limit = 1;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.searchRooms(query, skip, limit);
+  }
+
+  @Test
+  public void updateRoomTest() throws Exception {
+    // Arrange
+    StreamsClient streamsClient = new StreamsClient(new SymOBOClient(new SymConfig(), null));
+    String streamId = "aaaaa";
+    Room room = new Room();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamsClient.updateRoom(streamId, room);
+  }
+}

--- a/src/test/java/clients/symphony/api/UsersClientTest.java
+++ b/src/test/java/clients/symphony/api/UsersClientTest.java
@@ -1,0 +1,134 @@
+package clients.symphony.api;
+
+import static org.junit.Assert.assertEquals;
+import authentication.ISymAuth;
+import authentication.SymBotAuth;
+import clients.SymOBOClient;
+import clients.symphony.api.UsersClient;
+import configuration.SymConfig;
+import java.util.ArrayList;
+import java.util.List;
+import model.UserFilter;
+import model.UserInfo;
+import model.UserSearchResult;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class UsersClientTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void UsersClientTest() throws Exception {
+    // Arrange
+    SymOBOClient symOBOClient = new SymOBOClient(new SymConfig(), null);
+
+    // Act
+    new UsersClient(symOBOClient);
+
+    // Assert
+    assertEquals(null, symOBOClient.getSymAuth());
+  }
+
+  @Test
+  public void getSessionUserTest() throws Exception {
+    // Arrange
+    UsersClient usersClient = new UsersClient(new SymOBOClient(new SymConfig(), null));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    usersClient.getSessionUser();
+  }
+
+  @Test
+  public void getUserFromEmailTest() throws Exception {
+    // Arrange
+    UsersClient usersClient = new UsersClient(new SymOBOClient(new SymConfig(), null));
+    String email = "aaaaa";
+    Boolean local = new Boolean(true);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    usersClient.getUserFromEmail(email, local);
+  }
+
+  @Test
+  public void getUserFromIdTest() throws Exception {
+    // Arrange
+    UsersClient usersClient = new UsersClient(new SymOBOClient(new SymConfig(), null));
+    Long id = new Long(1L);
+    Boolean local = new Boolean(true);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    usersClient.getUserFromId(id, local);
+  }
+
+  @Test
+  public void getUserFromUsernameTest() throws Exception {
+    // Arrange
+    UsersClient usersClient = new UsersClient(new SymOBOClient(new SymConfig(), null));
+    String username = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    usersClient.getUserFromUsername(username);
+  }
+
+  @Test
+  public void getUsersFromEmailListTest() throws Exception {
+    // Arrange
+    UsersClient usersClient = new UsersClient(new SymOBOClient(new SymConfig(), null));
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+    Boolean local = new Boolean(true);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    usersClient.getUsersFromEmailList(arrayList, local);
+  }
+
+  @Test
+  public void getUsersFromIdListTest() throws Exception {
+    // Arrange
+    UsersClient usersClient = new UsersClient(new SymOBOClient(new SymConfig(), null));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+    Boolean local = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    usersClient.getUsersFromIdList(arrayList, local);
+  }
+
+  @Test
+  public void getUsersV3Test() throws Exception {
+    // Arrange
+    UsersClient usersClient = new UsersClient(new SymOBOClient(new SymConfig(), null));
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+    ArrayList<Long> arrayList1 = new ArrayList<Long>(1);
+    arrayList1.add(new Long(1L));
+    Boolean local = new Boolean(true);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    usersClient.getUsersV3(arrayList, arrayList1, local);
+  }
+
+  @Test
+  public void searchUsersTest() throws Exception {
+    // Arrange
+    UsersClient usersClient = new UsersClient(new SymOBOClient(new SymConfig(), null));
+    String query = "aaaaa";
+    boolean local = true;
+    int skip = 1;
+    int limit = 11;
+    UserFilter filter = new UserFilter();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    usersClient.searchUsers(query, local, skip, limit, filter);
+  }
+}

--- a/src/test/java/clients/symphony/api/constants/QueryParameterNamesTest.java
+++ b/src/test/java/clients/symphony/api/constants/QueryParameterNamesTest.java
@@ -1,0 +1,19 @@
+package clients.symphony.api.constants;
+
+import static org.junit.Assert.assertEquals;
+import clients.symphony.api.constants.QueryParameterNames;
+import org.junit.Test;
+
+public class QueryParameterNamesTest {
+  @Test
+  public void getNameTest() throws Exception {
+    // Arrange
+    QueryParameterNames queryParameterNames = QueryParameterNames.SHOW_FIREHOSE_ERRORS;
+
+    // Act
+    String actual = queryParameterNames.getName();
+
+    // Assert
+    assertEquals("showFirehoseErrors", actual);
+  }
+}

--- a/src/test/java/configuration/LoadBalancingTest.java
+++ b/src/test/java/configuration/LoadBalancingTest.java
@@ -1,0 +1,69 @@
+package configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import configuration.LoadBalancing;
+import configuration.LoadBalancingMethod;
+import org.junit.Test;
+
+public class LoadBalancingTest {
+  @Test
+  public void LoadBalancingTest() throws Exception {
+    // Arrange and Act
+    LoadBalancing loadBalancing = new LoadBalancing();
+
+    // Assert
+    assertEquals(null, loadBalancing.getMethod());
+  }
+
+  @Test
+  public void getMethodTest() throws Exception {
+    // Arrange
+    LoadBalancing loadBalancing = new LoadBalancing();
+
+    // Act
+    LoadBalancingMethod actual = loadBalancing.getMethod();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void isStickySessionsTest() throws Exception {
+    // Arrange
+    LoadBalancing loadBalancing = new LoadBalancing();
+
+    // Act
+    boolean actual = loadBalancing.isStickySessions();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void setMethodTest() throws Exception {
+    // Arrange
+    LoadBalancing loadBalancing = new LoadBalancing();
+    LoadBalancingMethod method = LoadBalancingMethod.random;
+
+    // Act
+    loadBalancing.setMethod(method);
+
+    // Assert
+    assertEquals(LoadBalancingMethod.random, loadBalancing.getMethod());
+  }
+
+  @Test
+  public void setStickySessionsTest() throws Exception {
+    // Arrange
+    LoadBalancing loadBalancing = new LoadBalancing();
+    boolean stickySessions = true;
+
+    // Act
+    loadBalancing.setStickySessions(stickySessions);
+
+    // Assert
+    assertTrue(loadBalancing.isStickySessions());
+  }
+}

--- a/src/test/java/configuration/SymConfigLoaderTest.java
+++ b/src/test/java/configuration/SymConfigLoaderTest.java
@@ -1,0 +1,120 @@
+package configuration;
+
+import static org.junit.Assert.assertEquals;
+import configuration.SymConfig;
+import configuration.SymConfigLoader;
+import java.io.ByteArrayInputStream;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SymConfigLoaderTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void loadConfigTest() throws Exception {
+    // Arrange
+    String configPath = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymConfigLoader.loadConfig(configPath);
+  }
+
+  @Test
+  public void loadConfigTest2() throws Exception {
+    // Arrange
+    String configPath = "aaaaa";
+    Class<SymConfig> clazz = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymConfigLoader.<SymConfig>loadConfig(configPath, clazz);
+  }
+
+  @Test
+  public void loadFromFileTest() throws Exception {
+    // Arrange
+    String path = "aaaaa";
+    Class<SymConfig> clazz = null;
+
+    // Act
+    SymConfig actual = SymConfigLoader.<SymConfig>loadFromFile(path, clazz);
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void loadFromFileTest2() throws Exception {
+    // Arrange
+    String path = "aaaaa";
+
+    // Act
+    SymConfig actual = SymConfigLoader.loadFromFile(path);
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void loadLoadBalancerConfigTest() throws Exception {
+    // Arrange
+    String configPath = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymConfigLoader.loadLoadBalancerConfig(configPath);
+  }
+
+  @Test
+  public void loadLoadBalancerFromFileTest() throws Exception {
+    // Arrange
+    String path = "aaaaa";
+
+    // Act
+    SymLoadBalancedConfig actual = SymConfigLoader.loadLoadBalancerFromFile(path);
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void loadLoadBalancerTest() throws Exception {
+    // Arrange
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(
+        new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+    // Act
+    SymLoadBalancedConfig actual = SymConfigLoader.loadLoadBalancer(inputStream);
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void loadTest() throws Exception {
+    // Arrange
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(
+        new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+    Class<SymConfig> clazz = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymConfigLoader.<SymConfig>load(inputStream, clazz);
+  }
+
+  @Test
+  public void loadTest2() throws Exception {
+    // Arrange
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(
+        new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+    // Act
+    SymConfig actual = SymConfigLoader.load(inputStream);
+
+    // Assert
+    assertEquals(null, actual);
+  }
+}

--- a/src/test/java/configuration/SymConfigTest.java
+++ b/src/test/java/configuration/SymConfigTest.java
@@ -1,0 +1,1016 @@
+package configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import configuration.SymConfig;
+import org.junit.Test;
+
+public class SymConfigTest {
+  @Test
+  public void SymConfigTest() throws Exception {
+    // Arrange and Act
+    SymConfig symConfig = new SymConfig();
+
+    // Assert
+    assertEquals(null, symConfig.getAppCertName());
+  }
+
+  @Test
+  public void getAgentHostTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getAgentHost();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAgentPortTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    int actual = symConfig.getAgentPort();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getAgentUrlTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getAgentUrl();
+
+    // Assert
+    assertEquals("https://null:0", actual);
+  }
+
+  @Test
+  public void getAppCertNameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getAppCertName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAppCertPasswordTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getAppCertPassword();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAppCertPathTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getAppCertPath();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAppIdTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getAppId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAppPrivateKeyNameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getAppPrivateKeyName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAppPrivateKeyPathTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getAppPrivateKeyPath();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAuthTokenRefreshPeriodTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    int actual = symConfig.getAuthTokenRefreshPeriod();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getAuthenticationFilterUrlPatternTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getAuthenticationFilterUrlPattern();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getBotCertNameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getBotCertName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getBotCertPasswordTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getBotCertPassword();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getBotCertPathTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getBotCertPath();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getBotEmailAddressTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getBotEmailAddress();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getBotPrivateKeyNameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getBotPrivateKeyName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getBotPrivateKeyPathTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getBotPrivateKeyPath();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getBotUsernameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getBotUsername();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getConnectionTimeoutTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    int actual = symConfig.getConnectionTimeout();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getDatafeedEventsErrorTimeoutTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    int actual = symConfig.getDatafeedEventsErrorTimeout();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getDatafeedEventsThreadpoolSizeTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    int actual = symConfig.getDatafeedEventsThreadpoolSize();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getKeyAuthHostTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getKeyAuthHost();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getKeyAuthPortTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    int actual = symConfig.getKeyAuthPort();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getKeyAuthUrlTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getKeyAuthUrl();
+
+    // Assert
+    assertEquals("https://null:0", actual);
+  }
+
+  @Test
+  public void getKeyManagerProxyPasswordTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getKeyManagerProxyPassword();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getKeyManagerProxyURLTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getKeyManagerProxyURL();
+
+    // Assert
+    assertEquals("", actual);
+  }
+
+  @Test
+  public void getKeyManagerProxyUsernameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getKeyManagerProxyUsername();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPodHostTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getPodHost();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPodPortTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    int actual = symConfig.getPodPort();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getPodProxyPasswordTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getPodProxyPassword();
+
+    // Assert
+    assertEquals("", actual);
+  }
+
+  @Test
+  public void getPodProxyURLTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getPodProxyURL();
+
+    // Assert
+    assertEquals("", actual);
+  }
+
+  @Test
+  public void getPodProxyUsernameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getPodProxyUsername();
+
+    // Assert
+    assertEquals("", actual);
+  }
+
+  @Test
+  public void getPodUrlTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getPodUrl();
+
+    // Assert
+    assertEquals("https://null:0", actual);
+  }
+
+  @Test
+  public void getProxyPasswordTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getProxyPassword();
+
+    // Assert
+    assertEquals("", actual);
+  }
+
+  @Test
+  public void getProxyURLTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getProxyURL();
+
+    // Assert
+    assertEquals("", actual);
+  }
+
+  @Test
+  public void getProxyUsernameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getProxyUsername();
+
+    // Assert
+    assertEquals("", actual);
+  }
+
+  @Test
+  public void getSessionAuthHostTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getSessionAuthHost();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSessionAuthPortTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    int actual = symConfig.getSessionAuthPort();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getSessionAuthUrlTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getSessionAuthUrl();
+
+    // Assert
+    assertEquals("https://null:0", actual);
+  }
+
+  @Test
+  public void getShowFirehoseErrorsTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    boolean actual = symConfig.getShowFirehoseErrors();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void getTruststorePasswordTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getTruststorePassword();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTruststorePathTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    String actual = symConfig.getTruststorePath();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAgentHostTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String agentHost = "aaaaa";
+
+    // Act
+    symConfig.setAgentHost(agentHost);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getAgentHost());
+  }
+
+  @Test
+  public void setAgentPortTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    int agentPort = 1;
+
+    // Act
+    symConfig.setAgentPort(agentPort);
+
+    // Assert
+    assertEquals(1, symConfig.getAgentPort());
+  }
+
+  @Test
+  public void setAppCertNameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String appCertName = "aaaaa";
+
+    // Act
+    symConfig.setAppCertName(appCertName);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getAppCertName());
+  }
+
+  @Test
+  public void setAppCertPasswordTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String appCertPassword = "aaaaa";
+
+    // Act
+    symConfig.setAppCertPassword(appCertPassword);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getAppCertPassword());
+  }
+
+  @Test
+  public void setAppCertPathTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String appCertPath = "aaaaa";
+
+    // Act
+    symConfig.setAppCertPath(appCertPath);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getAppCertPath());
+  }
+
+  @Test
+  public void setAppIdTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String appId = "aaaaa";
+
+    // Act
+    symConfig.setAppId(appId);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getAppId());
+  }
+
+  @Test
+  public void setAppPrivateKeyNameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String appPrivateKeyName = "aaaaa";
+
+    // Act
+    symConfig.setAppPrivateKeyName(appPrivateKeyName);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getAppPrivateKeyName());
+  }
+
+  @Test
+  public void setAppPrivateKeyPathTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String appPrivateKeyPath = "aaaaa";
+
+    // Act
+    symConfig.setAppPrivateKeyPath(appPrivateKeyPath);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getAppPrivateKeyPath());
+  }
+
+  @Test
+  public void setAuthTokenRefreshPeriodTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    int authTokenRefreshPeriod = 1;
+
+    // Act
+    symConfig.setAuthTokenRefreshPeriod(authTokenRefreshPeriod);
+
+    // Assert
+    assertEquals(1, symConfig.getAuthTokenRefreshPeriod());
+  }
+
+  @Test
+  public void setAuthenticationFilterUrlPatternTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String authenticationFilterUrlPattern = "aaaaa";
+
+    // Act
+    symConfig.setAuthenticationFilterUrlPattern(authenticationFilterUrlPattern);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getAuthenticationFilterUrlPattern());
+  }
+
+  @Test
+  public void setBotCertNameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String botCertName = "aaaaa";
+
+    // Act
+    symConfig.setBotCertName(botCertName);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getBotCertName());
+  }
+
+  @Test
+  public void setBotCertPasswordTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String botCertPassword = "aaaaa";
+
+    // Act
+    symConfig.setBotCertPassword(botCertPassword);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getBotCertPassword());
+  }
+
+  @Test
+  public void setBotCertPathTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String botCertPath = "aaaaa";
+
+    // Act
+    symConfig.setBotCertPath(botCertPath);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getBotCertPath());
+  }
+
+  @Test
+  public void setBotEmailAddressTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String botEmailAddress = "aaaaa";
+
+    // Act
+    symConfig.setBotEmailAddress(botEmailAddress);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getBotEmailAddress());
+  }
+
+  @Test
+  public void setBotPrivateKeyNameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String botPrivateKeyName = "aaaaa";
+
+    // Act
+    symConfig.setBotPrivateKeyName(botPrivateKeyName);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getBotPrivateKeyName());
+  }
+
+  @Test
+  public void setBotPrivateKeyPathTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String botPrivateKeyPath = "aaaaa";
+
+    // Act
+    symConfig.setBotPrivateKeyPath(botPrivateKeyPath);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getBotPrivateKeyPath());
+  }
+
+  @Test
+  public void setBotUsernameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String botUsername = "aaaaa";
+
+    // Act
+    symConfig.setBotUsername(botUsername);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getBotUsername());
+  }
+
+  @Test
+  public void setConnectionTimeoutTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    int connectionTimeout = 1;
+
+    // Act
+    symConfig.setConnectionTimeout(connectionTimeout);
+
+    // Assert
+    assertEquals(1, symConfig.getConnectionTimeout());
+  }
+
+  @Test
+  public void setDatafeedEventsErrorTimeoutTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    int datafeedEventsErrorTimeout = 1;
+
+    // Act
+    symConfig.setDatafeedEventsErrorTimeout(datafeedEventsErrorTimeout);
+
+    // Assert
+    assertEquals(1, symConfig.getDatafeedEventsErrorTimeout());
+  }
+
+  @Test
+  public void setDatafeedEventsThreadpoolSizeTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    int datafeedEventsThreadpoolSize = 1;
+
+    // Act
+    symConfig.setDatafeedEventsThreadpoolSize(datafeedEventsThreadpoolSize);
+
+    // Assert
+    assertEquals(1, symConfig.getDatafeedEventsThreadpoolSize());
+  }
+
+  @Test
+  public void setKeyAuthHostTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String keyAuthHost = "aaaaa";
+
+    // Act
+    symConfig.setKeyAuthHost(keyAuthHost);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getKeyAuthHost());
+  }
+
+  @Test
+  public void setKeyAuthPortTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    int keyAuthPort = 1;
+
+    // Act
+    symConfig.setKeyAuthPort(keyAuthPort);
+
+    // Assert
+    assertEquals(1, symConfig.getKeyAuthPort());
+  }
+
+  @Test
+  public void setKeyManagerProxyPasswordTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String keyManagerProxyPassword = "aaaaa";
+
+    // Act
+    symConfig.setKeyManagerProxyPassword(keyManagerProxyPassword);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getKeyManagerProxyPassword());
+  }
+
+  @Test
+  public void setKeyManagerProxyURLTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String keyManagerProxyURL = "aaaaa";
+
+    // Act
+    symConfig.setKeyManagerProxyURL(keyManagerProxyURL);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getKeyManagerProxyURL());
+  }
+
+  @Test
+  public void setKeyManagerProxyUsernameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String keyManagerProxyUsername = "aaaaa";
+
+    // Act
+    symConfig.setKeyManagerProxyUsername(keyManagerProxyUsername);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getKeyManagerProxyUsername());
+  }
+
+  @Test
+  public void setPodHostTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String podHost = "aaaaa";
+
+    // Act
+    symConfig.setPodHost(podHost);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getPodHost());
+  }
+
+  @Test
+  public void setPodPortTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    int podPort = 1;
+
+    // Act
+    symConfig.setPodPort(podPort);
+
+    // Assert
+    assertEquals(1, symConfig.getPodPort());
+  }
+
+  @Test
+  public void setPodProxyPasswordTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String podProxyPassword = "aaaaa";
+
+    // Act
+    symConfig.setPodProxyPassword(podProxyPassword);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getPodProxyPassword());
+  }
+
+  @Test
+  public void setPodProxyURLTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String podProxyURL = "aaaaa";
+
+    // Act
+    symConfig.setPodProxyURL(podProxyURL);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getPodProxyURL());
+  }
+
+  @Test
+  public void setPodProxyUsernameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String podProxyUsername = "aaaaa";
+
+    // Act
+    symConfig.setPodProxyUsername(podProxyUsername);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getPodProxyUsername());
+  }
+
+  @Test
+  public void setProxyPasswordTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String proxyPassword = "aaaaa";
+
+    // Act
+    symConfig.setProxyPassword(proxyPassword);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getProxyPassword());
+  }
+
+  @Test
+  public void setProxyURLTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String proxyURL = "aaaaa";
+
+    // Act
+    symConfig.setProxyURL(proxyURL);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getProxyURL());
+  }
+
+  @Test
+  public void setProxyUsernameTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String proxyUsername = "aaaaa";
+
+    // Act
+    symConfig.setProxyUsername(proxyUsername);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getProxyUsername());
+  }
+
+  @Test
+  public void setSessionAuthHostTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String sessionAuthHost = "aaaaa";
+
+    // Act
+    symConfig.setSessionAuthHost(sessionAuthHost);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getSessionAuthHost());
+  }
+
+  @Test
+  public void setSessionAuthPortTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    int sessionAuthPort = 1;
+
+    // Act
+    symConfig.setSessionAuthPort(sessionAuthPort);
+
+    // Assert
+    assertEquals(1, symConfig.getSessionAuthPort());
+  }
+
+  @Test
+  public void setShowFirehoseErrorsTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    boolean showFirehoseErrors = true;
+
+    // Act
+    symConfig.setShowFirehoseErrors(showFirehoseErrors);
+
+    // Assert
+    assertTrue(symConfig.getShowFirehoseErrors());
+  }
+
+  @Test
+  public void setTruststorePasswordTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String truststorePassword = "aaaaa";
+
+    // Act
+    symConfig.setTruststorePassword(truststorePassword);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getTruststorePassword());
+  }
+
+  @Test
+  public void setTruststorePathTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+    String truststorePath = "aaaaa";
+
+    // Act
+    symConfig.setTruststorePath(truststorePath);
+
+    // Assert
+    assertEquals("aaaaa", symConfig.getTruststorePath());
+  }
+}

--- a/src/test/java/configuration/SymLoadBalancedConfigTest.java
+++ b/src/test/java/configuration/SymLoadBalancedConfigTest.java
@@ -1,0 +1,158 @@
+package configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import configuration.SymLoadBalancedConfig;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SymLoadBalancedConfigTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SymLoadBalancedConfigTest() throws Exception {
+    // Arrange and Act
+    SymLoadBalancedConfig symLoadBalancedConfig = new SymLoadBalancedConfig();
+
+    // Assert
+    assertEquals(null, symLoadBalancedConfig.getAppCertName());
+  }
+
+  @Test
+  public void cloneAttributesTest() throws Exception {
+    // Arrange
+    SymLoadBalancedConfig symLoadBalancedConfig = new SymLoadBalancedConfig();
+    SymConfig config = new SymConfig();
+
+    // Act
+    symLoadBalancedConfig.cloneAttributes(config);
+
+    // Assert
+    String appCertName = symLoadBalancedConfig.getAppCertName();
+    String truststorePath = symLoadBalancedConfig.getTruststorePath();
+    String keyAuthHost = symLoadBalancedConfig.getKeyAuthHost();
+    String appPrivateKeyName = symLoadBalancedConfig.getAppPrivateKeyName();
+    int keyAuthPort = symLoadBalancedConfig.getKeyAuthPort();
+    String podHost = symLoadBalancedConfig.getPodHost();
+    assertEquals(null, appCertName);
+    assertEquals("https://null:0", symLoadBalancedConfig.getPodUrl());
+    assertEquals(null, podHost);
+    assertEquals(0, keyAuthPort);
+    assertEquals(null, appPrivateKeyName);
+    assertEquals(null, keyAuthHost);
+    assertEquals(null, truststorePath);
+  }
+
+  @Test
+  public void getAgentHostTest() throws Exception {
+    // Arrange
+    SymLoadBalancedConfig symLoadBalancedConfig = new SymLoadBalancedConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    symLoadBalancedConfig.getAgentHost();
+  }
+
+  @Test
+  public void getAgentPortTest() throws Exception {
+    // Arrange
+    SymLoadBalancedConfig symLoadBalancedConfig = new SymLoadBalancedConfig();
+
+    // Act
+    int actual = symLoadBalancedConfig.getAgentPort();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getAgentServersTest() throws Exception {
+    // Arrange
+    SymLoadBalancedConfig symLoadBalancedConfig = new SymLoadBalancedConfig();
+
+    // Act
+    List<String> actual = symLoadBalancedConfig.getAgentServers();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLoadBalancingTest() throws Exception {
+    // Arrange
+    SymLoadBalancedConfig symLoadBalancedConfig = new SymLoadBalancedConfig();
+
+    // Act
+    LoadBalancing actual = symLoadBalancedConfig.getLoadBalancing();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void rotateAgentTest() throws Exception {
+    // Arrange
+    SymLoadBalancedConfig symLoadBalancedConfig = new SymLoadBalancedConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    symLoadBalancedConfig.rotateAgent();
+  }
+
+  @Test
+  public void setActualAgentHostTest() throws Exception {
+    // Arrange
+    SymLoadBalancedConfig symLoadBalancedConfig = new SymLoadBalancedConfig();
+    String actualAgentHost = "aaaaa";
+
+    // Act
+    symLoadBalancedConfig.setActualAgentHost(actualAgentHost);
+
+    // Assert
+    assertEquals(null, symLoadBalancedConfig.getAppCertName());
+  }
+
+  @Test
+  public void setAgentServersTest() throws Exception {
+    // Arrange
+    SymLoadBalancedConfig symLoadBalancedConfig = new SymLoadBalancedConfig();
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    symLoadBalancedConfig.setAgentServers(arrayList);
+
+    // Assert
+    assertSame(arrayList, symLoadBalancedConfig.getAgentServers());
+  }
+
+  @Test
+  public void setCurrentAgentIndexTest() throws Exception {
+    // Arrange
+    SymLoadBalancedConfig symLoadBalancedConfig = new SymLoadBalancedConfig();
+    int currentAgentIndex = 1;
+
+    // Act
+    symLoadBalancedConfig.setCurrentAgentIndex(currentAgentIndex);
+
+    // Assert
+    assertEquals(null, symLoadBalancedConfig.getAppCertName());
+  }
+
+  @Test
+  public void setLoadBalancingTest() throws Exception {
+    // Arrange
+    SymLoadBalancedConfig symLoadBalancedConfig = new SymLoadBalancedConfig();
+    LoadBalancing loadBalancing = new LoadBalancing();
+
+    // Act
+    symLoadBalancedConfig.setLoadBalancing(loadBalancing);
+
+    // Assert
+    assertSame(loadBalancing, symLoadBalancedConfig.getLoadBalancing());
+  }
+}

--- a/src/test/java/exceptions/APIClientErrorExceptionTest.java
+++ b/src/test/java/exceptions/APIClientErrorExceptionTest.java
@@ -1,0 +1,19 @@
+package exceptions;
+
+import static org.junit.Assert.assertEquals;
+import exceptions.APIClientErrorException;
+import org.junit.Test;
+
+public class APIClientErrorExceptionTest {
+  @Test
+  public void APIClientErrorExceptionTest() throws Exception {
+    // Arrange
+    String message = "aaaaa";
+
+    // Act
+    APIClientErrorException aPIClientErrorException = new APIClientErrorException(message);
+
+    // Assert
+    assertEquals("exceptions.APIClientErrorException: aaaaa", aPIClientErrorException.toString());
+  }
+}

--- a/src/test/java/exceptions/AuthenticationExceptionTest.java
+++ b/src/test/java/exceptions/AuthenticationExceptionTest.java
@@ -1,0 +1,45 @@
+package exceptions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import exceptions.AuthenticationException;
+import org.junit.Test;
+
+public class AuthenticationExceptionTest {
+  @Test
+  public void AuthenticationExceptionTest() throws Exception {
+    // Arrange
+    Exception exception = new Exception();
+
+    // Act
+    AuthenticationException authenticationException = new AuthenticationException(exception);
+
+    // Assert
+    assertSame(exception, authenticationException.getRootException());
+  }
+
+  @Test
+  public void getRootExceptionTest() throws Exception {
+    // Arrange
+    AuthenticationException authenticationException = new AuthenticationException(new Exception());
+
+    // Act
+    Exception actual = authenticationException.getRootException();
+
+    // Assert
+    assertEquals("java.lang.Exception", actual.toString());
+  }
+
+  @Test
+  public void setRootExceptionTest() throws Exception {
+    // Arrange
+    AuthenticationException authenticationException = new AuthenticationException(new Exception());
+    Exception exception = new Exception();
+
+    // Act
+    authenticationException.setRootException(exception);
+
+    // Assert
+    assertSame(exception, authenticationException.getRootException());
+  }
+}

--- a/src/test/java/exceptions/ForbiddenExceptionTest.java
+++ b/src/test/java/exceptions/ForbiddenExceptionTest.java
@@ -1,0 +1,19 @@
+package exceptions;
+
+import static org.junit.Assert.assertEquals;
+import exceptions.ForbiddenException;
+import org.junit.Test;
+
+public class ForbiddenExceptionTest {
+  @Test
+  public void ForbiddenExceptionTest() throws Exception {
+    // Arrange
+    String message = "aaaaa";
+
+    // Act
+    ForbiddenException forbiddenException = new ForbiddenException(message);
+
+    // Assert
+    assertEquals("exceptions.ForbiddenException: aaaaa", forbiddenException.toString());
+  }
+}

--- a/src/test/java/exceptions/NoConfigExceptionTest.java
+++ b/src/test/java/exceptions/NoConfigExceptionTest.java
@@ -1,0 +1,19 @@
+package exceptions;
+
+import static org.junit.Assert.assertEquals;
+import exceptions.NoConfigException;
+import org.junit.Test;
+
+public class NoConfigExceptionTest {
+  @Test
+  public void NoConfigExceptionTest() throws Exception {
+    // Arrange
+    String message = "aaaaa";
+
+    // Act
+    NoConfigException noConfigException = new NoConfigException(message);
+
+    // Assert
+    assertEquals("exceptions.NoConfigException: aaaaa", noConfigException.toString());
+  }
+}

--- a/src/test/java/exceptions/ServerErrorExceptionTest.java
+++ b/src/test/java/exceptions/ServerErrorExceptionTest.java
@@ -1,0 +1,19 @@
+package exceptions;
+
+import static org.junit.Assert.assertEquals;
+import exceptions.ServerErrorException;
+import org.junit.Test;
+
+public class ServerErrorExceptionTest {
+  @Test
+  public void ServerErrorExceptionTest() throws Exception {
+    // Arrange
+    String message = "aaaaa";
+
+    // Act
+    ServerErrorException serverErrorException = new ServerErrorException(message);
+
+    // Assert
+    assertEquals("exceptions.ServerErrorException: aaaaa", serverErrorException.toString());
+  }
+}

--- a/src/test/java/exceptions/SymClientExceptionTest.java
+++ b/src/test/java/exceptions/SymClientExceptionTest.java
@@ -1,0 +1,19 @@
+package exceptions;
+
+import static org.junit.Assert.assertEquals;
+import exceptions.SymClientException;
+import org.junit.Test;
+
+public class SymClientExceptionTest {
+  @Test
+  public void SymClientExceptionTest() throws Exception {
+    // Arrange
+    String message = "aaaaa";
+
+    // Act
+    SymClientException symClientException = new SymClientException(message);
+
+    // Assert
+    assertEquals("exceptions.SymClientException: aaaaa", symClientException.toString());
+  }
+}

--- a/src/test/java/exceptions/UnauthorizedExceptionTest.java
+++ b/src/test/java/exceptions/UnauthorizedExceptionTest.java
@@ -1,0 +1,19 @@
+package exceptions;
+
+import static org.junit.Assert.assertEquals;
+import exceptions.UnauthorizedException;
+import org.junit.Test;
+
+public class UnauthorizedExceptionTest {
+  @Test
+  public void UnauthorizedExceptionTest() throws Exception {
+    // Arrange
+    String message = "aaaaa";
+
+    // Act
+    UnauthorizedException unauthorizedException = new UnauthorizedException(message);
+
+    // Assert
+    assertEquals("exceptions.UnauthorizedException: aaaaa", unauthorizedException.toString());
+  }
+}

--- a/src/test/java/model/AdminNewUserTest.java
+++ b/src/test/java/model/AdminNewUserTest.java
@@ -1,0 +1,96 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.AdminNewUser;
+import model.Password;
+import org.junit.Test;
+
+public class AdminNewUserTest {
+  @Test
+  public void AdminNewUserTest() throws Exception {
+    // Arrange and Act
+    AdminNewUser adminNewUser = new AdminNewUser();
+
+    // Assert
+    assertEquals(null, adminNewUser.getPassword());
+  }
+
+  @Test
+  public void getPasswordTest() throws Exception {
+    // Arrange
+    AdminNewUser adminNewUser = new AdminNewUser();
+
+    // Act
+    Password actual = adminNewUser.getPassword();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRolesTest() throws Exception {
+    // Arrange
+    AdminNewUser adminNewUser = new AdminNewUser();
+
+    // Act
+    List<String> actual = adminNewUser.getRoles();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserAttributesTest() throws Exception {
+    // Arrange
+    AdminNewUser adminNewUser = new AdminNewUser();
+
+    // Act
+    AdminUserAttributes actual = adminNewUser.getUserAttributes();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setPasswordTest() throws Exception {
+    // Arrange
+    AdminNewUser adminNewUser = new AdminNewUser();
+    Password password = new Password();
+
+    // Act
+    adminNewUser.setPassword(password);
+
+    // Assert
+    assertSame(password, adminNewUser.getPassword());
+  }
+
+  @Test
+  public void setRolesTest() throws Exception {
+    // Arrange
+    AdminNewUser adminNewUser = new AdminNewUser();
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    adminNewUser.setRoles(arrayList);
+
+    // Assert
+    assertSame(arrayList, adminNewUser.getRoles());
+  }
+
+  @Test
+  public void setUserAttributesTest() throws Exception {
+    // Arrange
+    AdminNewUser adminNewUser = new AdminNewUser();
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    adminNewUser.setUserAttributes(adminUserAttributes);
+
+    // Assert
+    assertSame(adminUserAttributes, adminNewUser.getUserAttributes());
+  }
+}

--- a/src/test/java/model/AdminStreamAttributesTest.java
+++ b/src/test/java/model/AdminStreamAttributesTest.java
@@ -1,0 +1,295 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.AdminStreamAttributes;
+import org.junit.Test;
+
+public class AdminStreamAttributesTest {
+  @Test
+  public void AdminStreamAttributesTest() throws Exception {
+    // Arrange and Act
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Assert
+    assertEquals(null, adminStreamAttributes.getRoomName());
+  }
+
+  @Test
+  public void getCreatedByUserIdTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Act
+    long actual = adminStreamAttributes.getCreatedByUserId();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getCreatedDateTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Act
+    long actual = adminStreamAttributes.getCreatedDate();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getDescriptionTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Act
+    String actual = adminStreamAttributes.getDescription();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLastMessageDateTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Act
+    long actual = adminStreamAttributes.getLastMessageDate();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getLastModifiedDateTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Act
+    long actual = adminStreamAttributes.getLastModifiedDate();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getMembersCountTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Act
+    Integer actual = adminStreamAttributes.getMembersCount();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMembersTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Act
+    List<Long> actual = adminStreamAttributes.getMembers();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOriginCompanyIdTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Act
+    Integer actual = adminStreamAttributes.getOriginCompanyId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOriginCompanyTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Act
+    String actual = adminStreamAttributes.getOriginCompany();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomDescriptionTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Act
+    String actual = adminStreamAttributes.getRoomDescription();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomNameTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Act
+    String actual = adminStreamAttributes.getRoomName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setCreatedByUserIdTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+    long createdByUserId = 1L;
+
+    // Act
+    adminStreamAttributes.setCreatedByUserId(createdByUserId);
+
+    // Assert
+    assertEquals(1L, adminStreamAttributes.getCreatedByUserId());
+  }
+
+  @Test
+  public void setCreatedDateTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+    long createdDate = 1L;
+
+    // Act
+    adminStreamAttributes.setCreatedDate(createdDate);
+
+    // Assert
+    assertEquals(1L, adminStreamAttributes.getCreatedDate());
+  }
+
+  @Test
+  public void setDescriptionTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+    String description = "aaaaa";
+
+    // Act
+    adminStreamAttributes.setDescription(description);
+
+    // Assert
+    assertEquals("aaaaa", adminStreamAttributes.getDescription());
+  }
+
+  @Test
+  public void setLastMessageDateTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+    long lastMessageDate = 1L;
+
+    // Act
+    adminStreamAttributes.setLastMessageDate(lastMessageDate);
+
+    // Assert
+    assertEquals(1L, adminStreamAttributes.getLastMessageDate());
+  }
+
+  @Test
+  public void setLastModifiedDateTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+    long lastModifiedDate = 1L;
+
+    // Act
+    adminStreamAttributes.setLastModifiedDate(lastModifiedDate);
+
+    // Assert
+    assertEquals(1L, adminStreamAttributes.getLastModifiedDate());
+  }
+
+  @Test
+  public void setMembersCountTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+    Integer membersCount = new Integer(1);
+
+    // Act
+    adminStreamAttributes.setMembersCount(membersCount);
+
+    // Assert
+    assertEquals(Integer.valueOf(1), adminStreamAttributes.getMembersCount());
+  }
+
+  @Test
+  public void setMembersTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act
+    adminStreamAttributes.setMembers(arrayList);
+
+    // Assert
+    assertSame(arrayList, adminStreamAttributes.getMembers());
+  }
+
+  @Test
+  public void setOriginCompanyIdTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+    Integer originCompanyId = new Integer(1);
+
+    // Act
+    adminStreamAttributes.setOriginCompanyId(originCompanyId);
+
+    // Assert
+    assertEquals(Integer.valueOf(1), adminStreamAttributes.getOriginCompanyId());
+  }
+
+  @Test
+  public void setOriginCompanyTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+    String originCompany = "aaaaa";
+
+    // Act
+    adminStreamAttributes.setOriginCompany(originCompany);
+
+    // Assert
+    assertEquals("aaaaa", adminStreamAttributes.getOriginCompany());
+  }
+
+  @Test
+  public void setRoomDescriptionTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+    String roomDescription = "aaaaa";
+
+    // Act
+    adminStreamAttributes.setRoomDescription(roomDescription);
+
+    // Assert
+    assertEquals("aaaaa", adminStreamAttributes.getRoomDescription());
+  }
+
+  @Test
+  public void setRoomNameTest() throws Exception {
+    // Arrange
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+    String roomName = "aaaaa";
+
+    // Act
+    adminStreamAttributes.setRoomName(roomName);
+
+    // Assert
+    assertEquals("aaaaa", adminStreamAttributes.getRoomName());
+  }
+}

--- a/src/test/java/model/AdminStreamFilterTest.java
+++ b/src/test/java/model/AdminStreamFilterTest.java
@@ -1,0 +1,195 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.AdminStreamFilter;
+import org.junit.Test;
+
+public class AdminStreamFilterTest {
+  @Test
+  public void AdminStreamFilterTest() throws Exception {
+    // Arrange and Act
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+
+    // Assert
+    assertEquals(null, adminStreamFilter.getOrigin());
+  }
+
+  @Test
+  public void getEndDateTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+
+    // Act
+    Long actual = adminStreamFilter.getEndDate();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOriginTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+
+    // Act
+    String actual = adminStreamFilter.getOrigin();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPrivacyTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+
+    // Act
+    String actual = adminStreamFilter.getPrivacy();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getScopeTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+
+    // Act
+    String actual = adminStreamFilter.getScope();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStartDateTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+
+    // Act
+    Long actual = adminStreamFilter.getStartDate();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStatusTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+
+    // Act
+    String actual = adminStreamFilter.getStatus();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTypesTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+
+    // Act
+    List<String> actual = adminStreamFilter.getStreamTypes();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setEndDateTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+    Long endDate = new Long(1L);
+
+    // Act
+    adminStreamFilter.setEndDate(endDate);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), adminStreamFilter.getEndDate());
+  }
+
+  @Test
+  public void setOriginTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+    String origin = "aaaaa";
+
+    // Act
+    adminStreamFilter.setOrigin(origin);
+
+    // Assert
+    assertEquals("aaaaa", adminStreamFilter.getOrigin());
+  }
+
+  @Test
+  public void setPrivacyTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+    String privacy = "aaaaa";
+
+    // Act
+    adminStreamFilter.setPrivacy(privacy);
+
+    // Assert
+    assertEquals("aaaaa", adminStreamFilter.getPrivacy());
+  }
+
+  @Test
+  public void setScopeTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+    String scope = "aaaaa";
+
+    // Act
+    adminStreamFilter.setScope(scope);
+
+    // Assert
+    assertEquals("aaaaa", adminStreamFilter.getScope());
+  }
+
+  @Test
+  public void setStartDateTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+    Long startDate = new Long(1L);
+
+    // Act
+    adminStreamFilter.setStartDate(startDate);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), adminStreamFilter.getStartDate());
+  }
+
+  @Test
+  public void setStatusTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+    String status = "aaaaa";
+
+    // Act
+    adminStreamFilter.setStatus(status);
+
+    // Assert
+    assertEquals("aaaaa", adminStreamFilter.getStatus());
+  }
+
+  @Test
+  public void setStreamTypesTest() throws Exception {
+    // Arrange
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    adminStreamFilter.setStreamTypes(arrayList);
+
+    // Assert
+    assertSame(arrayList, adminStreamFilter.getStreamTypes());
+  }
+}

--- a/src/test/java/model/AdminStreamInfoTest.java
+++ b/src/test/java/model/AdminStreamInfoTest.java
@@ -1,0 +1,220 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import model.AdminStreamAttributes;
+import model.AdminStreamInfo;
+import org.junit.Test;
+
+public class AdminStreamInfoTest {
+  @Test
+  public void AdminStreamInfoTest() throws Exception {
+    // Arrange and Act
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+
+    // Assert
+    assertEquals(null, adminStreamInfo.getOrigin());
+  }
+
+  @Test
+  public void getAttributesTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+
+    // Act
+    AdminStreamAttributes actual = adminStreamInfo.getAttributes();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+
+    // Act
+    String actual = adminStreamInfo.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOriginTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+
+    // Act
+    String actual = adminStreamInfo.getOrigin();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTypeTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+
+    // Act
+    String actual = adminStreamInfo.getType();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void isActiveTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+
+    // Act
+    boolean actual = adminStreamInfo.isActive();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void isCrossPodTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+
+    // Act
+    boolean actual = adminStreamInfo.isCrossPod();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void isExternalTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+
+    // Act
+    boolean actual = adminStreamInfo.isExternal();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void isPublicTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+
+    // Act
+    boolean actual = adminStreamInfo.isPublic();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void setActiveTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+    boolean active = true;
+
+    // Act
+    adminStreamInfo.setActive(active);
+
+    // Assert
+    assertTrue(adminStreamInfo.isActive());
+  }
+
+  @Test
+  public void setAttributesTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+    AdminStreamAttributes adminStreamAttributes = new AdminStreamAttributes();
+
+    // Act
+    adminStreamInfo.setAttributes(adminStreamAttributes);
+
+    // Assert
+    assertSame(adminStreamAttributes, adminStreamInfo.getAttributes());
+  }
+
+  @Test
+  public void setCrossPodTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+    boolean crossPod = true;
+
+    // Act
+    adminStreamInfo.setCrossPod(crossPod);
+
+    // Assert
+    assertTrue(adminStreamInfo.isCrossPod());
+  }
+
+  @Test
+  public void setExternalTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+    boolean external = true;
+
+    // Act
+    adminStreamInfo.setExternal(external);
+
+    // Assert
+    assertTrue(adminStreamInfo.isExternal());
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+    String id = "aaaaa";
+
+    // Act
+    adminStreamInfo.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", adminStreamInfo.getId());
+  }
+
+  @Test
+  public void setOriginTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+    String origin = "aaaaa";
+
+    // Act
+    adminStreamInfo.setOrigin(origin);
+
+    // Assert
+    assertEquals("aaaaa", adminStreamInfo.getOrigin());
+  }
+
+  @Test
+  public void setPublicTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+    boolean isPublic = true;
+
+    // Act
+    adminStreamInfo.setPublic(isPublic);
+
+    // Assert
+    assertTrue(adminStreamInfo.isPublic());
+  }
+
+  @Test
+  public void setTypeTest() throws Exception {
+    // Arrange
+    AdminStreamInfo adminStreamInfo = new AdminStreamInfo();
+    String type = "aaaaa";
+
+    // Act
+    adminStreamInfo.setType(type);
+
+    // Assert
+    assertEquals("aaaaa", adminStreamInfo.getType());
+  }
+}

--- a/src/test/java/model/AdminUserAttributesTest.java
+++ b/src/test/java/model/AdminUserAttributesTest.java
@@ -1,0 +1,521 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.AdminUserAttributes;
+import org.junit.Test;
+
+public class AdminUserAttributesTest {
+  @Test
+  public void AdminUserAttributesTest() throws Exception {
+    // Arrange and Act
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Assert
+    assertEquals(null, adminUserAttributes.getLocation());
+  }
+
+  @Test
+  public void getAccountTypeTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getAccountType();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAssetClassesTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    List<String> actual = adminUserAttributes.getAssetClasses();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCompanyNameTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getCompanyName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCurrentKeyTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    UserKey actual = adminUserAttributes.getCurrentKey();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDepartmentTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getDepartment();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDisplayNameTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getDisplayName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDivisionTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getDivision();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getEmailAddressTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getEmailAddress();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getFirstNameTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getFirstName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIndustriesTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    List<String> actual = adminUserAttributes.getIndustries();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getJobFunctionTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getJobFunction();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLastNameTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getLastName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLocationTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getLocation();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMobilePhoneNumberTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getMobilePhoneNumber();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPreviousKeyTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    UserKey actual = adminUserAttributes.getPreviousKey();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSmsNumberTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getSmsNumber();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTitleTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getTitle();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTwoFactorAuthPhoneTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getTwoFactorAuthPhone();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserNameTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getUserName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getWorkPhoneNumberTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    String actual = adminUserAttributes.getWorkPhoneNumber();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAccountTypeTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String accountType = "aaaaa";
+
+    // Act
+    adminUserAttributes.setAccountType(accountType);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getAccountType());
+  }
+
+  @Test
+  public void setAssetClassesTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    adminUserAttributes.setAssetClasses(arrayList);
+
+    // Assert
+    assertSame(arrayList, adminUserAttributes.getAssetClasses());
+  }
+
+  @Test
+  public void setCompanyNameTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String companyName = "aaaaa";
+
+    // Act
+    adminUserAttributes.setCompanyName(companyName);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getCompanyName());
+  }
+
+  @Test
+  public void setCurrentKeyTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    UserKey userKey = new UserKey();
+
+    // Act
+    adminUserAttributes.setCurrentKey(userKey);
+
+    // Assert
+    assertSame(userKey, adminUserAttributes.getCurrentKey());
+  }
+
+  @Test
+  public void setDepartmentTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String department = "aaaaa";
+
+    // Act
+    adminUserAttributes.setDepartment(department);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getDepartment());
+  }
+
+  @Test
+  public void setDisplayNameTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String displayName = "aaaaa";
+
+    // Act
+    adminUserAttributes.setDisplayName(displayName);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getDisplayName());
+  }
+
+  @Test
+  public void setDivisionTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String division = "aaaaa";
+
+    // Act
+    adminUserAttributes.setDivision(division);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getDivision());
+  }
+
+  @Test
+  public void setEmailAddressTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String emailAddress = "aaaaa";
+
+    // Act
+    adminUserAttributes.setEmailAddress(emailAddress);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getEmailAddress());
+  }
+
+  @Test
+  public void setFirstNameTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String firstName = "aaaaa";
+
+    // Act
+    adminUserAttributes.setFirstName(firstName);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getFirstName());
+  }
+
+  @Test
+  public void setIndustriesTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    adminUserAttributes.setIndustries(arrayList);
+
+    // Assert
+    assertSame(arrayList, adminUserAttributes.getIndustries());
+  }
+
+  @Test
+  public void setJobFunctionTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String jobFunction = "aaaaa";
+
+    // Act
+    adminUserAttributes.setJobFunction(jobFunction);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getJobFunction());
+  }
+
+  @Test
+  public void setLastNameTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String lastName = "aaaaa";
+
+    // Act
+    adminUserAttributes.setLastName(lastName);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getLastName());
+  }
+
+  @Test
+  public void setLocationTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String location = "aaaaa";
+
+    // Act
+    adminUserAttributes.setLocation(location);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getLocation());
+  }
+
+  @Test
+  public void setMobilePhoneNumberTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String mobilePhoneNumber = "aaaaa";
+
+    // Act
+    adminUserAttributes.setMobilePhoneNumber(mobilePhoneNumber);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getMobilePhoneNumber());
+  }
+
+  @Test
+  public void setPreviousKeyTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    UserKey userKey = new UserKey();
+
+    // Act
+    adminUserAttributes.setPreviousKey(userKey);
+
+    // Assert
+    assertSame(userKey, adminUserAttributes.getPreviousKey());
+  }
+
+  @Test
+  public void setSmsNumberTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String smsNumber = "aaaaa";
+
+    // Act
+    adminUserAttributes.setSmsNumber(smsNumber);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getSmsNumber());
+  }
+
+  @Test
+  public void setTitleTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String title = "aaaaa";
+
+    // Act
+    adminUserAttributes.setTitle(title);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getTitle());
+  }
+
+  @Test
+  public void setTwoFactorAuthPhoneTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String twoFactorAuthPhone = "aaaaa";
+
+    // Act
+    adminUserAttributes.setTwoFactorAuthPhone(twoFactorAuthPhone);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getTwoFactorAuthPhone());
+  }
+
+  @Test
+  public void setUserNameTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String userName = "aaaaa";
+
+    // Act
+    adminUserAttributes.setUserName(userName);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getUserName());
+  }
+
+  @Test
+  public void setWorkPhoneNumberTest() throws Exception {
+    // Arrange
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+    String workPhoneNumber = "aaaaa";
+
+    // Act
+    adminUserAttributes.setWorkPhoneNumber(workPhoneNumber);
+
+    // Assert
+    assertEquals("aaaaa", adminUserAttributes.getWorkPhoneNumber());
+  }
+}

--- a/src/test/java/model/AdminUserInfoListTest.java
+++ b/src/test/java/model/AdminUserInfoListTest.java
@@ -1,0 +1,16 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.AdminUserInfoList;
+import org.junit.Test;
+
+public class AdminUserInfoListTest {
+  @Test
+  public void AdminUserInfoListTest() throws Exception {
+    // Arrange and Act
+    AdminUserInfoList adminUserInfoList = new AdminUserInfoList();
+
+    // Assert
+    assertEquals(0, adminUserInfoList.size());
+  }
+}

--- a/src/test/java/model/AdminUserInfoTest.java
+++ b/src/test/java/model/AdminUserInfoTest.java
@@ -1,0 +1,225 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.AdminUserInfo;
+import model.Avatar;
+import org.junit.Test;
+
+public class AdminUserInfoTest {
+  @Test
+  public void AdminUserInfoTest() throws Exception {
+    // Arrange and Act
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+
+    // Assert
+    assertEquals(null, adminUserInfo.getFeatures());
+  }
+
+  @Test
+  public void getAppsTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+
+    // Act
+    List<Long> actual = adminUserInfo.getApps();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAvatarTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+
+    // Act
+    Avatar actual = adminUserInfo.getAvatar();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDisclaimersTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+
+    // Act
+    List<Long> actual = adminUserInfo.getDisclaimers();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getFeaturesTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+
+    // Act
+    List<Long> actual = adminUserInfo.getFeatures();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getGroupsTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+
+    // Act
+    List<Long> actual = adminUserInfo.getGroups();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRolesTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+
+    // Act
+    List<String> actual = adminUserInfo.getRoles();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserAttributesTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+
+    // Act
+    AdminUserAttributes actual = adminUserInfo.getUserAttributes();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserSystemInfoTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+
+    // Act
+    AdminUserSystemInfo actual = adminUserInfo.getUserSystemInfo();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAppsTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act
+    adminUserInfo.setApps(arrayList);
+
+    // Assert
+    assertSame(arrayList, adminUserInfo.getApps());
+  }
+
+  @Test
+  public void setAvatarTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+    Avatar avatar = new Avatar();
+
+    // Act
+    adminUserInfo.setAvatar(avatar);
+
+    // Assert
+    assertSame(avatar, adminUserInfo.getAvatar());
+  }
+
+  @Test
+  public void setDisclaimersTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act
+    adminUserInfo.setDisclaimers(arrayList);
+
+    // Assert
+    assertSame(arrayList, adminUserInfo.getDisclaimers());
+  }
+
+  @Test
+  public void setFeaturesTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act
+    adminUserInfo.setFeatures(arrayList);
+
+    // Assert
+    assertSame(arrayList, adminUserInfo.getFeatures());
+  }
+
+  @Test
+  public void setGroupsTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act
+    adminUserInfo.setGroups(arrayList);
+
+    // Assert
+    assertSame(arrayList, adminUserInfo.getGroups());
+  }
+
+  @Test
+  public void setRolesTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    adminUserInfo.setRoles(arrayList);
+
+    // Assert
+    assertSame(arrayList, adminUserInfo.getRoles());
+  }
+
+  @Test
+  public void setUserAttributesTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+    AdminUserAttributes adminUserAttributes = new AdminUserAttributes();
+
+    // Act
+    adminUserInfo.setUserAttributes(adminUserAttributes);
+
+    // Assert
+    assertSame(adminUserAttributes, adminUserInfo.getUserAttributes());
+  }
+
+  @Test
+  public void setUserSystemInfoTest() throws Exception {
+    // Arrange
+    AdminUserInfo adminUserInfo = new AdminUserInfo();
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+
+    // Act
+    adminUserInfo.setUserSystemInfo(adminUserSystemInfo);
+
+    // Assert
+    assertSame(adminUserSystemInfo, adminUserInfo.getUserSystemInfo());
+  }
+}

--- a/src/test/java/model/AdminUserSystemInfoTest.java
+++ b/src/test/java/model/AdminUserSystemInfoTest.java
@@ -1,0 +1,166 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.AdminUserSystemInfo;
+import org.junit.Test;
+
+public class AdminUserSystemInfoTest {
+  @Test
+  public void AdminUserSystemInfoTest() throws Exception {
+    // Arrange and Act
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+
+    // Assert
+    assertEquals(null, adminUserSystemInfo.getCreatedBy());
+  }
+
+  @Test
+  public void getCreatedByTest() throws Exception {
+    // Arrange
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+
+    // Act
+    String actual = adminUserSystemInfo.getCreatedBy();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCreatedDateTest() throws Exception {
+    // Arrange
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+
+    // Act
+    Long actual = adminUserSystemInfo.getCreatedDate();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+
+    // Act
+    Long actual = adminUserSystemInfo.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLastLoginDateTest() throws Exception {
+    // Arrange
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+
+    // Act
+    Long actual = adminUserSystemInfo.getLastLoginDate();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLastUpdatedDateTest() throws Exception {
+    // Arrange
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+
+    // Act
+    Long actual = adminUserSystemInfo.getLastUpdatedDate();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStatusTest() throws Exception {
+    // Arrange
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+
+    // Act
+    String actual = adminUserSystemInfo.getStatus();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setCreatedByTest() throws Exception {
+    // Arrange
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+    String createdBy = "aaaaa";
+
+    // Act
+    adminUserSystemInfo.setCreatedBy(createdBy);
+
+    // Assert
+    assertEquals("aaaaa", adminUserSystemInfo.getCreatedBy());
+  }
+
+  @Test
+  public void setCreatedDateTest() throws Exception {
+    // Arrange
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+    Long createdDate = new Long(1L);
+
+    // Act
+    adminUserSystemInfo.setCreatedDate(createdDate);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), adminUserSystemInfo.getCreatedDate());
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+    Long id = new Long(1L);
+
+    // Act
+    adminUserSystemInfo.setId(id);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), adminUserSystemInfo.getId());
+  }
+
+  @Test
+  public void setLastLoginDateTest() throws Exception {
+    // Arrange
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+    Long lastLoginDate = new Long(1L);
+
+    // Act
+    adminUserSystemInfo.setLastLoginDate(lastLoginDate);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), adminUserSystemInfo.getLastLoginDate());
+  }
+
+  @Test
+  public void setLastUpdatedDateTest() throws Exception {
+    // Arrange
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+    Long lastUpdatedDate = new Long(1L);
+
+    // Act
+    adminUserSystemInfo.setLastUpdatedDate(lastUpdatedDate);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), adminUserSystemInfo.getLastUpdatedDate());
+  }
+
+  @Test
+  public void setStatusTest() throws Exception {
+    // Arrange
+    AdminUserSystemInfo adminUserSystemInfo = new AdminUserSystemInfo();
+    String status = "aaaaa";
+
+    // Act
+    adminUserSystemInfo.setStatus(status);
+
+    // Assert
+    assertEquals("aaaaa", adminUserSystemInfo.getStatus());
+  }
+}

--- a/src/test/java/model/AppAuthResponseTest.java
+++ b/src/test/java/model/AppAuthResponseTest.java
@@ -1,0 +1,116 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.AppAuthResponse;
+import org.junit.Test;
+
+public class AppAuthResponseTest {
+  @Test
+  public void AppAuthResponseTest() throws Exception {
+    // Arrange and Act
+    AppAuthResponse appAuthResponse = new AppAuthResponse();
+
+    // Assert
+    assertEquals(null, appAuthResponse.getAppToken());
+  }
+
+  @Test
+  public void getAppIdTest() throws Exception {
+    // Arrange
+    AppAuthResponse appAuthResponse = new AppAuthResponse();
+
+    // Act
+    String actual = appAuthResponse.getAppId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAppTokenTest() throws Exception {
+    // Arrange
+    AppAuthResponse appAuthResponse = new AppAuthResponse();
+
+    // Act
+    String actual = appAuthResponse.getAppToken();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getExpireAtTest() throws Exception {
+    // Arrange
+    AppAuthResponse appAuthResponse = new AppAuthResponse();
+
+    // Act
+    long actual = appAuthResponse.getExpireAt();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getSymphonyTokenTest() throws Exception {
+    // Arrange
+    AppAuthResponse appAuthResponse = new AppAuthResponse();
+
+    // Act
+    String actual = appAuthResponse.getSymphonyToken();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAppIdTest() throws Exception {
+    // Arrange
+    AppAuthResponse appAuthResponse = new AppAuthResponse();
+    String appId = "aaaaa";
+
+    // Act
+    appAuthResponse.setAppId(appId);
+
+    // Assert
+    assertEquals("aaaaa", appAuthResponse.getAppId());
+  }
+
+  @Test
+  public void setAppTokenTest() throws Exception {
+    // Arrange
+    AppAuthResponse appAuthResponse = new AppAuthResponse();
+    String appToken = "aaaaa";
+
+    // Act
+    appAuthResponse.setAppToken(appToken);
+
+    // Assert
+    assertEquals("aaaaa", appAuthResponse.getAppToken());
+  }
+
+  @Test
+  public void setExpireAtTest() throws Exception {
+    // Arrange
+    AppAuthResponse appAuthResponse = new AppAuthResponse();
+    long expireAt = 1L;
+
+    // Act
+    appAuthResponse.setExpireAt(expireAt);
+
+    // Assert
+    assertEquals(1L, appAuthResponse.getExpireAt());
+  }
+
+  @Test
+  public void setSymphonyTokenTest() throws Exception {
+    // Arrange
+    AppAuthResponse appAuthResponse = new AppAuthResponse();
+    String symphonyToken = "aaaaa";
+
+    // Act
+    appAuthResponse.setSymphonyToken(symphonyToken);
+
+    // Assert
+    assertEquals("aaaaa", appAuthResponse.getSymphonyToken());
+  }
+}

--- a/src/test/java/model/ApplicationEntitlementListTest.java
+++ b/src/test/java/model/ApplicationEntitlementListTest.java
@@ -1,0 +1,16 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.ApplicationEntitlementList;
+import org.junit.Test;
+
+public class ApplicationEntitlementListTest {
+  @Test
+  public void ApplicationEntitlementListTest() throws Exception {
+    // Arrange and Act
+    ApplicationEntitlementList applicationEntitlementList = new ApplicationEntitlementList();
+
+    // Assert
+    assertEquals(0, applicationEntitlementList.size());
+  }
+}

--- a/src/test/java/model/ApplicationEntitlementTest.java
+++ b/src/test/java/model/ApplicationEntitlementTest.java
@@ -1,0 +1,146 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.ApplicationEntitlement;
+import model.ApplicationProduct;
+import org.junit.Test;
+
+public class ApplicationEntitlementTest {
+  @Test
+  public void ApplicationEntitlementTest() throws Exception {
+    // Arrange and Act
+    ApplicationEntitlement applicationEntitlement = new ApplicationEntitlement();
+
+    // Assert
+    assertEquals(null, applicationEntitlement.getInstall());
+  }
+
+  @Test
+  public void getAppIdTest() throws Exception {
+    // Arrange
+    ApplicationEntitlement applicationEntitlement = new ApplicationEntitlement();
+
+    // Act
+    String actual = applicationEntitlement.getAppId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAppNameTest() throws Exception {
+    // Arrange
+    ApplicationEntitlement applicationEntitlement = new ApplicationEntitlement();
+
+    // Act
+    String actual = applicationEntitlement.getAppName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getInstallTest() throws Exception {
+    // Arrange
+    ApplicationEntitlement applicationEntitlement = new ApplicationEntitlement();
+
+    // Act
+    Boolean actual = applicationEntitlement.getInstall();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getListedTest() throws Exception {
+    // Arrange
+    ApplicationEntitlement applicationEntitlement = new ApplicationEntitlement();
+
+    // Act
+    Boolean actual = applicationEntitlement.getListed();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getProductsTest() throws Exception {
+    // Arrange
+    ApplicationEntitlement applicationEntitlement = new ApplicationEntitlement();
+
+    // Act
+    List<ApplicationProduct> actual = applicationEntitlement.getProducts();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAppIdTest() throws Exception {
+    // Arrange
+    ApplicationEntitlement applicationEntitlement = new ApplicationEntitlement();
+    String appId = "aaaaa";
+
+    // Act
+    applicationEntitlement.setAppId(appId);
+
+    // Assert
+    assertEquals("aaaaa", applicationEntitlement.getAppId());
+  }
+
+  @Test
+  public void setAppNameTest() throws Exception {
+    // Arrange
+    ApplicationEntitlement applicationEntitlement = new ApplicationEntitlement();
+    String appName = "aaaaa";
+
+    // Act
+    applicationEntitlement.setAppName(appName);
+
+    // Assert
+    assertEquals("aaaaa", applicationEntitlement.getAppName());
+  }
+
+  @Test
+  public void setInstallTest() throws Exception {
+    // Arrange
+    ApplicationEntitlement applicationEntitlement = new ApplicationEntitlement();
+    Boolean install = new Boolean(true);
+
+    // Act
+    applicationEntitlement.setInstall(install);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), applicationEntitlement.getInstall());
+  }
+
+  @Test
+  public void setListedTest() throws Exception {
+    // Arrange
+    ApplicationEntitlement applicationEntitlement = new ApplicationEntitlement();
+    Boolean listed = new Boolean(true);
+
+    // Act
+    applicationEntitlement.setListed(listed);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), applicationEntitlement.getListed());
+  }
+
+  @Test
+  public void setProductsTest() throws Exception {
+    // Arrange
+    ApplicationEntitlement applicationEntitlement = new ApplicationEntitlement();
+    ArrayList<ApplicationProduct> arrayList = new ArrayList<ApplicationProduct>();
+    arrayList.add(new ApplicationProduct());
+
+    // Act
+    applicationEntitlement.setProducts(arrayList);
+
+    // Assert
+    assertSame(arrayList, applicationEntitlement.getProducts());
+  }
+}

--- a/src/test/java/model/ApplicationInfoTest.java
+++ b/src/test/java/model/ApplicationInfoTest.java
@@ -1,0 +1,141 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.ApplicationInfo;
+import org.junit.Test;
+
+public class ApplicationInfoTest {
+  @Test
+  public void ApplicationInfoTest() throws Exception {
+    // Arrange and Act
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+
+    // Assert
+    assertEquals(null, applicationInfo.getDomain());
+  }
+
+  @Test
+  public void getAppIdTest() throws Exception {
+    // Arrange
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+
+    // Act
+    String actual = applicationInfo.getAppId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAppUrlTest() throws Exception {
+    // Arrange
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+
+    // Act
+    String actual = applicationInfo.getAppUrl();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDomainTest() throws Exception {
+    // Arrange
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+
+    // Act
+    String actual = applicationInfo.getDomain();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getNameTest() throws Exception {
+    // Arrange
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+
+    // Act
+    String actual = applicationInfo.getName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPublisherTest() throws Exception {
+    // Arrange
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+
+    // Act
+    String actual = applicationInfo.getPublisher();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAppIdTest() throws Exception {
+    // Arrange
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+    String appId = "aaaaa";
+
+    // Act
+    applicationInfo.setAppId(appId);
+
+    // Assert
+    assertEquals("aaaaa", applicationInfo.getAppId());
+  }
+
+  @Test
+  public void setAppUrlTest() throws Exception {
+    // Arrange
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+    String appUrl = "aaaaa";
+
+    // Act
+    applicationInfo.setAppUrl(appUrl);
+
+    // Assert
+    assertEquals("aaaaa", applicationInfo.getAppUrl());
+  }
+
+  @Test
+  public void setDomainTest() throws Exception {
+    // Arrange
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+    String domain = "aaaaa";
+
+    // Act
+    applicationInfo.setDomain(domain);
+
+    // Assert
+    assertEquals("aaaaa", applicationInfo.getDomain());
+  }
+
+  @Test
+  public void setNameTest() throws Exception {
+    // Arrange
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+    String name = "aaaaa";
+
+    // Act
+    applicationInfo.setName(name);
+
+    // Assert
+    assertEquals("aaaaa", applicationInfo.getName());
+  }
+
+  @Test
+  public void setPublisherTest() throws Exception {
+    // Arrange
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+    String publisher = "aaaaa";
+
+    // Act
+    applicationInfo.setPublisher(publisher);
+
+    // Assert
+    assertEquals("aaaaa", applicationInfo.getPublisher());
+  }
+}

--- a/src/test/java/model/ApplicationProductTest.java
+++ b/src/test/java/model/ApplicationProductTest.java
@@ -1,0 +1,141 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.ApplicationProduct;
+import org.junit.Test;
+
+public class ApplicationProductTest {
+  @Test
+  public void ApplicationProductTest() throws Exception {
+    // Arrange and Act
+    ApplicationProduct applicationProduct = new ApplicationProduct();
+
+    // Assert
+    assertEquals(null, applicationProduct.getSku());
+  }
+
+  @Test
+  public void getAppIdTest() throws Exception {
+    // Arrange
+    ApplicationProduct applicationProduct = new ApplicationProduct();
+
+    // Act
+    String actual = applicationProduct.getAppId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getNameTest() throws Exception {
+    // Arrange
+    ApplicationProduct applicationProduct = new ApplicationProduct();
+
+    // Act
+    String actual = applicationProduct.getName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSkuTest() throws Exception {
+    // Arrange
+    ApplicationProduct applicationProduct = new ApplicationProduct();
+
+    // Act
+    String actual = applicationProduct.getSku();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSubscribedTest() throws Exception {
+    // Arrange
+    ApplicationProduct applicationProduct = new ApplicationProduct();
+
+    // Act
+    Boolean actual = applicationProduct.getSubscribed();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTypeTest() throws Exception {
+    // Arrange
+    ApplicationProduct applicationProduct = new ApplicationProduct();
+
+    // Act
+    String actual = applicationProduct.getType();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAppIdTest() throws Exception {
+    // Arrange
+    ApplicationProduct applicationProduct = new ApplicationProduct();
+    String appId = "aaaaa";
+
+    // Act
+    applicationProduct.setAppId(appId);
+
+    // Assert
+    assertEquals("aaaaa", applicationProduct.getAppId());
+  }
+
+  @Test
+  public void setNameTest() throws Exception {
+    // Arrange
+    ApplicationProduct applicationProduct = new ApplicationProduct();
+    String name = "aaaaa";
+
+    // Act
+    applicationProduct.setName(name);
+
+    // Assert
+    assertEquals("aaaaa", applicationProduct.getName());
+  }
+
+  @Test
+  public void setSkuTest() throws Exception {
+    // Arrange
+    ApplicationProduct applicationProduct = new ApplicationProduct();
+    String sku = "aaaaa";
+
+    // Act
+    applicationProduct.setSku(sku);
+
+    // Assert
+    assertEquals("aaaaa", applicationProduct.getSku());
+  }
+
+  @Test
+  public void setSubscribedTest() throws Exception {
+    // Arrange
+    ApplicationProduct applicationProduct = new ApplicationProduct();
+    Boolean subscribed = new Boolean(true);
+
+    // Act
+    applicationProduct.setSubscribed(subscribed);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), applicationProduct.getSubscribed());
+  }
+
+  @Test
+  public void setTypeTest() throws Exception {
+    // Arrange
+    ApplicationProduct applicationProduct = new ApplicationProduct();
+    String type = "aaaaa";
+
+    // Act
+    applicationProduct.setType(type);
+
+    // Assert
+    assertEquals("aaaaa", applicationProduct.getType());
+  }
+}

--- a/src/test/java/model/ApplicationTest.java
+++ b/src/test/java/model/ApplicationTest.java
@@ -1,0 +1,170 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.Application;
+import org.junit.Test;
+
+public class ApplicationTest {
+  @Test
+  public void ApplicationTest() throws Exception {
+    // Arrange and Act
+    Application application = new Application();
+
+    // Assert
+    assertEquals(null, application.getApplicationInfo());
+  }
+
+  @Test
+  public void getAllowOriginsTest() throws Exception {
+    // Arrange
+    Application application = new Application();
+
+    // Act
+    String actual = application.getAllowOrigins();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getApplicationInfoTest() throws Exception {
+    // Arrange
+    Application application = new Application();
+
+    // Act
+    ApplicationInfo actual = application.getApplicationInfo();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCertTest() throws Exception {
+    // Arrange
+    Application application = new Application();
+
+    // Act
+    String actual = application.getCert();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDescriptionTest() throws Exception {
+    // Arrange
+    Application application = new Application();
+
+    // Act
+    String actual = application.getDescription();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIconUrlTest() throws Exception {
+    // Arrange
+    Application application = new Application();
+
+    // Act
+    String actual = application.getIconUrl();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPermissionsTest() throws Exception {
+    // Arrange
+    Application application = new Application();
+
+    // Act
+    List<String> actual = application.getPermissions();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAllowOriginsTest() throws Exception {
+    // Arrange
+    Application application = new Application();
+    String allowOrigins = "aaaaa";
+
+    // Act
+    application.setAllowOrigins(allowOrigins);
+
+    // Assert
+    assertEquals("aaaaa", application.getAllowOrigins());
+  }
+
+  @Test
+  public void setApplicationInfoTest() throws Exception {
+    // Arrange
+    Application application = new Application();
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+
+    // Act
+    application.setApplicationInfo(applicationInfo);
+
+    // Assert
+    assertSame(applicationInfo, application.getApplicationInfo());
+  }
+
+  @Test
+  public void setCertTest() throws Exception {
+    // Arrange
+    Application application = new Application();
+    String cert = "aaaaa";
+
+    // Act
+    application.setCert(cert);
+
+    // Assert
+    assertEquals("aaaaa", application.getCert());
+  }
+
+  @Test
+  public void setDescriptionTest() throws Exception {
+    // Arrange
+    Application application = new Application();
+    String description = "aaaaa";
+
+    // Act
+    application.setDescription(description);
+
+    // Assert
+    assertEquals("aaaaa", application.getDescription());
+  }
+
+  @Test
+  public void setIconUrlTest() throws Exception {
+    // Arrange
+    Application application = new Application();
+    String iconUrl = "aaaaa";
+
+    // Act
+    application.setIconUrl(iconUrl);
+
+    // Assert
+    assertEquals("aaaaa", application.getIconUrl());
+  }
+
+  @Test
+  public void setPermissionsTest() throws Exception {
+    // Arrange
+    Application application = new Application();
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    application.setPermissions(arrayList);
+
+    // Assert
+    assertSame(arrayList, application.getPermissions());
+  }
+}

--- a/src/test/java/model/AttachmentTest.java
+++ b/src/test/java/model/AttachmentTest.java
@@ -1,0 +1,117 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.Attachment;
+import org.junit.Test;
+
+public class AttachmentTest {
+  @Test
+  public void AttachmentTest() throws Exception {
+    // Arrange and Act
+    Attachment attachment = new Attachment();
+
+    // Assert
+    assertEquals(null, attachment.getSize());
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    Attachment attachment = new Attachment();
+
+    // Act
+    String actual = attachment.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getImageTest() throws Exception {
+    // Arrange
+    Attachment attachment = new Attachment();
+
+    // Act
+    ImageInfo actual = attachment.getImage();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getNameTest() throws Exception {
+    // Arrange
+    Attachment attachment = new Attachment();
+
+    // Act
+    String actual = attachment.getName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSizeTest() throws Exception {
+    // Arrange
+    Attachment attachment = new Attachment();
+
+    // Act
+    Long actual = attachment.getSize();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    Attachment attachment = new Attachment();
+    String id = "aaaaa";
+
+    // Act
+    attachment.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", attachment.getId());
+  }
+
+  @Test
+  public void setImageTest() throws Exception {
+    // Arrange
+    Attachment attachment = new Attachment();
+    ImageInfo imageInfo = new ImageInfo();
+
+    // Act
+    attachment.setImage(imageInfo);
+
+    // Assert
+    assertSame(imageInfo, attachment.getImage());
+  }
+
+  @Test
+  public void setNameTest() throws Exception {
+    // Arrange
+    Attachment attachment = new Attachment();
+    String name = "aaaaa";
+
+    // Act
+    attachment.setName(name);
+
+    // Assert
+    assertEquals("aaaaa", attachment.getName());
+  }
+
+  @Test
+  public void setSizeTest() throws Exception {
+    // Arrange
+    Attachment attachment = new Attachment();
+    Long size = new Long(1L);
+
+    // Act
+    attachment.setSize(size);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), attachment.getSize());
+  }
+}

--- a/src/test/java/model/AvatarListTest.java
+++ b/src/test/java/model/AvatarListTest.java
@@ -1,0 +1,16 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.AvatarList;
+import org.junit.Test;
+
+public class AvatarListTest {
+  @Test
+  public void AvatarListTest() throws Exception {
+    // Arrange and Act
+    AvatarList avatarList = new AvatarList();
+
+    // Assert
+    assertEquals(0, avatarList.size());
+  }
+}

--- a/src/test/java/model/AvatarTest.java
+++ b/src/test/java/model/AvatarTest.java
@@ -1,0 +1,66 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.Avatar;
+import org.junit.Test;
+
+public class AvatarTest {
+  @Test
+  public void AvatarTest() throws Exception {
+    // Arrange and Act
+    Avatar avatar = new Avatar();
+
+    // Assert
+    assertEquals(null, avatar.getUrl());
+  }
+
+  @Test
+  public void getSizeTest() throws Exception {
+    // Arrange
+    Avatar avatar = new Avatar();
+
+    // Act
+    String actual = avatar.getSize();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUrlTest() throws Exception {
+    // Arrange
+    Avatar avatar = new Avatar();
+
+    // Act
+    String actual = avatar.getUrl();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setSizeTest() throws Exception {
+    // Arrange
+    Avatar avatar = new Avatar();
+    String size = "aaaaa";
+
+    // Act
+    avatar.setSize(size);
+
+    // Assert
+    assertEquals("aaaaa", avatar.getSize());
+  }
+
+  @Test
+  public void setUrlTest() throws Exception {
+    // Arrange
+    Avatar avatar = new Avatar();
+    String url = "aaaaa";
+
+    // Act
+    avatar.setUrl(url);
+
+    // Assert
+    assertEquals("aaaaa", avatar.getUrl());
+  }
+}

--- a/src/test/java/model/ClientErrorTest.java
+++ b/src/test/java/model/ClientErrorTest.java
@@ -1,0 +1,92 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import model.ClientError;
+import org.junit.Test;
+
+public class ClientErrorTest {
+  @Test
+  public void ClientErrorTest() throws Exception {
+    // Arrange and Act
+    ClientError clientError = new ClientError();
+
+    // Assert
+    assertEquals(0, clientError.getCode());
+  }
+
+  @Test
+  public void getCodeTest() throws Exception {
+    // Arrange
+    ClientError clientError = new ClientError();
+
+    // Act
+    int actual = clientError.getCode();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getDetailsTest() throws Exception {
+    // Arrange
+    ClientError clientError = new ClientError();
+
+    // Act
+    Object actual = clientError.getDetails();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMessageTest() throws Exception {
+    // Arrange
+    ClientError clientError = new ClientError();
+
+    // Act
+    String actual = clientError.getMessage();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setCodeTest() throws Exception {
+    // Arrange
+    ClientError clientError = new ClientError();
+    int code = 1;
+
+    // Act
+    clientError.setCode(code);
+
+    // Assert
+    assertEquals(1, clientError.getCode());
+  }
+
+  @Test
+  public void setDetailsTest() throws Exception {
+    // Arrange
+    ClientError clientError = new ClientError();
+    String details = "aaaaa";
+
+    // Act
+    clientError.setDetails(details);
+
+    // Assert
+    assertTrue(clientError.getDetails() instanceof String);
+  }
+
+  @Test
+  public void setMessageTest() throws Exception {
+    // Arrange
+    ClientError clientError = new ClientError();
+    String message = "aaaaa";
+
+    // Act
+    clientError.setMessage(message);
+
+    // Assert
+    assertEquals("aaaaa", clientError.getMessage());
+  }
+}

--- a/src/test/java/model/DatafeedEventTest.java
+++ b/src/test/java/model/DatafeedEventTest.java
@@ -1,0 +1,192 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.DatafeedEvent;
+import org.junit.Test;
+
+public class DatafeedEventTest {
+  @Test
+  public void DatafeedEventTest() throws Exception {
+    // Arrange and Act
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+
+    // Assert
+    assertEquals(null, datafeedEvent.getTimestamp());
+  }
+
+  @Test
+  public void getDiagnosticTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+
+    // Act
+    String actual = datafeedEvent.getDiagnostic();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+
+    // Act
+    String actual = datafeedEvent.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getInitiatorTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+
+    // Act
+    Initiator actual = datafeedEvent.getInitiator();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMessageIdTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+
+    // Act
+    String actual = datafeedEvent.getMessageId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPayloadTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+
+    // Act
+    EventPayload actual = datafeedEvent.getPayload();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTimestampTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+
+    // Act
+    Long actual = datafeedEvent.getTimestamp();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTypeTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+
+    // Act
+    String actual = datafeedEvent.getType();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setDiagnosticTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+    String diagnostic = "aaaaa";
+
+    // Act
+    datafeedEvent.setDiagnostic(diagnostic);
+
+    // Assert
+    assertEquals("aaaaa", datafeedEvent.getDiagnostic());
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+    String id = "aaaaa";
+
+    // Act
+    datafeedEvent.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", datafeedEvent.getId());
+  }
+
+  @Test
+  public void setInitiatorTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+    Initiator initiator = new Initiator();
+
+    // Act
+    datafeedEvent.setInitiator(initiator);
+
+    // Assert
+    assertSame(initiator, datafeedEvent.getInitiator());
+  }
+
+  @Test
+  public void setMessageIdTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+    String messageId = "aaaaa";
+
+    // Act
+    datafeedEvent.setMessageId(messageId);
+
+    // Assert
+    assertEquals("aaaaa", datafeedEvent.getMessageId());
+  }
+
+  @Test
+  public void setPayloadTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    datafeedEvent.setPayload(eventPayload);
+
+    // Assert
+    assertSame(eventPayload, datafeedEvent.getPayload());
+  }
+
+  @Test
+  public void setTimestampTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+    Long timestamp = new Long(1L);
+
+    // Act
+    datafeedEvent.setTimestamp(timestamp);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), datafeedEvent.getTimestamp());
+  }
+
+  @Test
+  public void setTypeTest() throws Exception {
+    // Arrange
+    DatafeedEvent datafeedEvent = new DatafeedEvent();
+    String type = "aaaaa";
+
+    // Act
+    datafeedEvent.setType(type);
+
+    // Assert
+    assertEquals("aaaaa", datafeedEvent.getType());
+  }
+}

--- a/src/test/java/model/DatafeedEventsListTest.java
+++ b/src/test/java/model/DatafeedEventsListTest.java
@@ -1,0 +1,16 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.DatafeedEventsList;
+import org.junit.Test;
+
+public class DatafeedEventsListTest {
+  @Test
+  public void DatafeedEventsListTest() throws Exception {
+    // Arrange and Act
+    DatafeedEventsList datafeedEventsList = new DatafeedEventsList();
+
+    // Assert
+    assertEquals(0, datafeedEventsList.size());
+  }
+}

--- a/src/test/java/model/DropdownMenuOptionTest.java
+++ b/src/test/java/model/DropdownMenuOptionTest.java
@@ -1,0 +1,101 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import model.DropdownMenuOption;
+import org.junit.Test;
+
+public class DropdownMenuOptionTest {
+  @Test
+  public void DropdownMenuOptionTest() throws Exception {
+    // Arrange
+    String value = "aaaaa";
+    String display = "aaaaa";
+    boolean selected = true;
+
+    // Act
+    DropdownMenuOption dropdownMenuOption = new DropdownMenuOption(value, display, selected);
+
+    // Assert
+    boolean isSelectedResult = dropdownMenuOption.isSelected();
+    String display1 = dropdownMenuOption.getDisplay();
+    assertTrue(isSelectedResult);
+    assertEquals("aaaaa", dropdownMenuOption.getValue());
+    assertEquals("aaaaa", display1);
+  }
+
+  @Test
+  public void getDisplayTest() throws Exception {
+    // Arrange
+    DropdownMenuOption dropdownMenuOption = new DropdownMenuOption("aaaaa", "aaaaa", true);
+
+    // Act
+    String actual = dropdownMenuOption.getDisplay();
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void getValueTest() throws Exception {
+    // Arrange
+    DropdownMenuOption dropdownMenuOption = new DropdownMenuOption("aaaaa", "aaaaa", true);
+
+    // Act
+    String actual = dropdownMenuOption.getValue();
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void isSelectedTest() throws Exception {
+    // Arrange
+    DropdownMenuOption dropdownMenuOption = new DropdownMenuOption("aaaaa", "aaaaa", true);
+
+    // Act
+    boolean actual = dropdownMenuOption.isSelected();
+
+    // Assert
+    assertTrue(actual);
+  }
+
+  @Test
+  public void setDisplayTest() throws Exception {
+    // Arrange
+    DropdownMenuOption dropdownMenuOption = new DropdownMenuOption("aaaaa", "aaaaa", true);
+    String display = "aaaaa";
+
+    // Act
+    dropdownMenuOption.setDisplay(display);
+
+    // Assert
+    assertEquals("aaaaa", dropdownMenuOption.getDisplay());
+  }
+
+  @Test
+  public void setSelectedTest() throws Exception {
+    // Arrange
+    DropdownMenuOption dropdownMenuOption = new DropdownMenuOption("aaaaa", "aaaaa", true);
+    boolean selected = true;
+
+    // Act
+    dropdownMenuOption.setSelected(selected);
+
+    // Assert
+    assertTrue(dropdownMenuOption.isSelected());
+  }
+
+  @Test
+  public void setValueTest() throws Exception {
+    // Arrange
+    DropdownMenuOption dropdownMenuOption = new DropdownMenuOption("aaaaa", "aaaaa", true);
+    String value = "aaaaa";
+
+    // Act
+    dropdownMenuOption.setValue(value);
+
+    // Assert
+    assertEquals("aaaaa", dropdownMenuOption.getValue());
+  }
+}

--- a/src/test/java/model/EventPayloadTest.java
+++ b/src/test/java/model/EventPayloadTest.java
@@ -1,0 +1,407 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.EventPayload;
+import model.events.ConnectionAccepted;
+import model.events.ConnectionRequested;
+import model.events.IMCreated;
+import model.events.MessageSent;
+import model.events.MessageSuppressed;
+import model.events.RoomCreated;
+import model.events.RoomDeactivated;
+import model.events.RoomMemberDemotedFromOwner;
+import model.events.RoomMemberPromotedToOwner;
+import model.events.RoomReactivated;
+import model.events.RoomUpdated;
+import model.events.SharedPost;
+import model.events.SymphonyElementsAction;
+import model.events.UserJoinedRoom;
+import model.events.UserLeftRoom;
+import org.junit.Test;
+
+public class EventPayloadTest {
+  @Test
+  public void EventPayloadTest() throws Exception {
+    // Arrange and Act
+    EventPayload eventPayload = new EventPayload();
+
+    // Assert
+    assertEquals(null, eventPayload.getConnectionRequested());
+  }
+
+  @Test
+  public void getConnectionAcceptedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    ConnectionAccepted actual = eventPayload.getConnectionAccepted();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getConnectionRequestedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    ConnectionRequested actual = eventPayload.getConnectionRequested();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getInstantMessageCreatedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    IMCreated actual = eventPayload.getInstantMessageCreated();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMessageSentTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    MessageSent actual = eventPayload.getMessageSent();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMessageSuppressedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    MessageSuppressed actual = eventPayload.getMessageSuppressed();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomCreatedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    RoomCreated actual = eventPayload.getRoomCreated();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomDeactivatedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    RoomDeactivated actual = eventPayload.getRoomDeactivated();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomMemberDemotedFromOwnerTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    RoomMemberDemotedFromOwner actual = eventPayload.getRoomMemberDemotedFromOwner();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomMemberPromotedToOwnerTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    RoomMemberPromotedToOwner actual = eventPayload.getRoomMemberPromotedToOwner();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomReactivatedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    RoomReactivated actual = eventPayload.getRoomReactivated();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomUpdatedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    RoomUpdated actual = eventPayload.getRoomUpdated();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSharedPostTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    SharedPost actual = eventPayload.getSharedPost();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSymphonyElementsActionTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    SymphonyElementsAction actual = eventPayload.getSymphonyElementsAction();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserJoinedRoomTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    UserJoinedRoom actual = eventPayload.getUserJoinedRoom();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserLeftRoomTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+
+    // Act
+    UserLeftRoom actual = eventPayload.getUserLeftRoom();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setConnectionAcceptedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    ConnectionAccepted connectionAccepted = new ConnectionAccepted();
+
+    // Act
+    eventPayload.setConnectionAccepted(connectionAccepted);
+
+    // Assert
+    assertSame(connectionAccepted, eventPayload.getConnectionAccepted());
+  }
+
+  @Test
+  public void setConnectionRequestedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    ConnectionRequested connectionRequested = new ConnectionRequested();
+
+    // Act
+    eventPayload.setConnectionRequested(connectionRequested);
+
+    // Assert
+    assertSame(connectionRequested, eventPayload.getConnectionRequested());
+  }
+
+  @Test
+  public void setInstantMessageCreatedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    IMCreated iMCreated = new IMCreated();
+
+    // Act
+    eventPayload.setInstantMessageCreated(iMCreated);
+
+    // Assert
+    assertSame(iMCreated, eventPayload.getInstantMessageCreated());
+  }
+
+  @Test
+  public void setMessageSentTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    MessageSent messageSent = new MessageSent();
+
+    // Act
+    eventPayload.setMessageSent(messageSent);
+
+    // Assert
+    assertSame(messageSent, eventPayload.getMessageSent());
+  }
+
+  @Test
+  public void setMessageSuppressedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    MessageSuppressed messageSuppressed = new MessageSuppressed();
+
+    // Act
+    eventPayload.setMessageSuppressed(messageSuppressed);
+
+    // Assert
+    assertSame(messageSuppressed, eventPayload.getMessageSuppressed());
+  }
+
+  @Test
+  public void setRoomCreatedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    RoomCreated roomCreated = new RoomCreated();
+
+    // Act
+    eventPayload.setRoomCreated(roomCreated);
+
+    // Assert
+    assertSame(roomCreated, eventPayload.getRoomCreated());
+  }
+
+  @Test
+  public void setRoomDeactivatedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    RoomDeactivated roomDeactivated = new RoomDeactivated();
+
+    // Act
+    eventPayload.setRoomDeactivated(roomDeactivated);
+
+    // Assert
+    assertSame(roomDeactivated, eventPayload.getRoomDeactivated());
+  }
+
+  @Test
+  public void setRoomMemberDemotedFromOwnerTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    RoomMemberDemotedFromOwner roomMemberDemotedFromOwner = new RoomMemberDemotedFromOwner();
+
+    // Act
+    eventPayload.setRoomMemberDemotedFromOwner(roomMemberDemotedFromOwner);
+
+    // Assert
+    assertSame(roomMemberDemotedFromOwner, eventPayload.getRoomMemberDemotedFromOwner());
+  }
+
+  @Test
+  public void setRoomMemberPromotedToOwnerTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    RoomMemberPromotedToOwner roomMemberPromotedToOwner = new RoomMemberPromotedToOwner();
+
+    // Act
+    eventPayload.setRoomMemberPromotedToOwner(roomMemberPromotedToOwner);
+
+    // Assert
+    assertSame(roomMemberPromotedToOwner, eventPayload.getRoomMemberPromotedToOwner());
+  }
+
+  @Test
+  public void setRoomReactivatedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    RoomReactivated roomReactivated = new RoomReactivated();
+
+    // Act
+    eventPayload.setRoomReactivated(roomReactivated);
+
+    // Assert
+    assertSame(roomReactivated, eventPayload.getRoomReactivated());
+  }
+
+  @Test
+  public void setRoomUpdatedTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    RoomUpdated roomUpdated = new RoomUpdated();
+
+    // Act
+    eventPayload.setRoomUpdated(roomUpdated);
+
+    // Assert
+    assertSame(roomUpdated, eventPayload.getRoomUpdated());
+  }
+
+  @Test
+  public void setSharedPostTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    SharedPost sharedPost = new SharedPost();
+
+    // Act
+    eventPayload.setSharedPost(sharedPost);
+
+    // Assert
+    assertSame(sharedPost, eventPayload.getSharedPost());
+  }
+
+  @Test
+  public void setSymphonyElementsActionTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    SymphonyElementsAction symphonyElementsAction = new SymphonyElementsAction();
+
+    // Act
+    eventPayload.setSymphonyElementsAction(symphonyElementsAction);
+
+    // Assert
+    assertSame(symphonyElementsAction, eventPayload.getSymphonyElementsAction());
+  }
+
+  @Test
+  public void setUserJoinedRoomTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    UserJoinedRoom userJoinedRoom = new UserJoinedRoom();
+
+    // Act
+    eventPayload.setUserJoinedRoom(userJoinedRoom);
+
+    // Assert
+    assertSame(userJoinedRoom, eventPayload.getUserJoinedRoom());
+  }
+
+  @Test
+  public void setUserLeftRoomTest() throws Exception {
+    // Arrange
+    EventPayload eventPayload = new EventPayload();
+    UserLeftRoom userLeftRoom = new UserLeftRoom();
+
+    // Act
+    eventPayload.setUserLeftRoom(userLeftRoom);
+
+    // Assert
+    assertSame(userLeftRoom, eventPayload.getUserLeftRoom());
+  }
+}

--- a/src/test/java/model/FeatureEntitlementListTest.java
+++ b/src/test/java/model/FeatureEntitlementListTest.java
@@ -1,0 +1,16 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.FeatureEntitlementList;
+import org.junit.Test;
+
+public class FeatureEntitlementListTest {
+  @Test
+  public void FeatureEntitlementListTest() throws Exception {
+    // Arrange and Act
+    FeatureEntitlementList featureEntitlementList = new FeatureEntitlementList();
+
+    // Assert
+    assertEquals(0, featureEntitlementList.size());
+  }
+}

--- a/src/test/java/model/FeatureEntitlementTest.java
+++ b/src/test/java/model/FeatureEntitlementTest.java
@@ -1,0 +1,66 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.FeatureEntitlement;
+import org.junit.Test;
+
+public class FeatureEntitlementTest {
+  @Test
+  public void FeatureEntitlementTest() throws Exception {
+    // Arrange and Act
+    FeatureEntitlement featureEntitlement = new FeatureEntitlement();
+
+    // Assert
+    assertEquals(null, featureEntitlement.getEntitlment());
+  }
+
+  @Test
+  public void getEnabledTest() throws Exception {
+    // Arrange
+    FeatureEntitlement featureEntitlement = new FeatureEntitlement();
+
+    // Act
+    Boolean actual = featureEntitlement.getEnabled();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getEntitlmentTest() throws Exception {
+    // Arrange
+    FeatureEntitlement featureEntitlement = new FeatureEntitlement();
+
+    // Act
+    String actual = featureEntitlement.getEntitlment();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setEnabledTest() throws Exception {
+    // Arrange
+    FeatureEntitlement featureEntitlement = new FeatureEntitlement();
+    Boolean enabled = new Boolean(true);
+
+    // Act
+    featureEntitlement.setEnabled(enabled);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), featureEntitlement.getEnabled());
+  }
+
+  @Test
+  public void setEntitlmentTest() throws Exception {
+    // Arrange
+    FeatureEntitlement featureEntitlement = new FeatureEntitlement();
+    String entitlment = "aaaaa";
+
+    // Act
+    featureEntitlement.setEntitlment(entitlment);
+
+    // Assert
+    assertEquals("aaaaa", featureEntitlement.getEntitlment());
+  }
+}

--- a/src/test/java/model/FileAttachmentTest.java
+++ b/src/test/java/model/FileAttachmentTest.java
@@ -1,0 +1,92 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.FileAttachment;
+import org.junit.Test;
+
+public class FileAttachmentTest {
+  @Test
+  public void FileAttachmentTest() throws Exception {
+    // Arrange and Act
+    FileAttachment fileAttachment = new FileAttachment();
+
+    // Assert
+    assertEquals(null, fileAttachment.getFileName());
+  }
+
+  @Test
+  public void getFileContentTest() throws Exception {
+    // Arrange
+    FileAttachment fileAttachment = new FileAttachment();
+
+    // Act
+    byte[] actual = fileAttachment.getFileContent();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getFileNameTest() throws Exception {
+    // Arrange
+    FileAttachment fileAttachment = new FileAttachment();
+
+    // Act
+    String actual = fileAttachment.getFileName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSizeTest() throws Exception {
+    // Arrange
+    FileAttachment fileAttachment = new FileAttachment();
+
+    // Act
+    Long actual = fileAttachment.getSize();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setFileContentTest() throws Exception {
+    // Arrange
+    FileAttachment fileAttachment = new FileAttachment();
+    byte[] byteArray = new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    // Act
+    fileAttachment.setFileContent(byteArray);
+
+    // Assert
+    assertSame(byteArray, fileAttachment.getFileContent());
+  }
+
+  @Test
+  public void setFileNameTest() throws Exception {
+    // Arrange
+    FileAttachment fileAttachment = new FileAttachment();
+    String fileName = "aaaaa";
+
+    // Act
+    fileAttachment.setFileName(fileName);
+
+    // Assert
+    assertEquals("aaaaa", fileAttachment.getFileName());
+  }
+
+  @Test
+  public void setSizeTest() throws Exception {
+    // Arrange
+    FileAttachment fileAttachment = new FileAttachment();
+    Long size = new Long(1L);
+
+    // Act
+    fileAttachment.setSize(size);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), fileAttachment.getSize());
+  }
+}

--- a/src/test/java/model/FqdnHostTest.java
+++ b/src/test/java/model/FqdnHostTest.java
@@ -1,0 +1,41 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.FqdnHost;
+import org.junit.Test;
+
+public class FqdnHostTest {
+  @Test
+  public void FqdnHostTest() throws Exception {
+    // Arrange and Act
+    FqdnHost fqdnHost = new FqdnHost();
+
+    // Assert
+    assertEquals(null, fqdnHost.getServerFqdn());
+  }
+
+  @Test
+  public void getServerFqdnTest() throws Exception {
+    // Arrange
+    FqdnHost fqdnHost = new FqdnHost();
+
+    // Act
+    String actual = fqdnHost.getServerFqdn();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setServerFqdnTest() throws Exception {
+    // Arrange
+    FqdnHost fqdnHost = new FqdnHost();
+    String serverFqdn = "aaaaa";
+
+    // Act
+    fqdnHost.setServerFqdn(serverFqdn);
+
+    // Assert
+    assertEquals("aaaaa", fqdnHost.getServerFqdn());
+  }
+}

--- a/src/test/java/model/HealthcheckResponseTest.java
+++ b/src/test/java/model/HealthcheckResponseTest.java
@@ -1,0 +1,366 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.HealthcheckResponse;
+import org.junit.Test;
+
+public class HealthcheckResponseTest {
+  @Test
+  public void HealthcheckResponseTest() throws Exception {
+    // Arrange and Act
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Assert
+    assertEquals(null, healthcheckResponse.getAgentVersion());
+  }
+
+  @Test
+  public void getAgentServiceUserErrorTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    String actual = healthcheckResponse.getAgentServiceUserError();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAgentServiceUserTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    Boolean actual = healthcheckResponse.getAgentServiceUser();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAgentVersionTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    String actual = healthcheckResponse.getAgentVersion();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCeServiceUserErrorTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    String actual = healthcheckResponse.getCeServiceUserError();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCeServiceUserTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    Boolean actual = healthcheckResponse.getCeServiceUser();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getEncryptDecryptErrorTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    String actual = healthcheckResponse.getEncryptDecryptError();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getEncryptDecryptSuccessTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    Boolean actual = healthcheckResponse.getEncryptDecryptSuccess();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getFirehoseConnectivityErrorTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    String actual = healthcheckResponse.getFirehoseConnectivityError();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getFirehoseConnectivityTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    Boolean actual = healthcheckResponse.getFirehoseConnectivity();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getKeyManagerConnectivityErrorTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    String actual = healthcheckResponse.getKeyManagerConnectivityError();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getKeyManagerConnectivityTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    Boolean actual = healthcheckResponse.getKeyManagerConnectivity();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPodConnectivityErrorTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    String actual = healthcheckResponse.getPodConnectivityError();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPodConnectivityTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    Boolean actual = healthcheckResponse.getPodConnectivity();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPodVersionTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+
+    // Act
+    String actual = healthcheckResponse.getPodVersion();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAgentServiceUserErrorTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    String agentServiceUserError = "aaaaa";
+
+    // Act
+    healthcheckResponse.setAgentServiceUserError(agentServiceUserError);
+
+    // Assert
+    assertEquals("aaaaa", healthcheckResponse.getAgentServiceUserError());
+  }
+
+  @Test
+  public void setAgentServiceUserTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    Boolean agentServiceUser = new Boolean(true);
+
+    // Act
+    healthcheckResponse.setAgentServiceUser(agentServiceUser);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), healthcheckResponse.getAgentServiceUser());
+  }
+
+  @Test
+  public void setAgentVersionTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    String agentVersion = "aaaaa";
+
+    // Act
+    healthcheckResponse.setAgentVersion(agentVersion);
+
+    // Assert
+    assertEquals("aaaaa", healthcheckResponse.getAgentVersion());
+  }
+
+  @Test
+  public void setCeServiceUserErrorTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    String ceServiceUserError = "aaaaa";
+
+    // Act
+    healthcheckResponse.setCeServiceUserError(ceServiceUserError);
+
+    // Assert
+    assertEquals("aaaaa", healthcheckResponse.getCeServiceUserError());
+  }
+
+  @Test
+  public void setCeServiceUserTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    Boolean ceServiceUser = new Boolean(true);
+
+    // Act
+    healthcheckResponse.setCeServiceUser(ceServiceUser);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), healthcheckResponse.getCeServiceUser());
+  }
+
+  @Test
+  public void setEncryptDecryptErrorTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    String encryptDecryptError = "aaaaa";
+
+    // Act
+    healthcheckResponse.setEncryptDecryptError(encryptDecryptError);
+
+    // Assert
+    assertEquals("aaaaa", healthcheckResponse.getEncryptDecryptError());
+  }
+
+  @Test
+  public void setEncryptDecryptSuccessTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    Boolean encryptDecryptSuccess = new Boolean(true);
+
+    // Act
+    healthcheckResponse.setEncryptDecryptSuccess(encryptDecryptSuccess);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), healthcheckResponse.getEncryptDecryptSuccess());
+  }
+
+  @Test
+  public void setFirehoseConnectivityErrorTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    String firehoseConnectivityError = "aaaaa";
+
+    // Act
+    healthcheckResponse.setFirehoseConnectivityError(firehoseConnectivityError);
+
+    // Assert
+    assertEquals("aaaaa", healthcheckResponse.getFirehoseConnectivityError());
+  }
+
+  @Test
+  public void setFirehoseConnectivityTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    Boolean firehoseConnectivity = new Boolean(true);
+
+    // Act
+    healthcheckResponse.setFirehoseConnectivity(firehoseConnectivity);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), healthcheckResponse.getFirehoseConnectivity());
+  }
+
+  @Test
+  public void setKeyManagerConnectivityErrorTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    String keyManagerConnectivityError = "aaaaa";
+
+    // Act
+    healthcheckResponse.setKeyManagerConnectivityError(keyManagerConnectivityError);
+
+    // Assert
+    assertEquals("aaaaa", healthcheckResponse.getKeyManagerConnectivityError());
+  }
+
+  @Test
+  public void setKeyManagerConnectivityTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    Boolean keyManagerConnectivity = new Boolean(true);
+
+    // Act
+    healthcheckResponse.setKeyManagerConnectivity(keyManagerConnectivity);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), healthcheckResponse.getKeyManagerConnectivity());
+  }
+
+  @Test
+  public void setPodConnectivityErrorTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    String podConnectivityError = "aaaaa";
+
+    // Act
+    healthcheckResponse.setPodConnectivityError(podConnectivityError);
+
+    // Assert
+    assertEquals("aaaaa", healthcheckResponse.getPodConnectivityError());
+  }
+
+  @Test
+  public void setPodConnectivityTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    Boolean podConnectivity = new Boolean(true);
+
+    // Act
+    healthcheckResponse.setPodConnectivity(podConnectivity);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), healthcheckResponse.getPodConnectivity());
+  }
+
+  @Test
+  public void setPodVersionTest() throws Exception {
+    // Arrange
+    HealthcheckResponse healthcheckResponse = new HealthcheckResponse();
+    String podVersion = "aaaaa";
+
+    // Act
+    healthcheckResponse.setPodVersion(podVersion);
+
+    // Assert
+    assertEquals("aaaaa", healthcheckResponse.getPodVersion());
+  }
+}

--- a/src/test/java/model/ImageInfoTest.java
+++ b/src/test/java/model/ImageInfoTest.java
@@ -1,0 +1,66 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.ImageInfo;
+import org.junit.Test;
+
+public class ImageInfoTest {
+  @Test
+  public void ImageInfoTest() throws Exception {
+    // Arrange and Act
+    ImageInfo imageInfo = new ImageInfo();
+
+    // Assert
+    assertEquals(null, imageInfo.getId());
+  }
+
+  @Test
+  public void getDimensionTest() throws Exception {
+    // Arrange
+    ImageInfo imageInfo = new ImageInfo();
+
+    // Act
+    String actual = imageInfo.getDimension();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    ImageInfo imageInfo = new ImageInfo();
+
+    // Act
+    String actual = imageInfo.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setDimensionTest() throws Exception {
+    // Arrange
+    ImageInfo imageInfo = new ImageInfo();
+    String dimension = "aaaaa";
+
+    // Act
+    imageInfo.setDimension(dimension);
+
+    // Assert
+    assertEquals("aaaaa", imageInfo.getDimension());
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    ImageInfo imageInfo = new ImageInfo();
+    String id = "aaaaa";
+
+    // Act
+    imageInfo.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", imageInfo.getId());
+  }
+}

--- a/src/test/java/model/InboundConnectionRequestListTest.java
+++ b/src/test/java/model/InboundConnectionRequestListTest.java
@@ -1,0 +1,16 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.InboundConnectionRequestList;
+import org.junit.Test;
+
+public class InboundConnectionRequestListTest {
+  @Test
+  public void InboundConnectionRequestListTest() throws Exception {
+    // Arrange and Act
+    InboundConnectionRequestList inboundConnectionRequestList = new InboundConnectionRequestList();
+
+    // Assert
+    assertEquals(0, inboundConnectionRequestList.size());
+  }
+}

--- a/src/test/java/model/InboundConnectionRequestTest.java
+++ b/src/test/java/model/InboundConnectionRequestTest.java
@@ -1,0 +1,141 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.InboundConnectionRequest;
+import org.junit.Test;
+
+public class InboundConnectionRequestTest {
+  @Test
+  public void InboundConnectionRequestTest() throws Exception {
+    // Arrange and Act
+    InboundConnectionRequest inboundConnectionRequest = new InboundConnectionRequest();
+
+    // Assert
+    assertEquals(null, inboundConnectionRequest.getFirstRequestedAt());
+  }
+
+  @Test
+  public void getFirstRequestedAtTest() throws Exception {
+    // Arrange
+    InboundConnectionRequest inboundConnectionRequest = new InboundConnectionRequest();
+
+    // Act
+    Long actual = inboundConnectionRequest.getFirstRequestedAt();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRequestCounterTest() throws Exception {
+    // Arrange
+    InboundConnectionRequest inboundConnectionRequest = new InboundConnectionRequest();
+
+    // Act
+    Integer actual = inboundConnectionRequest.getRequestCounter();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStatusTest() throws Exception {
+    // Arrange
+    InboundConnectionRequest inboundConnectionRequest = new InboundConnectionRequest();
+
+    // Act
+    String actual = inboundConnectionRequest.getStatus();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUpdatedAtTest() throws Exception {
+    // Arrange
+    InboundConnectionRequest inboundConnectionRequest = new InboundConnectionRequest();
+
+    // Act
+    Long actual = inboundConnectionRequest.getUpdatedAt();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserIdTest() throws Exception {
+    // Arrange
+    InboundConnectionRequest inboundConnectionRequest = new InboundConnectionRequest();
+
+    // Act
+    Long actual = inboundConnectionRequest.getUserId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setFirstRequestedAtTest() throws Exception {
+    // Arrange
+    InboundConnectionRequest inboundConnectionRequest = new InboundConnectionRequest();
+    Long firstRequestedAt = new Long(1L);
+
+    // Act
+    inboundConnectionRequest.setFirstRequestedAt(firstRequestedAt);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), inboundConnectionRequest.getFirstRequestedAt());
+  }
+
+  @Test
+  public void setRequestCounterTest() throws Exception {
+    // Arrange
+    InboundConnectionRequest inboundConnectionRequest = new InboundConnectionRequest();
+    Integer requestCounter = new Integer(1);
+
+    // Act
+    inboundConnectionRequest.setRequestCounter(requestCounter);
+
+    // Assert
+    assertEquals(Integer.valueOf(1), inboundConnectionRequest.getRequestCounter());
+  }
+
+  @Test
+  public void setStatusTest() throws Exception {
+    // Arrange
+    InboundConnectionRequest inboundConnectionRequest = new InboundConnectionRequest();
+    String status = "aaaaa";
+
+    // Act
+    inboundConnectionRequest.setStatus(status);
+
+    // Assert
+    assertEquals("aaaaa", inboundConnectionRequest.getStatus());
+  }
+
+  @Test
+  public void setUpdatedAtTest() throws Exception {
+    // Arrange
+    InboundConnectionRequest inboundConnectionRequest = new InboundConnectionRequest();
+    Long updatedAt = new Long(1L);
+
+    // Act
+    inboundConnectionRequest.setUpdatedAt(updatedAt);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), inboundConnectionRequest.getUpdatedAt());
+  }
+
+  @Test
+  public void setUserIdTest() throws Exception {
+    // Arrange
+    InboundConnectionRequest inboundConnectionRequest = new InboundConnectionRequest();
+    Long userId = new Long(1L);
+
+    // Act
+    inboundConnectionRequest.setUserId(userId);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), inboundConnectionRequest.getUserId());
+  }
+}

--- a/src/test/java/model/InboundImportMessageListTest.java
+++ b/src/test/java/model/InboundImportMessageListTest.java
@@ -1,0 +1,16 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.InboundImportMessageList;
+import org.junit.Test;
+
+public class InboundImportMessageListTest {
+  @Test
+  public void InboundImportMessageListTest() throws Exception {
+    // Arrange and Act
+    InboundImportMessageList inboundImportMessageList = new InboundImportMessageList();
+
+    // Assert
+    assertEquals(0, inboundImportMessageList.size());
+  }
+}

--- a/src/test/java/model/InboundImportMessageTest.java
+++ b/src/test/java/model/InboundImportMessageTest.java
@@ -1,0 +1,116 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.InboundImportMessage;
+import org.junit.Test;
+
+public class InboundImportMessageTest {
+  @Test
+  public void InboundImportMessageTest() throws Exception {
+    // Arrange and Act
+    InboundImportMessage inboundImportMessage = new InboundImportMessage();
+
+    // Assert
+    assertEquals(null, inboundImportMessage.getOriginalMessageId());
+  }
+
+  @Test
+  public void getDiagnosticTest() throws Exception {
+    // Arrange
+    InboundImportMessage inboundImportMessage = new InboundImportMessage();
+
+    // Act
+    String actual = inboundImportMessage.getDiagnostic();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMessageIdTest() throws Exception {
+    // Arrange
+    InboundImportMessage inboundImportMessage = new InboundImportMessage();
+
+    // Act
+    String actual = inboundImportMessage.getMessageId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOriginalMessageIdTest() throws Exception {
+    // Arrange
+    InboundImportMessage inboundImportMessage = new InboundImportMessage();
+
+    // Act
+    String actual = inboundImportMessage.getOriginalMessageId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOriginatingSystemIdTest() throws Exception {
+    // Arrange
+    InboundImportMessage inboundImportMessage = new InboundImportMessage();
+
+    // Act
+    String actual = inboundImportMessage.getOriginatingSystemId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setDiagnosticTest() throws Exception {
+    // Arrange
+    InboundImportMessage inboundImportMessage = new InboundImportMessage();
+    String diagnostic = "aaaaa";
+
+    // Act
+    inboundImportMessage.setDiagnostic(diagnostic);
+
+    // Assert
+    assertEquals("aaaaa", inboundImportMessage.getDiagnostic());
+  }
+
+  @Test
+  public void setMessageIdTest() throws Exception {
+    // Arrange
+    InboundImportMessage inboundImportMessage = new InboundImportMessage();
+    String messageId = "aaaaa";
+
+    // Act
+    inboundImportMessage.setMessageId(messageId);
+
+    // Assert
+    assertEquals("aaaaa", inboundImportMessage.getMessageId());
+  }
+
+  @Test
+  public void setOriginalMessageIdTest() throws Exception {
+    // Arrange
+    InboundImportMessage inboundImportMessage = new InboundImportMessage();
+    String originalMessageId = "aaaaa";
+
+    // Act
+    inboundImportMessage.setOriginalMessageId(originalMessageId);
+
+    // Assert
+    assertEquals("aaaaa", inboundImportMessage.getOriginalMessageId());
+  }
+
+  @Test
+  public void setOriginatingSystemIdTest() throws Exception {
+    // Arrange
+    InboundImportMessage inboundImportMessage = new InboundImportMessage();
+    String originatingSystemId = "aaaaa";
+
+    // Act
+    inboundImportMessage.setOriginatingSystemId(originatingSystemId);
+
+    // Assert
+    assertEquals("aaaaa", inboundImportMessage.getOriginatingSystemId());
+  }
+}

--- a/src/test/java/model/InboundMessageListTest.java
+++ b/src/test/java/model/InboundMessageListTest.java
@@ -1,0 +1,16 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.InboundMessageList;
+import org.junit.Test;
+
+public class InboundMessageListTest {
+  @Test
+  public void InboundMessageListTest() throws Exception {
+    // Arrange and Act
+    InboundMessageList inboundMessageList = new InboundMessageList();
+
+    // Assert
+    assertEquals(0, inboundMessageList.size());
+  }
+}

--- a/src/test/java/model/InboundMessageTest.java
+++ b/src/test/java/model/InboundMessageTest.java
@@ -1,0 +1,330 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.InboundMessage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class InboundMessageTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void InboundMessageTest() throws Exception {
+    // Arrange and Act
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Assert
+    assertEquals(null, inboundMessage.getOriginalFormat());
+  }
+
+  @Test
+  public void getAttachmentsTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    List<Attachment> actual = inboundMessage.getAttachments();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCashtagsTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    inboundMessage.getCashtags();
+  }
+
+  @Test
+  public void getDataTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    String actual = inboundMessage.getData();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDiagnosticTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    String actual = inboundMessage.getDiagnostic();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getExternalRecipientsTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    Boolean actual = inboundMessage.getExternalRecipients();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getHashtagsTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    inboundMessage.getHashtags();
+  }
+
+  @Test
+  public void getMentionsTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    inboundMessage.getMentions();
+  }
+
+  @Test
+  public void getMessageIdTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    String actual = inboundMessage.getMessageId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMessageTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    String actual = inboundMessage.getMessage();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOriginalFormatTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    String actual = inboundMessage.getOriginalFormat();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    Stream actual = inboundMessage.getStream();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTimestampTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    Long actual = inboundMessage.getTimestamp();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserAgentTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    String actual = inboundMessage.getUserAgent();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    User actual = inboundMessage.getUser();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAttachmentsTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+    ArrayList<Attachment> arrayList = new ArrayList<Attachment>();
+    arrayList.add(new Attachment());
+
+    // Act
+    inboundMessage.setAttachments(arrayList);
+
+    // Assert
+    assertSame(arrayList, inboundMessage.getAttachments());
+  }
+
+  @Test
+  public void setDataTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+    String data = "aaaaa";
+
+    // Act
+    inboundMessage.setData(data);
+
+    // Assert
+    assertEquals("aaaaa", inboundMessage.getData());
+  }
+
+  @Test
+  public void setDiagnosticTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+    String diagnostic = "aaaaa";
+
+    // Act
+    inboundMessage.setDiagnostic(diagnostic);
+
+    // Assert
+    assertEquals("aaaaa", inboundMessage.getDiagnostic());
+  }
+
+  @Test
+  public void setExternalRecipientsTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+    Boolean externalRecipients = new Boolean(true);
+
+    // Act
+    inboundMessage.setExternalRecipients(externalRecipients);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), inboundMessage.getExternalRecipients());
+  }
+
+  @Test
+  public void setMessageIdTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+    String messageId = "aaaaa";
+
+    // Act
+    inboundMessage.setMessageId(messageId);
+
+    // Assert
+    assertEquals("aaaaa", inboundMessage.getMessageId());
+  }
+
+  @Test
+  public void setMessageTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+    String message = "aaaaa";
+
+    // Act
+    inboundMessage.setMessage(message);
+
+    // Assert
+    assertEquals("aaaaa", inboundMessage.getMessage());
+  }
+
+  @Test
+  public void setOriginalFormatTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+    String originalFormat = "aaaaa";
+
+    // Act
+    inboundMessage.setOriginalFormat(originalFormat);
+
+    // Assert
+    assertEquals("aaaaa", inboundMessage.getOriginalFormat());
+  }
+
+  @Test
+  public void setStreamTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+    Stream stream = new Stream();
+
+    // Act
+    inboundMessage.setStream(stream);
+
+    // Assert
+    assertSame(stream, inboundMessage.getStream());
+  }
+
+  @Test
+  public void setTimestampTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+    Long timestamp = new Long(1L);
+
+    // Act
+    inboundMessage.setTimestamp(timestamp);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), inboundMessage.getTimestamp());
+  }
+
+  @Test
+  public void setUserAgentTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+    String userAgent = "aaaaa";
+
+    // Act
+    inboundMessage.setUserAgent(userAgent);
+
+    // Assert
+    assertEquals("aaaaa", inboundMessage.getUserAgent());
+  }
+
+  @Test
+  public void setUserTest() throws Exception {
+    // Arrange
+    InboundMessage inboundMessage = new InboundMessage();
+    User user = new User();
+
+    // Act
+    inboundMessage.setUser(user);
+
+    // Assert
+    assertSame(user, inboundMessage.getUser());
+  }
+}

--- a/src/test/java/model/InboundShareTest.java
+++ b/src/test/java/model/InboundShareTest.java
@@ -1,0 +1,166 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.InboundShare;
+import org.junit.Test;
+
+public class InboundShareTest {
+  @Test
+  public void InboundShareTest() throws Exception {
+    // Arrange and Act
+    InboundShare inboundShare = new InboundShare();
+
+    // Assert
+    assertEquals(null, inboundShare.getV2messageType());
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    InboundShare inboundShare = new InboundShare();
+
+    // Act
+    String actual = inboundShare.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMessageTest() throws Exception {
+    // Arrange
+    InboundShare inboundShare = new InboundShare();
+
+    // Act
+    String actual = inboundShare.getMessage();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamIdTest() throws Exception {
+    // Arrange
+    InboundShare inboundShare = new InboundShare();
+
+    // Act
+    String actual = inboundShare.getStreamId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTimestampTest() throws Exception {
+    // Arrange
+    InboundShare inboundShare = new InboundShare();
+
+    // Act
+    long actual = inboundShare.getTimestamp();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getUserIdTest() throws Exception {
+    // Arrange
+    InboundShare inboundShare = new InboundShare();
+
+    // Act
+    long actual = inboundShare.getUserId();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getV2messageTypeTest() throws Exception {
+    // Arrange
+    InboundShare inboundShare = new InboundShare();
+
+    // Act
+    String actual = inboundShare.getV2messageType();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    InboundShare inboundShare = new InboundShare();
+    String id = "aaaaa";
+
+    // Act
+    inboundShare.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", inboundShare.getId());
+  }
+
+  @Test
+  public void setMessageTest() throws Exception {
+    // Arrange
+    InboundShare inboundShare = new InboundShare();
+    String message = "aaaaa";
+
+    // Act
+    inboundShare.setMessage(message);
+
+    // Assert
+    assertEquals("aaaaa", inboundShare.getMessage());
+  }
+
+  @Test
+  public void setStreamIdTest() throws Exception {
+    // Arrange
+    InboundShare inboundShare = new InboundShare();
+    String streamId = "aaaaa";
+
+    // Act
+    inboundShare.setStreamId(streamId);
+
+    // Assert
+    assertEquals("aaaaa", inboundShare.getStreamId());
+  }
+
+  @Test
+  public void setTimestampTest() throws Exception {
+    // Arrange
+    InboundShare inboundShare = new InboundShare();
+    long timestamp = 1L;
+
+    // Act
+    inboundShare.setTimestamp(timestamp);
+
+    // Assert
+    assertEquals(1L, inboundShare.getTimestamp());
+  }
+
+  @Test
+  public void setUserIdTest() throws Exception {
+    // Arrange
+    InboundShare inboundShare = new InboundShare();
+    long userId = 1L;
+
+    // Act
+    inboundShare.setUserId(userId);
+
+    // Assert
+    assertEquals(1L, inboundShare.getUserId());
+  }
+
+  @Test
+  public void setV2messageTypeTest() throws Exception {
+    // Arrange
+    InboundShare inboundShare = new InboundShare();
+    String v2messageType = "aaaaa";
+
+    // Act
+    inboundShare.setV2messageType(v2messageType);
+
+    // Assert
+    assertEquals("aaaaa", inboundShare.getV2messageType());
+  }
+}

--- a/src/test/java/model/InformationBarrierGroupStatusTest.java
+++ b/src/test/java/model/InformationBarrierGroupStatusTest.java
@@ -1,0 +1,70 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.InformationBarrierGroupStatus;
+import org.junit.Test;
+
+public class InformationBarrierGroupStatusTest {
+  @Test
+  public void InformationBarrierGroupStatusTest() throws Exception {
+    // Arrange and Act
+    InformationBarrierGroupStatus informationBarrierGroupStatus = new InformationBarrierGroupStatus();
+
+    // Assert
+    assertEquals(null, informationBarrierGroupStatus.getOverallResult());
+  }
+
+  @Test
+  public void getOverallResultTest() throws Exception {
+    // Arrange
+    InformationBarrierGroupStatus informationBarrierGroupStatus = new InformationBarrierGroupStatus();
+
+    // Act
+    String actual = informationBarrierGroupStatus.getOverallResult();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getResultsTest() throws Exception {
+    // Arrange
+    InformationBarrierGroupStatus informationBarrierGroupStatus = new InformationBarrierGroupStatus();
+
+    // Act
+    List<String> actual = informationBarrierGroupStatus.getResults();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setOverallResultTest() throws Exception {
+    // Arrange
+    InformationBarrierGroupStatus informationBarrierGroupStatus = new InformationBarrierGroupStatus();
+    String overallResult = "aaaaa";
+
+    // Act
+    informationBarrierGroupStatus.setOverallResult(overallResult);
+
+    // Assert
+    assertEquals("aaaaa", informationBarrierGroupStatus.getOverallResult());
+  }
+
+  @Test
+  public void setResultsTest() throws Exception {
+    // Arrange
+    InformationBarrierGroupStatus informationBarrierGroupStatus = new InformationBarrierGroupStatus();
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    informationBarrierGroupStatus.setResults(arrayList);
+
+    // Assert
+    assertSame(arrayList, informationBarrierGroupStatus.getResults());
+  }
+}

--- a/src/test/java/model/InformationBarrierGroupTest.java
+++ b/src/test/java/model/InformationBarrierGroupTest.java
@@ -1,0 +1,197 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import java.util.ArrayList;
+import java.util.List;
+import model.InformationBarrierGroup;
+import org.junit.Test;
+
+public class InformationBarrierGroupTest {
+  @Test
+  public void InformationBarrierGroupTest() throws Exception {
+    // Arrange and Act
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+
+    // Assert
+    assertEquals(null, informationBarrierGroup.getName());
+  }
+
+  @Test
+  public void getCreatedDateTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+
+    // Act
+    long actual = informationBarrierGroup.getCreatedDate();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+
+    // Act
+    String actual = informationBarrierGroup.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMemberCountTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+
+    // Act
+    int actual = informationBarrierGroup.getMemberCount();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getModifiedDateTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+
+    // Act
+    long actual = informationBarrierGroup.getModifiedDate();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getNameTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+
+    // Act
+    String actual = informationBarrierGroup.getName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPoliciesTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+
+    // Act
+    List<String> actual = informationBarrierGroup.getPolicies();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void isActiveTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+
+    // Act
+    boolean actual = informationBarrierGroup.isActive();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void setActiveTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+    boolean active = true;
+
+    // Act
+    informationBarrierGroup.setActive(active);
+
+    // Assert
+    assertTrue(informationBarrierGroup.isActive());
+  }
+
+  @Test
+  public void setCreatedDateTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+    long createdDate = 1L;
+
+    // Act
+    informationBarrierGroup.setCreatedDate(createdDate);
+
+    // Assert
+    assertEquals(1L, informationBarrierGroup.getCreatedDate());
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+    String id = "aaaaa";
+
+    // Act
+    informationBarrierGroup.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", informationBarrierGroup.getId());
+  }
+
+  @Test
+  public void setMemberCountTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+    int memberCount = 1;
+
+    // Act
+    informationBarrierGroup.setMemberCount(memberCount);
+
+    // Assert
+    assertEquals(1, informationBarrierGroup.getMemberCount());
+  }
+
+  @Test
+  public void setModifiedDateTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+    long modifiedDate = 1L;
+
+    // Act
+    informationBarrierGroup.setModifiedDate(modifiedDate);
+
+    // Assert
+    assertEquals(1L, informationBarrierGroup.getModifiedDate());
+  }
+
+  @Test
+  public void setNameTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+    String name = "aaaaa";
+
+    // Act
+    informationBarrierGroup.setName(name);
+
+    // Assert
+    assertEquals("aaaaa", informationBarrierGroup.getName());
+  }
+
+  @Test
+  public void setPoliciesTest() throws Exception {
+    // Arrange
+    InformationBarrierGroup informationBarrierGroup = new InformationBarrierGroup();
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    informationBarrierGroup.setPolicies(arrayList);
+
+    // Assert
+    assertSame(arrayList, informationBarrierGroup.getPolicies());
+  }
+}

--- a/src/test/java/model/InitiatorTest.java
+++ b/src/test/java/model/InitiatorTest.java
@@ -1,0 +1,43 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.Initiator;
+import model.User;
+import org.junit.Test;
+
+public class InitiatorTest {
+  @Test
+  public void InitiatorTest() throws Exception {
+    // Arrange and Act
+    Initiator initiator = new Initiator();
+
+    // Assert
+    assertEquals(null, initiator.getUser());
+  }
+
+  @Test
+  public void getUserTest() throws Exception {
+    // Arrange
+    Initiator initiator = new Initiator();
+
+    // Act
+    User actual = initiator.getUser();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setUserTest() throws Exception {
+    // Arrange
+    Initiator initiator = new Initiator();
+    User user = new User();
+
+    // Act
+    initiator.setUser(user);
+
+    // Assert
+    assertSame(user, initiator.getUser());
+  }
+}

--- a/src/test/java/model/KeywordTest.java
+++ b/src/test/java/model/KeywordTest.java
@@ -1,0 +1,66 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.Keyword;
+import org.junit.Test;
+
+public class KeywordTest {
+  @Test
+  public void KeywordTest() throws Exception {
+    // Arrange and Act
+    Keyword keyword = new Keyword();
+
+    // Assert
+    assertEquals(null, keyword.getKey());
+  }
+
+  @Test
+  public void getKeyTest() throws Exception {
+    // Arrange
+    Keyword keyword = new Keyword();
+
+    // Act
+    String actual = keyword.getKey();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getValueTest() throws Exception {
+    // Arrange
+    Keyword keyword = new Keyword();
+
+    // Act
+    String actual = keyword.getValue();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setKeyTest() throws Exception {
+    // Arrange
+    Keyword keyword = new Keyword();
+    String key = "aaaaa";
+
+    // Act
+    keyword.setKey(key);
+
+    // Assert
+    assertEquals("aaaaa", keyword.getKey());
+  }
+
+  @Test
+  public void setValueTest() throws Exception {
+    // Arrange
+    Keyword keyword = new Keyword();
+    String value = "aaaaa";
+
+    // Act
+    keyword.setValue(value);
+
+    // Assert
+    assertEquals("aaaaa", keyword.getValue());
+  }
+}

--- a/src/test/java/model/MemberListTest.java
+++ b/src/test/java/model/MemberListTest.java
@@ -1,0 +1,16 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.MemberList;
+import org.junit.Test;
+
+public class MemberListTest {
+  @Test
+  public void MemberListTest() throws Exception {
+    // Arrange and Act
+    MemberList memberList = new MemberList();
+
+    // Assert
+    assertEquals(0, memberList.size());
+  }
+}

--- a/src/test/java/model/MessageStatusTest.java
+++ b/src/test/java/model/MessageStatusTest.java
@@ -1,0 +1,98 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.MessageStatus;
+import model.MessageStatusUser;
+import org.junit.Test;
+
+public class MessageStatusTest {
+  @Test
+  public void MessageStatusTest() throws Exception {
+    // Arrange and Act
+    MessageStatus messageStatus = new MessageStatus();
+
+    // Assert
+    assertEquals(null, messageStatus.getDelivered());
+  }
+
+  @Test
+  public void getDeliveredTest() throws Exception {
+    // Arrange
+    MessageStatus messageStatus = new MessageStatus();
+
+    // Act
+    List<MessageStatusUser> actual = messageStatus.getDelivered();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getReadTest() throws Exception {
+    // Arrange
+    MessageStatus messageStatus = new MessageStatus();
+
+    // Act
+    List<MessageStatusUser> actual = messageStatus.getRead();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSentTest() throws Exception {
+    // Arrange
+    MessageStatus messageStatus = new MessageStatus();
+
+    // Act
+    List<MessageStatusUser> actual = messageStatus.getSent();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setDeliveredTest() throws Exception {
+    // Arrange
+    MessageStatus messageStatus = new MessageStatus();
+    ArrayList<MessageStatusUser> arrayList = new ArrayList<MessageStatusUser>();
+    arrayList.add(new MessageStatusUser());
+
+    // Act
+    messageStatus.setDelivered(arrayList);
+
+    // Assert
+    assertSame(arrayList, messageStatus.getDelivered());
+  }
+
+  @Test
+  public void setReadTest() throws Exception {
+    // Arrange
+    MessageStatus messageStatus = new MessageStatus();
+    ArrayList<MessageStatusUser> arrayList = new ArrayList<MessageStatusUser>();
+    arrayList.add(new MessageStatusUser());
+
+    // Act
+    messageStatus.setRead(arrayList);
+
+    // Assert
+    assertSame(arrayList, messageStatus.getRead());
+  }
+
+  @Test
+  public void setSentTest() throws Exception {
+    // Arrange
+    MessageStatus messageStatus = new MessageStatus();
+    ArrayList<MessageStatusUser> arrayList = new ArrayList<MessageStatusUser>();
+    arrayList.add(new MessageStatusUser());
+
+    // Act
+    messageStatus.setSent(arrayList);
+
+    // Assert
+    assertSame(arrayList, messageStatus.getSent());
+  }
+}

--- a/src/test/java/model/MessageStatusUserTest.java
+++ b/src/test/java/model/MessageStatusUserTest.java
@@ -1,0 +1,166 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.MessageStatusUser;
+import org.junit.Test;
+
+public class MessageStatusUserTest {
+  @Test
+  public void MessageStatusUserTest() throws Exception {
+    // Arrange and Act
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+
+    // Assert
+    assertEquals(null, messageStatusUser.getLastName());
+  }
+
+  @Test
+  public void getEmailTest() throws Exception {
+    // Arrange
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+
+    // Act
+    String actual = messageStatusUser.getEmail();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getFirstNameTest() throws Exception {
+    // Arrange
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+
+    // Act
+    String actual = messageStatusUser.getFirstName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLastNameTest() throws Exception {
+    // Arrange
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+
+    // Act
+    String actual = messageStatusUser.getLastName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTimestampTest() throws Exception {
+    // Arrange
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+
+    // Act
+    Long actual = messageStatusUser.getTimestamp();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserIdTest() throws Exception {
+    // Arrange
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+
+    // Act
+    String actual = messageStatusUser.getUserId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUsernameTest() throws Exception {
+    // Arrange
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+
+    // Act
+    String actual = messageStatusUser.getUsername();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setEmailTest() throws Exception {
+    // Arrange
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+    String email = "aaaaa";
+
+    // Act
+    messageStatusUser.setEmail(email);
+
+    // Assert
+    assertEquals("aaaaa", messageStatusUser.getEmail());
+  }
+
+  @Test
+  public void setFirstNameTest() throws Exception {
+    // Arrange
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+    String firstName = "aaaaa";
+
+    // Act
+    messageStatusUser.setFirstName(firstName);
+
+    // Assert
+    assertEquals("aaaaa", messageStatusUser.getFirstName());
+  }
+
+  @Test
+  public void setLastNameTest() throws Exception {
+    // Arrange
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+    String lastName = "aaaaa";
+
+    // Act
+    messageStatusUser.setLastName(lastName);
+
+    // Assert
+    assertEquals("aaaaa", messageStatusUser.getLastName());
+  }
+
+  @Test
+  public void setTimestampTest() throws Exception {
+    // Arrange
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+    Long timestamp = new Long(1L);
+
+    // Act
+    messageStatusUser.setTimestamp(timestamp);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), messageStatusUser.getTimestamp());
+  }
+
+  @Test
+  public void setUserIdTest() throws Exception {
+    // Arrange
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+    String userId = "aaaaa";
+
+    // Act
+    messageStatusUser.setUserId(userId);
+
+    // Assert
+    assertEquals("aaaaa", messageStatusUser.getUserId());
+  }
+
+  @Test
+  public void setUsernameTest() throws Exception {
+    // Arrange
+    MessageStatusUser messageStatusUser = new MessageStatusUser();
+    String username = "aaaaa";
+
+    // Act
+    messageStatusUser.setUsername(username);
+
+    // Assert
+    assertEquals("aaaaa", messageStatusUser.getUsername());
+  }
+}

--- a/src/test/java/model/NumericIdTest.java
+++ b/src/test/java/model/NumericIdTest.java
@@ -1,0 +1,53 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.NumericId;
+import org.junit.Test;
+
+public class NumericIdTest {
+  @Test
+  public void NumericIdTest() throws Exception {
+    // Arrange and Act
+    NumericId numericId = new NumericId();
+
+    // Assert
+    assertEquals(0L, numericId.getId());
+  }
+
+  @Test
+  public void NumericIdTest2() throws Exception {
+    // Arrange
+    Long userId = new Long(1L);
+
+    // Act
+    NumericId numericId = new NumericId(userId);
+
+    // Assert
+    assertEquals(1L, numericId.getId());
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    NumericId numericId = new NumericId();
+
+    // Act
+    long actual = numericId.getId();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    NumericId numericId = new NumericId();
+    long id = 1L;
+
+    // Act
+    numericId.setId(id);
+
+    // Assert
+    assertEquals(1L, numericId.getId());
+  }
+}

--- a/src/test/java/model/OutboundImportMessageListTest.java
+++ b/src/test/java/model/OutboundImportMessageListTest.java
@@ -1,0 +1,16 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.OutboundImportMessageList;
+import org.junit.Test;
+
+public class OutboundImportMessageListTest {
+  @Test
+  public void OutboundImportMessageListTest() throws Exception {
+    // Arrange and Act
+    OutboundImportMessageList outboundImportMessageList = new OutboundImportMessageList();
+
+    // Assert
+    assertEquals(0, outboundImportMessageList.size());
+  }
+}

--- a/src/test/java/model/OutboundImportMessageTest.java
+++ b/src/test/java/model/OutboundImportMessageTest.java
@@ -1,0 +1,191 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.OutboundImportMessage;
+import org.junit.Test;
+
+public class OutboundImportMessageTest {
+  @Test
+  public void OutboundImportMessageTest() throws Exception {
+    // Arrange and Act
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+
+    // Assert
+    assertEquals(0L, outboundImportMessage.getIntendedMessageFromUserId());
+  }
+
+  @Test
+  public void getDataTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+
+    // Act
+    String actual = outboundImportMessage.getData();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIntendedMessageFromUserIdTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+
+    // Act
+    long actual = outboundImportMessage.getIntendedMessageFromUserId();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getIntendedMessageTimestampTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+
+    // Act
+    long actual = outboundImportMessage.getIntendedMessageTimestamp();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getMessageTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+
+    // Act
+    String actual = outboundImportMessage.getMessage();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOriginalMessageIdTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+
+    // Act
+    String actual = outboundImportMessage.getOriginalMessageId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOriginatingSystemIdTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+
+    // Act
+    String actual = outboundImportMessage.getOriginatingSystemId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamIdTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+
+    // Act
+    String actual = outboundImportMessage.getStreamId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setDataTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+    String data = "aaaaa";
+
+    // Act
+    outboundImportMessage.setData(data);
+
+    // Assert
+    assertEquals("aaaaa", outboundImportMessage.getData());
+  }
+
+  @Test
+  public void setIntendedMessageFromUserIdTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+    long intendedMessageFromUserId = 1L;
+
+    // Act
+    outboundImportMessage.setIntendedMessageFromUserId(intendedMessageFromUserId);
+
+    // Assert
+    assertEquals(1L, outboundImportMessage.getIntendedMessageFromUserId());
+  }
+
+  @Test
+  public void setIntendedMessageTimestampTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+    long intendedMessageTimestamp = 1L;
+
+    // Act
+    outboundImportMessage.setIntendedMessageTimestamp(intendedMessageTimestamp);
+
+    // Assert
+    assertEquals(1L, outboundImportMessage.getIntendedMessageTimestamp());
+  }
+
+  @Test
+  public void setMessageTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+    String message = "aaaaa";
+
+    // Act
+    outboundImportMessage.setMessage(message);
+
+    // Assert
+    assertEquals("aaaaa", outboundImportMessage.getMessage());
+  }
+
+  @Test
+  public void setOriginalMessageIdTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+    String originalMessageId = "aaaaa";
+
+    // Act
+    outboundImportMessage.setOriginalMessageId(originalMessageId);
+
+    // Assert
+    assertEquals("aaaaa", outboundImportMessage.getOriginalMessageId());
+  }
+
+  @Test
+  public void setOriginatingSystemIdTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+    String originatingSystemId = "aaaaa";
+
+    // Act
+    outboundImportMessage.setOriginatingSystemId(originatingSystemId);
+
+    // Assert
+    assertEquals("aaaaa", outboundImportMessage.getOriginatingSystemId());
+  }
+
+  @Test
+  public void setStreamIdTest() throws Exception {
+    // Arrange
+    OutboundImportMessage outboundImportMessage = new OutboundImportMessage();
+    String streamId = "aaaaa";
+
+    // Act
+    outboundImportMessage.setStreamId(streamId);
+
+    // Assert
+    assertEquals("aaaaa", outboundImportMessage.getStreamId());
+  }
+}

--- a/src/test/java/model/OutboundMessageTest.java
+++ b/src/test/java/model/OutboundMessageTest.java
@@ -1,0 +1,140 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import java.io.File;
+import model.OutboundMessage;
+import org.junit.Test;
+
+public class OutboundMessageTest {
+  @Test
+  public void OutboundMessageTest() throws Exception {
+    // Arrange
+    String message = "aaaaa";
+    String data = "aaaaa";
+
+    // Act
+    OutboundMessage outboundMessage = new OutboundMessage(message, data);
+
+    // Assert
+    String message1 = outboundMessage.getMessage();
+    assertEquals("aaaaa", message1);
+    assertEquals("aaaaa", outboundMessage.getData());
+  }
+
+  @Test
+  public void OutboundMessageTest2() throws Exception {
+    // Arrange
+    String message = "aaaaa";
+
+    // Act
+    OutboundMessage outboundMessage = new OutboundMessage(message);
+
+    // Assert
+    assertEquals("aaaaa", outboundMessage.getMessage());
+  }
+
+  @Test
+  public void OutboundMessageTest3() throws Exception {
+    // Arrange
+    String message = "aaaaa";
+    String string = "aaaaa";
+    File file = new File("aaaaa");
+    File[] attachment = new File[]{file, new File(string), new File(string)};
+
+    // Act
+    OutboundMessage outboundMessage = new OutboundMessage(message, string, attachment);
+
+    // Assert
+    String message1 = outboundMessage.getMessage();
+    String data = outboundMessage.getData();
+    assertEquals("aaaaa", message1);
+    assertEquals(3, outboundMessage.getAttachment().length);
+    assertEquals("aaaaa", data);
+  }
+
+  @Test
+  public void OutboundMessageTest4() throws Exception {
+    // Arrange and Act
+    OutboundMessage outboundMessage = new OutboundMessage();
+
+    // Assert
+    assertEquals(null, outboundMessage.getMessage());
+  }
+
+  @Test
+  public void getAttachmentTest() throws Exception {
+    // Arrange
+    OutboundMessage outboundMessage = new OutboundMessage();
+
+    // Act
+    File[] actual = outboundMessage.getAttachment();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDataTest() throws Exception {
+    // Arrange
+    OutboundMessage outboundMessage = new OutboundMessage();
+
+    // Act
+    String actual = outboundMessage.getData();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMessageTest() throws Exception {
+    // Arrange
+    OutboundMessage outboundMessage = new OutboundMessage();
+
+    // Act
+    String actual = outboundMessage.getMessage();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAttachmentTest() throws Exception {
+    // Arrange
+    OutboundMessage outboundMessage = new OutboundMessage();
+    File file = new File("aaaaa");
+    File file1 = new File("aaaaa");
+    File[] fileArray = new File[]{file, file1, new File("aaaaaaaaaaaaaaa")};
+
+    // Act
+    outboundMessage.setAttachment(fileArray);
+
+    // Assert
+    assertEquals(3, fileArray.length);
+  }
+
+  @Test
+  public void setDataTest() throws Exception {
+    // Arrange
+    OutboundMessage outboundMessage = new OutboundMessage();
+    String data = "aaaaa";
+
+    // Act
+    outboundMessage.setData(data);
+
+    // Assert
+    assertEquals("aaaaa", outboundMessage.getData());
+  }
+
+  @Test
+  public void setMessageTest() throws Exception {
+    // Arrange
+    OutboundMessage outboundMessage = new OutboundMessage();
+    String message = "aaaaa";
+
+    // Act
+    outboundMessage.setMessage(message);
+
+    // Assert
+    assertEquals("aaaaa", outboundMessage.getMessage());
+  }
+}

--- a/src/test/java/model/OutboundShareTest.java
+++ b/src/test/java/model/OutboundShareTest.java
@@ -1,0 +1,341 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.OutboundShare;
+import org.junit.Test;
+
+public class OutboundShareTest {
+  @Test
+  public void OutboundShareTest() throws Exception {
+    // Arrange and Act
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Assert
+    assertEquals(null, outboundShare.getAppIconUrl());
+  }
+
+  @Test
+  public void getAppIconUrlTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    String actual = outboundShare.getAppIconUrl();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAppIdTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    String actual = outboundShare.getAppId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAppNameTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    String actual = outboundShare.getAppName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getArticleIdTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    String actual = outboundShare.getArticleId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getArticleUrlTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    String actual = outboundShare.getArticleUrl();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getAuthorTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    String actual = outboundShare.getAuthor();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMessageTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    String actual = outboundShare.getMessage();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPublishDateTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    long actual = outboundShare.getPublishDate();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getPublisherTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    String actual = outboundShare.getPublisher();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSubTitleTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    String actual = outboundShare.getSubTitle();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSummaryTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    String actual = outboundShare.getSummary();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getThumbnailUrlTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    String actual = outboundShare.getThumbnailUrl();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTitleTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+
+    // Act
+    String actual = outboundShare.getTitle();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAppIconUrlTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    String appIconUrl = "aaaaa";
+
+    // Act
+    outboundShare.setAppIconUrl(appIconUrl);
+
+    // Assert
+    assertEquals("aaaaa", outboundShare.getAppIconUrl());
+  }
+
+  @Test
+  public void setAppIdTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    String appId = "aaaaa";
+
+    // Act
+    outboundShare.setAppId(appId);
+
+    // Assert
+    assertEquals("aaaaa", outboundShare.getAppId());
+  }
+
+  @Test
+  public void setAppNameTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    String appName = "aaaaa";
+
+    // Act
+    outboundShare.setAppName(appName);
+
+    // Assert
+    assertEquals("aaaaa", outboundShare.getAppName());
+  }
+
+  @Test
+  public void setArticleIdTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    String articleId = "aaaaa";
+
+    // Act
+    outboundShare.setArticleId(articleId);
+
+    // Assert
+    assertEquals("aaaaa", outboundShare.getArticleId());
+  }
+
+  @Test
+  public void setArticleUrlTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    String articleUrl = "aaaaa";
+
+    // Act
+    outboundShare.setArticleUrl(articleUrl);
+
+    // Assert
+    assertEquals("aaaaa", outboundShare.getArticleUrl());
+  }
+
+  @Test
+  public void setAuthorTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    String author = "aaaaa";
+
+    // Act
+    outboundShare.setAuthor(author);
+
+    // Assert
+    assertEquals("aaaaa", outboundShare.getAuthor());
+  }
+
+  @Test
+  public void setMessageTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    String message = "aaaaa";
+
+    // Act
+    outboundShare.setMessage(message);
+
+    // Assert
+    assertEquals("aaaaa", outboundShare.getMessage());
+  }
+
+  @Test
+  public void setPublishDateTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    long publishDate = 1L;
+
+    // Act
+    outboundShare.setPublishDate(publishDate);
+
+    // Assert
+    assertEquals(1L, outboundShare.getPublishDate());
+  }
+
+  @Test
+  public void setPublisherTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    String publisher = "aaaaa";
+
+    // Act
+    outboundShare.setPublisher(publisher);
+
+    // Assert
+    assertEquals("aaaaa", outboundShare.getPublisher());
+  }
+
+  @Test
+  public void setSubTitleTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    String subTitle = "aaaaa";
+
+    // Act
+    outboundShare.setSubTitle(subTitle);
+
+    // Assert
+    assertEquals("aaaaa", outboundShare.getSubTitle());
+  }
+
+  @Test
+  public void setSummaryTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    String summary = "aaaaa";
+
+    // Act
+    outboundShare.setSummary(summary);
+
+    // Assert
+    assertEquals("aaaaa", outboundShare.getSummary());
+  }
+
+  @Test
+  public void setThumbnailUrlTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    String thumbnailUrl = "aaaaa";
+
+    // Act
+    outboundShare.setThumbnailUrl(thumbnailUrl);
+
+    // Assert
+    assertEquals("aaaaa", outboundShare.getThumbnailUrl());
+  }
+
+  @Test
+  public void setTitleTest() throws Exception {
+    // Arrange
+    OutboundShare outboundShare = new OutboundShare();
+    String title = "aaaaa";
+
+    // Act
+    outboundShare.setTitle(title);
+
+    // Assert
+    assertEquals("aaaaa", outboundShare.getTitle());
+  }
+}

--- a/src/test/java/model/PasswordTest.java
+++ b/src/test/java/model/PasswordTest.java
@@ -1,0 +1,116 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.Password;
+import org.junit.Test;
+
+public class PasswordTest {
+  @Test
+  public void PasswordTest() throws Exception {
+    // Arrange and Act
+    Password password = new Password();
+
+    // Assert
+    assertEquals(null, password.getKhSalt());
+  }
+
+  @Test
+  public void getKhPasswordTest() throws Exception {
+    // Arrange
+    Password password = new Password();
+
+    // Act
+    String actual = password.getKhPassword();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getKhSaltTest() throws Exception {
+    // Arrange
+    Password password = new Password();
+
+    // Act
+    String actual = password.getKhSalt();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void gethPasswordTest() throws Exception {
+    // Arrange
+    Password password = new Password();
+
+    // Act
+    String actual = password.gethPassword();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void gethSaltTest() throws Exception {
+    // Arrange
+    Password password = new Password();
+
+    // Act
+    String actual = password.gethSalt();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setKhPasswordTest() throws Exception {
+    // Arrange
+    Password password = new Password();
+    String khPassword = "aaaaa";
+
+    // Act
+    password.setKhPassword(khPassword);
+
+    // Assert
+    assertEquals("aaaaa", password.getKhPassword());
+  }
+
+  @Test
+  public void setKhSaltTest() throws Exception {
+    // Arrange
+    Password password = new Password();
+    String khSalt = "aaaaa";
+
+    // Act
+    password.setKhSalt(khSalt);
+
+    // Assert
+    assertEquals("aaaaa", password.getKhSalt());
+  }
+
+  @Test
+  public void sethPasswordTest() throws Exception {
+    // Arrange
+    Password password = new Password();
+    String hhPassword = "aaaaa";
+
+    // Act
+    password.sethPassword(hhPassword);
+
+    // Assert
+    assertEquals(null, password.getKhSalt());
+  }
+
+  @Test
+  public void sethSaltTest() throws Exception {
+    // Arrange
+    Password password = new Password();
+    String hhSalt = "aaaaa";
+
+    // Act
+    password.sethSalt(hhSalt);
+
+    // Assert
+    assertEquals(null, password.getKhSalt());
+  }
+}

--- a/src/test/java/model/PodCertTest.java
+++ b/src/test/java/model/PodCertTest.java
@@ -1,0 +1,41 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.PodCert;
+import org.junit.Test;
+
+public class PodCertTest {
+  @Test
+  public void PodCertTest() throws Exception {
+    // Arrange and Act
+    PodCert podCert = new PodCert();
+
+    // Assert
+    assertEquals(null, podCert.getCertificate());
+  }
+
+  @Test
+  public void getCertificateTest() throws Exception {
+    // Arrange
+    PodCert podCert = new PodCert();
+
+    // Act
+    String actual = podCert.getCertificate();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setCertificateTest() throws Exception {
+    // Arrange
+    PodCert podCert = new PodCert();
+    String certificate = "aaaaa";
+
+    // Act
+    podCert.setCertificate(certificate);
+
+    // Assert
+    assertEquals("aaaaa", podCert.getCertificate());
+  }
+}

--- a/src/test/java/model/PolicyTest.java
+++ b/src/test/java/model/PolicyTest.java
@@ -1,0 +1,172 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import java.util.ArrayList;
+import java.util.List;
+import model.Policy;
+import org.junit.Test;
+
+public class PolicyTest {
+  @Test
+  public void PolicyTest() throws Exception {
+    // Arrange and Act
+    Policy policy = new Policy();
+
+    // Assert
+    assertEquals(0L, policy.getModifiedDate());
+  }
+
+  @Test
+  public void getCreatedDateTest() throws Exception {
+    // Arrange
+    Policy policy = new Policy();
+
+    // Act
+    long actual = policy.getCreatedDate();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getGroupsTest() throws Exception {
+    // Arrange
+    Policy policy = new Policy();
+
+    // Act
+    List<String> actual = policy.getGroups();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    Policy policy = new Policy();
+
+    // Act
+    String actual = policy.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getModifiedDateTest() throws Exception {
+    // Arrange
+    Policy policy = new Policy();
+
+    // Act
+    long actual = policy.getModifiedDate();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getPolicyTypeTest() throws Exception {
+    // Arrange
+    Policy policy = new Policy();
+
+    // Act
+    String actual = policy.getPolicyType();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void isActiveTest() throws Exception {
+    // Arrange
+    Policy policy = new Policy();
+
+    // Act
+    boolean actual = policy.isActive();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void setActiveTest() throws Exception {
+    // Arrange
+    Policy policy = new Policy();
+    boolean active = true;
+
+    // Act
+    policy.setActive(active);
+
+    // Assert
+    assertTrue(policy.isActive());
+  }
+
+  @Test
+  public void setCreatedDateTest() throws Exception {
+    // Arrange
+    Policy policy = new Policy();
+    long createdDate = 1L;
+
+    // Act
+    policy.setCreatedDate(createdDate);
+
+    // Assert
+    assertEquals(1L, policy.getCreatedDate());
+  }
+
+  @Test
+  public void setGroupsTest() throws Exception {
+    // Arrange
+    Policy policy = new Policy();
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    policy.setGroups(arrayList);
+
+    // Assert
+    assertSame(arrayList, policy.getGroups());
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    Policy policy = new Policy();
+    String id = "aaaaa";
+
+    // Act
+    policy.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", policy.getId());
+  }
+
+  @Test
+  public void setModifiedDateTest() throws Exception {
+    // Arrange
+    Policy policy = new Policy();
+    long modifiedDate = 1L;
+
+    // Act
+    policy.setModifiedDate(modifiedDate);
+
+    // Assert
+    assertEquals(1L, policy.getModifiedDate());
+  }
+
+  @Test
+  public void setPolicyTypeTest() throws Exception {
+    // Arrange
+    Policy policy = new Policy();
+    String policyType = "aaaaa";
+
+    // Act
+    policy.setPolicyType(policyType);
+
+    // Assert
+    assertEquals("aaaaa", policy.getPolicyType());
+  }
+}

--- a/src/test/java/model/RoomInfoTest.java
+++ b/src/test/java/model/RoomInfoTest.java
@@ -1,0 +1,68 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.Room;
+import model.RoomInfo;
+import org.junit.Test;
+
+public class RoomInfoTest {
+  @Test
+  public void RoomInfoTest() throws Exception {
+    // Arrange and Act
+    RoomInfo roomInfo = new RoomInfo();
+
+    // Assert
+    assertEquals(null, roomInfo.getRoomAttributes());
+  }
+
+  @Test
+  public void getRoomAttributesTest() throws Exception {
+    // Arrange
+    RoomInfo roomInfo = new RoomInfo();
+
+    // Act
+    Room actual = roomInfo.getRoomAttributes();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomSystemInfoTest() throws Exception {
+    // Arrange
+    RoomInfo roomInfo = new RoomInfo();
+
+    // Act
+    RoomSystemInfo actual = roomInfo.getRoomSystemInfo();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setRoomAttributesTest() throws Exception {
+    // Arrange
+    RoomInfo roomInfo = new RoomInfo();
+    Room room = new Room();
+
+    // Act
+    roomInfo.setRoomAttributes(room);
+
+    // Assert
+    assertSame(room, roomInfo.getRoomAttributes());
+  }
+
+  @Test
+  public void setRoomSystemInfoTest() throws Exception {
+    // Arrange
+    RoomInfo roomInfo = new RoomInfo();
+    RoomSystemInfo roomSystemInfo = new RoomSystemInfo();
+
+    // Act
+    roomInfo.setRoomSystemInfo(roomSystemInfo);
+
+    // Assert
+    assertSame(roomSystemInfo, roomInfo.getRoomSystemInfo());
+  }
+}

--- a/src/test/java/model/RoomMemberTest.java
+++ b/src/test/java/model/RoomMemberTest.java
@@ -1,0 +1,91 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.RoomMember;
+import org.junit.Test;
+
+public class RoomMemberTest {
+  @Test
+  public void RoomMemberTest() throws Exception {
+    // Arrange and Act
+    RoomMember roomMember = new RoomMember();
+
+    // Assert
+    assertEquals(null, roomMember.getJoinDate());
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    RoomMember roomMember = new RoomMember();
+
+    // Act
+    Long actual = roomMember.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getJoinDateTest() throws Exception {
+    // Arrange
+    RoomMember roomMember = new RoomMember();
+
+    // Act
+    Long actual = roomMember.getJoinDate();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOwnerTest() throws Exception {
+    // Arrange
+    RoomMember roomMember = new RoomMember();
+
+    // Act
+    Boolean actual = roomMember.getOwner();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    RoomMember roomMember = new RoomMember();
+    Long id = new Long(1L);
+
+    // Act
+    roomMember.setId(id);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), roomMember.getId());
+  }
+
+  @Test
+  public void setJoinDateTest() throws Exception {
+    // Arrange
+    RoomMember roomMember = new RoomMember();
+    Long joinDate = new Long(1L);
+
+    // Act
+    roomMember.setJoinDate(joinDate);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), roomMember.getJoinDate());
+  }
+
+  @Test
+  public void setOwnerTest() throws Exception {
+    // Arrange
+    RoomMember roomMember = new RoomMember();
+    Boolean owner = new Boolean(true);
+
+    // Act
+    roomMember.setOwner(owner);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), roomMember.getOwner());
+  }
+}

--- a/src/test/java/model/RoomNameTest.java
+++ b/src/test/java/model/RoomNameTest.java
@@ -1,0 +1,41 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.RoomName;
+import org.junit.Test;
+
+public class RoomNameTest {
+  @Test
+  public void RoomNameTest() throws Exception {
+    // Arrange and Act
+    RoomName roomName = new RoomName();
+
+    // Assert
+    assertEquals(null, roomName.getName());
+  }
+
+  @Test
+  public void getNameTest() throws Exception {
+    // Arrange
+    RoomName roomName = new RoomName();
+
+    // Act
+    String actual = roomName.getName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setNameTest() throws Exception {
+    // Arrange
+    RoomName roomName = new RoomName();
+    String name = "aaaaa";
+
+    // Act
+    roomName.setName(name);
+
+    // Assert
+    assertEquals("aaaaa", roomName.getName());
+  }
+}

--- a/src/test/java/model/RoomPropertiesTest.java
+++ b/src/test/java/model/RoomPropertiesTest.java
@@ -1,0 +1,345 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.RoomProperties;
+import org.junit.Test;
+
+public class RoomPropertiesTest {
+  @Test
+  public void RoomPropertiesTest() throws Exception {
+    // Arrange and Act
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Assert
+    assertEquals(null, roomProperties.getName());
+  }
+
+  @Test
+  public void getCanViewHistoryTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    Boolean actual = roomProperties.getCanViewHistory();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCopyProtectedTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    Boolean actual = roomProperties.getCopyProtected();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCreatedDateTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    Long actual = roomProperties.getCreatedDate();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCreatorUserTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    User actual = roomProperties.getCreatorUser();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCrossPodTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    Boolean actual = roomProperties.getCrossPod();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDescriptionTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    String actual = roomProperties.getDescription();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDiscoverableTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    Boolean actual = roomProperties.getDiscoverable();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getExternalTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    Boolean actual = roomProperties.getExternal();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getKeywordsTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    List<Keyword> actual = roomProperties.getKeywords();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMembersCanInviteTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    Boolean actual = roomProperties.getMembersCanInvite();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getNameTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    String actual = roomProperties.getName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPublicTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    Boolean actual = roomProperties.getPublic();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getReadOnlyTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    Boolean actual = roomProperties.getReadOnly();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setCanViewHistoryTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    Boolean canViewHistory = new Boolean(true);
+
+    // Act
+    roomProperties.setCanViewHistory(canViewHistory);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), roomProperties.getCanViewHistory());
+  }
+
+  @Test
+  public void setCopyProtectedTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    Boolean copyProtected = new Boolean(true);
+
+    // Act
+    roomProperties.setCopyProtected(copyProtected);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), roomProperties.getCopyProtected());
+  }
+
+  @Test
+  public void setCreatedDateTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    Long createdDate = new Long(1L);
+
+    // Act
+    roomProperties.setCreatedDate(createdDate);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), roomProperties.getCreatedDate());
+  }
+
+  @Test
+  public void setCreatorUserTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    User user = new User();
+
+    // Act
+    roomProperties.setCreatorUser(user);
+
+    // Assert
+    assertSame(user, roomProperties.getCreatorUser());
+  }
+
+  @Test
+  public void setCrossPodTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    Boolean crossPod = new Boolean(true);
+
+    // Act
+    roomProperties.setCrossPod(crossPod);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), roomProperties.getCrossPod());
+  }
+
+  @Test
+  public void setDescriptionTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    String description = "aaaaa";
+
+    // Act
+    roomProperties.setDescription(description);
+
+    // Assert
+    assertEquals("aaaaa", roomProperties.getDescription());
+  }
+
+  @Test
+  public void setDiscoverableTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    Boolean discoverable = new Boolean(true);
+
+    // Act
+    roomProperties.setDiscoverable(discoverable);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), roomProperties.getDiscoverable());
+  }
+
+  @Test
+  public void setExternalTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    Boolean external = new Boolean(true);
+
+    // Act
+    roomProperties.setExternal(external);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), roomProperties.getExternal());
+  }
+
+  @Test
+  public void setKeywordsTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    ArrayList<Keyword> arrayList = new ArrayList<Keyword>();
+    arrayList.add(new Keyword());
+
+    // Act
+    roomProperties.setKeywords(arrayList);
+
+    // Assert
+    assertSame(arrayList, roomProperties.getKeywords());
+  }
+
+  @Test
+  public void setMembersCanInviteTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    Boolean membersCanInvite = new Boolean(true);
+
+    // Act
+    roomProperties.setMembersCanInvite(membersCanInvite);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), roomProperties.getMembersCanInvite());
+  }
+
+  @Test
+  public void setNameTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    String name = "aaaaa";
+
+    // Act
+    roomProperties.setName(name);
+
+    // Assert
+    assertEquals("aaaaa", roomProperties.getName());
+  }
+
+  @Test
+  public void setPublicTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    Boolean isPublic = new Boolean(true);
+
+    // Act
+    roomProperties.setPublic(isPublic);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), roomProperties.getPublic());
+  }
+
+  @Test
+  public void setReadOnlyTest() throws Exception {
+    // Arrange
+    RoomProperties roomProperties = new RoomProperties();
+    Boolean readOnly = new Boolean(true);
+
+    // Act
+    roomProperties.setReadOnly(readOnly);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), roomProperties.getReadOnly());
+  }
+}

--- a/src/test/java/model/RoomSearchQueryTest.java
+++ b/src/test/java/model/RoomSearchQueryTest.java
@@ -1,0 +1,196 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.NumericId;
+import model.RoomSearchQuery;
+import org.junit.Test;
+
+public class RoomSearchQueryTest {
+  @Test
+  public void RoomSearchQueryTest() throws Exception {
+    // Arrange and Act
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+
+    // Assert
+    assertEquals(null, roomSearchQuery.getQuery());
+  }
+
+  @Test
+  public void getActiveTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+
+    // Act
+    Boolean actual = roomSearchQuery.getActive();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCreatorTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+
+    // Act
+    NumericId actual = roomSearchQuery.getCreator();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLabelsTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+
+    // Act
+    List<String> actual = roomSearchQuery.getLabels();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMemberTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+
+    // Act
+    NumericId actual = roomSearchQuery.getMember();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOwnerTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+
+    // Act
+    NumericId actual = roomSearchQuery.getOwner();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPrivateTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+
+    // Act
+    Boolean actual = roomSearchQuery.getPrivate();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getQueryTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+
+    // Act
+    String actual = roomSearchQuery.getQuery();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setActiveTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+    Boolean active = new Boolean(true);
+
+    // Act
+    roomSearchQuery.setActive(active);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), roomSearchQuery.getActive());
+  }
+
+  @Test
+  public void setCreatorTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+    NumericId numericId = new NumericId();
+
+    // Act
+    roomSearchQuery.setCreator(numericId);
+
+    // Assert
+    assertSame(numericId, roomSearchQuery.getCreator());
+  }
+
+  @Test
+  public void setLabelsTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    roomSearchQuery.setLabels(arrayList);
+
+    // Assert
+    assertSame(arrayList, roomSearchQuery.getLabels());
+  }
+
+  @Test
+  public void setMemberTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+    NumericId numericId = new NumericId();
+
+    // Act
+    roomSearchQuery.setMember(numericId);
+
+    // Assert
+    assertSame(numericId, roomSearchQuery.getMember());
+  }
+
+  @Test
+  public void setOwnerTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+    NumericId numericId = new NumericId();
+
+    // Act
+    roomSearchQuery.setOwner(numericId);
+
+    // Assert
+    assertSame(numericId, roomSearchQuery.getOwner());
+  }
+
+  @Test
+  public void setPrivateTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+    Boolean isPrivate = new Boolean(true);
+
+    // Act
+    roomSearchQuery.setPrivate(isPrivate);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), roomSearchQuery.getPrivate());
+  }
+
+  @Test
+  public void setQueryTest() throws Exception {
+    // Arrange
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+    String query = "aaaaa";
+
+    // Act
+    roomSearchQuery.setQuery(query);
+
+    // Assert
+    assertEquals("aaaaa", roomSearchQuery.getQuery());
+  }
+}

--- a/src/test/java/model/RoomSearchResultTest.java
+++ b/src/test/java/model/RoomSearchResultTest.java
@@ -1,0 +1,146 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.RoomInfo;
+import model.RoomSearchResult;
+import org.junit.Test;
+
+public class RoomSearchResultTest {
+  @Test
+  public void RoomSearchResultTest() throws Exception {
+    // Arrange and Act
+    RoomSearchResult roomSearchResult = new RoomSearchResult();
+
+    // Assert
+    assertEquals(0, roomSearchResult.getSkip());
+  }
+
+  @Test
+  public void getCountTest() throws Exception {
+    // Arrange
+    RoomSearchResult roomSearchResult = new RoomSearchResult();
+
+    // Act
+    int actual = roomSearchResult.getCount();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getLimitTest() throws Exception {
+    // Arrange
+    RoomSearchResult roomSearchResult = new RoomSearchResult();
+
+    // Act
+    int actual = roomSearchResult.getLimit();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getQueryTest() throws Exception {
+    // Arrange
+    RoomSearchResult roomSearchResult = new RoomSearchResult();
+
+    // Act
+    RoomSearchQuery actual = roomSearchResult.getQuery();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomsTest() throws Exception {
+    // Arrange
+    RoomSearchResult roomSearchResult = new RoomSearchResult();
+
+    // Act
+    List<RoomInfo> actual = roomSearchResult.getRooms();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSkipTest() throws Exception {
+    // Arrange
+    RoomSearchResult roomSearchResult = new RoomSearchResult();
+
+    // Act
+    int actual = roomSearchResult.getSkip();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void setCountTest() throws Exception {
+    // Arrange
+    RoomSearchResult roomSearchResult = new RoomSearchResult();
+    int count = 1;
+
+    // Act
+    roomSearchResult.setCount(count);
+
+    // Assert
+    assertEquals(1, roomSearchResult.getCount());
+  }
+
+  @Test
+  public void setLimitTest() throws Exception {
+    // Arrange
+    RoomSearchResult roomSearchResult = new RoomSearchResult();
+    int limit = 1;
+
+    // Act
+    roomSearchResult.setLimit(limit);
+
+    // Assert
+    assertEquals(1, roomSearchResult.getLimit());
+  }
+
+  @Test
+  public void setQueryTest() throws Exception {
+    // Arrange
+    RoomSearchResult roomSearchResult = new RoomSearchResult();
+    RoomSearchQuery roomSearchQuery = new RoomSearchQuery();
+
+    // Act
+    roomSearchResult.setQuery(roomSearchQuery);
+
+    // Assert
+    assertSame(roomSearchQuery, roomSearchResult.getQuery());
+  }
+
+  @Test
+  public void setRoomsTest() throws Exception {
+    // Arrange
+    RoomSearchResult roomSearchResult = new RoomSearchResult();
+    ArrayList<RoomInfo> arrayList = new ArrayList<RoomInfo>();
+    arrayList.add(new RoomInfo());
+
+    // Act
+    roomSearchResult.setRooms(arrayList);
+
+    // Assert
+    assertSame(arrayList, roomSearchResult.getRooms());
+  }
+
+  @Test
+  public void setSkipTest() throws Exception {
+    // Arrange
+    RoomSearchResult roomSearchResult = new RoomSearchResult();
+    int skip = 1;
+
+    // Act
+    roomSearchResult.setSkip(skip);
+
+    // Assert
+    assertEquals(1, roomSearchResult.getSkip());
+  }
+}

--- a/src/test/java/model/RoomSystemInfoTest.java
+++ b/src/test/java/model/RoomSystemInfoTest.java
@@ -1,0 +1,118 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import model.RoomSystemInfo;
+import org.junit.Test;
+
+public class RoomSystemInfoTest {
+  @Test
+  public void RoomSystemInfoTest() throws Exception {
+    // Arrange and Act
+    RoomSystemInfo roomSystemInfo = new RoomSystemInfo();
+
+    // Assert
+    assertEquals(0L, roomSystemInfo.getCreatedByUserId());
+  }
+
+  @Test
+  public void getCreatedByUserIdTest() throws Exception {
+    // Arrange
+    RoomSystemInfo roomSystemInfo = new RoomSystemInfo();
+
+    // Act
+    long actual = roomSystemInfo.getCreatedByUserId();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getCreationDateTest() throws Exception {
+    // Arrange
+    RoomSystemInfo roomSystemInfo = new RoomSystemInfo();
+
+    // Act
+    long actual = roomSystemInfo.getCreationDate();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    RoomSystemInfo roomSystemInfo = new RoomSystemInfo();
+
+    // Act
+    String actual = roomSystemInfo.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void isActiveTest() throws Exception {
+    // Arrange
+    RoomSystemInfo roomSystemInfo = new RoomSystemInfo();
+
+    // Act
+    boolean actual = roomSystemInfo.isActive();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void setActiveTest() throws Exception {
+    // Arrange
+    RoomSystemInfo roomSystemInfo = new RoomSystemInfo();
+    boolean active = true;
+
+    // Act
+    roomSystemInfo.setActive(active);
+
+    // Assert
+    assertTrue(roomSystemInfo.isActive());
+  }
+
+  @Test
+  public void setCreatedByUserIdTest() throws Exception {
+    // Arrange
+    RoomSystemInfo roomSystemInfo = new RoomSystemInfo();
+    long createdByUserId = 1L;
+
+    // Act
+    roomSystemInfo.setCreatedByUserId(createdByUserId);
+
+    // Assert
+    assertEquals(1L, roomSystemInfo.getCreatedByUserId());
+  }
+
+  @Test
+  public void setCreationDateTest() throws Exception {
+    // Arrange
+    RoomSystemInfo roomSystemInfo = new RoomSystemInfo();
+    long creationDate = 1L;
+
+    // Act
+    roomSystemInfo.setCreationDate(creationDate);
+
+    // Assert
+    assertEquals(1L, roomSystemInfo.getCreationDate());
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    RoomSystemInfo roomSystemInfo = new RoomSystemInfo();
+    String id = "aaaaa";
+
+    // Act
+    roomSystemInfo.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", roomSystemInfo.getId());
+  }
+}

--- a/src/test/java/model/RoomTest.java
+++ b/src/test/java/model/RoomTest.java
@@ -1,0 +1,295 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.Room;
+import org.junit.Test;
+
+public class RoomTest {
+  @Test
+  public void RoomTest() throws Exception {
+    // Arrange and Act
+    Room room = new Room();
+
+    // Assert
+    assertEquals(null, room.getMembersCanInvite());
+  }
+
+  @Test
+  public void getCopyProtectedTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+
+    // Act
+    Boolean actual = room.getCopyProtected();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCrossPodTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+
+    // Act
+    Boolean actual = room.getCrossPod();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDescriptionTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+
+    // Act
+    String actual = room.getDescription();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDiscoverableTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+
+    // Act
+    Boolean actual = room.getDiscoverable();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getKeywordsTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+
+    // Act
+    List<Keyword> actual = room.getKeywords();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMembersCanInviteTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+
+    // Act
+    Boolean actual = room.getMembersCanInvite();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMultiLateralRoomTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+
+    // Act
+    Boolean actual = room.getMultiLateralRoom();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getNameTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+
+    // Act
+    String actual = room.getName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getPublicTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+
+    // Act
+    Boolean actual = room.getPublic();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getReadOnlyTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+
+    // Act
+    Boolean actual = room.getReadOnly();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getViewHistoryTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+
+    // Act
+    Boolean actual = room.getViewHistory();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setCopyProtectedTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+    Boolean copyProtected = new Boolean(true);
+
+    // Act
+    room.setCopyProtected(copyProtected);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), room.getCopyProtected());
+  }
+
+  @Test
+  public void setCrossPodTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+    Boolean crossPod = new Boolean(true);
+
+    // Act
+    room.setCrossPod(crossPod);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), room.getCrossPod());
+  }
+
+  @Test
+  public void setDescriptionTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+    String description = "aaaaa";
+
+    // Act
+    room.setDescription(description);
+
+    // Assert
+    assertEquals("aaaaa", room.getDescription());
+  }
+
+  @Test
+  public void setDiscoverableTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+    Boolean discoverable = new Boolean(true);
+
+    // Act
+    room.setDiscoverable(discoverable);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), room.getDiscoverable());
+  }
+
+  @Test
+  public void setKeywordsTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+    ArrayList<Keyword> arrayList = new ArrayList<Keyword>();
+    arrayList.add(new Keyword());
+
+    // Act
+    room.setKeywords(arrayList);
+
+    // Assert
+    assertSame(arrayList, room.getKeywords());
+  }
+
+  @Test
+  public void setMembersCanInviteTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+    Boolean membersCanInvite = new Boolean(true);
+
+    // Act
+    room.setMembersCanInvite(membersCanInvite);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), room.getMembersCanInvite());
+  }
+
+  @Test
+  public void setMultiLateralRoomTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+    Boolean multiLateralRoom = new Boolean(true);
+
+    // Act
+    room.setMultiLateralRoom(multiLateralRoom);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), room.getMultiLateralRoom());
+  }
+
+  @Test
+  public void setNameTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+    String name = "aaaaa";
+
+    // Act
+    room.setName(name);
+
+    // Assert
+    assertEquals("aaaaa", room.getName());
+  }
+
+  @Test
+  public void setPublicTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+    Boolean isPublic = new Boolean(true);
+
+    // Act
+    room.setPublic(isPublic);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), room.getPublic());
+  }
+
+  @Test
+  public void setReadOnlyTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+    Boolean readOnly = new Boolean(true);
+
+    // Act
+    room.setReadOnly(readOnly);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), room.getReadOnly());
+  }
+
+  @Test
+  public void setViewHistoryTest() throws Exception {
+    // Arrange
+    Room room = new Room();
+    Boolean viewHistory = new Boolean(true);
+
+    // Act
+    room.setViewHistory(viewHistory);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), room.getViewHistory());
+  }
+}

--- a/src/test/java/model/SessionTokenTest.java
+++ b/src/test/java/model/SessionTokenTest.java
@@ -1,0 +1,41 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.SessionToken;
+import org.junit.Test;
+
+public class SessionTokenTest {
+  @Test
+  public void SessionTokenTest() throws Exception {
+    // Arrange and Act
+    SessionToken sessionToken = new SessionToken();
+
+    // Assert
+    assertEquals(null, sessionToken.getSessionToken());
+  }
+
+  @Test
+  public void getSessionTokenTest() throws Exception {
+    // Arrange
+    SessionToken sessionToken = new SessionToken();
+
+    // Act
+    String actual = sessionToken.getSessionToken();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setSessionTokenTest() throws Exception {
+    // Arrange
+    SessionToken sessionToken = new SessionToken();
+    String sessionToken1 = "aaaaa";
+
+    // Act
+    sessionToken.setSessionToken(sessionToken1);
+
+    // Assert
+    assertEquals("aaaaa", sessionToken.getSessionToken());
+  }
+}

--- a/src/test/java/model/SignalListTest.java
+++ b/src/test/java/model/SignalListTest.java
@@ -1,0 +1,16 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.SignalList;
+import org.junit.Test;
+
+public class SignalListTest {
+  @Test
+  public void SignalListTest() throws Exception {
+    // Arrange and Act
+    SignalList signalList = new SignalList();
+
+    // Assert
+    assertEquals(0, signalList.size());
+  }
+}

--- a/src/test/java/model/SignalSubscriberListTest.java
+++ b/src/test/java/model/SignalSubscriberListTest.java
@@ -1,0 +1,122 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import java.util.ArrayList;
+import java.util.List;
+import model.SignalSubscriberList;
+import org.junit.Test;
+
+public class SignalSubscriberListTest {
+  @Test
+  public void SignalSubscriberListTest() throws Exception {
+    // Arrange and Act
+    SignalSubscriberList signalSubscriberList = new SignalSubscriberList();
+
+    // Assert
+    assertEquals(null, signalSubscriberList.getData());
+  }
+
+  @Test
+  public void getDataTest() throws Exception {
+    // Arrange
+    SignalSubscriberList signalSubscriberList = new SignalSubscriberList();
+
+    // Act
+    List<SignalSubscriber> actual = signalSubscriberList.getData();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOffsetTest() throws Exception {
+    // Arrange
+    SignalSubscriberList signalSubscriberList = new SignalSubscriberList();
+
+    // Act
+    int actual = signalSubscriberList.getOffset();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getTotalTest() throws Exception {
+    // Arrange
+    SignalSubscriberList signalSubscriberList = new SignalSubscriberList();
+
+    // Act
+    int actual = signalSubscriberList.getTotal();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void isHasMoreTest() throws Exception {
+    // Arrange
+    SignalSubscriberList signalSubscriberList = new SignalSubscriberList();
+
+    // Act
+    boolean actual = signalSubscriberList.isHasMore();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void setDataTest() throws Exception {
+    // Arrange
+    SignalSubscriberList signalSubscriberList = new SignalSubscriberList();
+    ArrayList<SignalSubscriber> arrayList = new ArrayList<SignalSubscriber>();
+    arrayList.add(new SignalSubscriber());
+
+    // Act
+    signalSubscriberList.setData(arrayList);
+
+    // Assert
+    assertSame(arrayList, signalSubscriberList.getData());
+  }
+
+  @Test
+  public void setHasMoreTest() throws Exception {
+    // Arrange
+    SignalSubscriberList signalSubscriberList = new SignalSubscriberList();
+    boolean hasMore = true;
+
+    // Act
+    signalSubscriberList.setHasMore(hasMore);
+
+    // Assert
+    assertTrue(signalSubscriberList.isHasMore());
+  }
+
+  @Test
+  public void setOffsetTest() throws Exception {
+    // Arrange
+    SignalSubscriberList signalSubscriberList = new SignalSubscriberList();
+    int offset = 1;
+
+    // Act
+    signalSubscriberList.setOffset(offset);
+
+    // Assert
+    assertEquals(1, signalSubscriberList.getOffset());
+  }
+
+  @Test
+  public void setTotalTest() throws Exception {
+    // Arrange
+    SignalSubscriberList signalSubscriberList = new SignalSubscriberList();
+    int total = 1;
+
+    // Act
+    signalSubscriberList.setTotal(total);
+
+    // Assert
+    assertEquals(1, signalSubscriberList.getTotal());
+  }
+}

--- a/src/test/java/model/SignalSubscriberTest.java
+++ b/src/test/java/model/SignalSubscriberTest.java
@@ -1,0 +1,143 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import model.SignalSubscriber;
+import org.junit.Test;
+
+public class SignalSubscriberTest {
+  @Test
+  public void SignalSubscriberTest() throws Exception {
+    // Arrange and Act
+    SignalSubscriber signalSubscriber = new SignalSubscriber();
+
+    // Assert
+    assertEquals(null, signalSubscriber.getTimestamp());
+  }
+
+  @Test
+  public void getSubscriberNameTest() throws Exception {
+    // Arrange
+    SignalSubscriber signalSubscriber = new SignalSubscriber();
+
+    // Act
+    String actual = signalSubscriber.getSubscriberName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTimestampTest() throws Exception {
+    // Arrange
+    SignalSubscriber signalSubscriber = new SignalSubscriber();
+
+    // Act
+    Long actual = signalSubscriber.getTimestamp();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserIdTest() throws Exception {
+    // Arrange
+    SignalSubscriber signalSubscriber = new SignalSubscriber();
+
+    // Act
+    Long actual = signalSubscriber.getUserId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void isOwnerTest() throws Exception {
+    // Arrange
+    SignalSubscriber signalSubscriber = new SignalSubscriber();
+
+    // Act
+    boolean actual = signalSubscriber.isOwner();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void isPushedTest() throws Exception {
+    // Arrange
+    SignalSubscriber signalSubscriber = new SignalSubscriber();
+
+    // Act
+    boolean actual = signalSubscriber.isPushed();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void setOwnerTest() throws Exception {
+    // Arrange
+    SignalSubscriber signalSubscriber = new SignalSubscriber();
+    boolean owner = true;
+
+    // Act
+    signalSubscriber.setOwner(owner);
+
+    // Assert
+    assertTrue(signalSubscriber.isOwner());
+  }
+
+  @Test
+  public void setPushedTest() throws Exception {
+    // Arrange
+    SignalSubscriber signalSubscriber = new SignalSubscriber();
+    boolean pushed = true;
+
+    // Act
+    signalSubscriber.setPushed(pushed);
+
+    // Assert
+    assertTrue(signalSubscriber.isPushed());
+  }
+
+  @Test
+  public void setSubscriberNameTest() throws Exception {
+    // Arrange
+    SignalSubscriber signalSubscriber = new SignalSubscriber();
+    String subscriberName = "aaaaa";
+
+    // Act
+    signalSubscriber.setSubscriberName(subscriberName);
+
+    // Assert
+    assertEquals("aaaaa", signalSubscriber.getSubscriberName());
+  }
+
+  @Test
+  public void setTimestampTest() throws Exception {
+    // Arrange
+    SignalSubscriber signalSubscriber = new SignalSubscriber();
+    Long timestamp = new Long(1L);
+
+    // Act
+    signalSubscriber.setTimestamp(timestamp);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), signalSubscriber.getTimestamp());
+  }
+
+  @Test
+  public void setUserIdTest() throws Exception {
+    // Arrange
+    SignalSubscriber signalSubscriber = new SignalSubscriber();
+    Long userId = new Long(1L);
+
+    // Act
+    signalSubscriber.setUserId(userId);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), signalSubscriber.getUserId());
+  }
+}

--- a/src/test/java/model/SignalSubscriptionResultTest.java
+++ b/src/test/java/model/SignalSubscriptionResultTest.java
@@ -1,0 +1,120 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.SignalSubscriptionResult;
+import org.junit.Test;
+
+public class SignalSubscriptionResultTest {
+  @Test
+  public void SignalSubscriptionResultTest() throws Exception {
+    // Arrange and Act
+    SignalSubscriptionResult signalSubscriptionResult = new SignalSubscriptionResult();
+
+    // Assert
+    assertEquals(0, signalSubscriptionResult.getSuccessfulSubscription());
+  }
+
+  @Test
+  public void getFailedSubscriptionTest() throws Exception {
+    // Arrange
+    SignalSubscriptionResult signalSubscriptionResult = new SignalSubscriptionResult();
+
+    // Act
+    int actual = signalSubscriptionResult.getFailedSubscription();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getRequestedSubscriptionTest() throws Exception {
+    // Arrange
+    SignalSubscriptionResult signalSubscriptionResult = new SignalSubscriptionResult();
+
+    // Act
+    int actual = signalSubscriptionResult.getRequestedSubscription();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getSubscriptionErrorsTest() throws Exception {
+    // Arrange
+    SignalSubscriptionResult signalSubscriptionResult = new SignalSubscriptionResult();
+
+    // Act
+    List<Long> actual = signalSubscriptionResult.getSubscriptionErrors();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSuccessfulSubscriptionTest() throws Exception {
+    // Arrange
+    SignalSubscriptionResult signalSubscriptionResult = new SignalSubscriptionResult();
+
+    // Act
+    int actual = signalSubscriptionResult.getSuccessfulSubscription();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void setFailedSubscriptionTest() throws Exception {
+    // Arrange
+    SignalSubscriptionResult signalSubscriptionResult = new SignalSubscriptionResult();
+    int failedSubscription = 1;
+
+    // Act
+    signalSubscriptionResult.setFailedSubscription(failedSubscription);
+
+    // Assert
+    assertEquals(1, signalSubscriptionResult.getFailedSubscription());
+  }
+
+  @Test
+  public void setRequestedSubscriptionTest() throws Exception {
+    // Arrange
+    SignalSubscriptionResult signalSubscriptionResult = new SignalSubscriptionResult();
+    int requestedSubscription = 1;
+
+    // Act
+    signalSubscriptionResult.setRequestedSubscription(requestedSubscription);
+
+    // Assert
+    assertEquals(1, signalSubscriptionResult.getRequestedSubscription());
+  }
+
+  @Test
+  public void setSubscriptionErrorsTest() throws Exception {
+    // Arrange
+    SignalSubscriptionResult signalSubscriptionResult = new SignalSubscriptionResult();
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act
+    signalSubscriptionResult.setSubscriptionErrors(arrayList);
+
+    // Assert
+    assertSame(arrayList, signalSubscriptionResult.getSubscriptionErrors());
+  }
+
+  @Test
+  public void setSuccessfulSubscriptionTest() throws Exception {
+    // Arrange
+    SignalSubscriptionResult signalSubscriptionResult = new SignalSubscriptionResult();
+    int successfulSubscription = 1;
+
+    // Act
+    signalSubscriptionResult.setSuccessfulSubscription(successfulSubscription);
+
+    // Assert
+    assertEquals(1, signalSubscriptionResult.getSuccessfulSubscription());
+  }
+}

--- a/src/test/java/model/SignalTest.java
+++ b/src/test/java/model/SignalTest.java
@@ -1,0 +1,168 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import model.Signal;
+import org.junit.Test;
+
+public class SignalTest {
+  @Test
+  public void SignalTest() throws Exception {
+    // Arrange and Act
+    Signal signal = new Signal();
+
+    // Assert
+    assertEquals(null, signal.getQuery());
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    Signal signal = new Signal();
+
+    // Act
+    String actual = signal.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getNameTest() throws Exception {
+    // Arrange
+    Signal signal = new Signal();
+
+    // Act
+    String actual = signal.getName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getQueryTest() throws Exception {
+    // Arrange
+    Signal signal = new Signal();
+
+    // Act
+    String actual = signal.getQuery();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTimestampTest() throws Exception {
+    // Arrange
+    Signal signal = new Signal();
+
+    // Act
+    long actual = signal.getTimestamp();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void isCompanyWideTest() throws Exception {
+    // Arrange
+    Signal signal = new Signal();
+
+    // Act
+    boolean actual = signal.isCompanyWide();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void isVisibleOnProfileTest() throws Exception {
+    // Arrange
+    Signal signal = new Signal();
+
+    // Act
+    boolean actual = signal.isVisibleOnProfile();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void setCompanyWideTest() throws Exception {
+    // Arrange
+    Signal signal = new Signal();
+    boolean companyWide = true;
+
+    // Act
+    signal.setCompanyWide(companyWide);
+
+    // Assert
+    assertTrue(signal.isCompanyWide());
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    Signal signal = new Signal();
+    String id = "aaaaa";
+
+    // Act
+    signal.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", signal.getId());
+  }
+
+  @Test
+  public void setNameTest() throws Exception {
+    // Arrange
+    Signal signal = new Signal();
+    String name = "aaaaa";
+
+    // Act
+    signal.setName(name);
+
+    // Assert
+    assertEquals("aaaaa", signal.getName());
+  }
+
+  @Test
+  public void setQueryTest() throws Exception {
+    // Arrange
+    Signal signal = new Signal();
+    String query = "aaaaa";
+
+    // Act
+    signal.setQuery(query);
+
+    // Assert
+    assertEquals("aaaaa", signal.getQuery());
+  }
+
+  @Test
+  public void setTimestampTest() throws Exception {
+    // Arrange
+    Signal signal = new Signal();
+    long timestamp = 1L;
+
+    // Act
+    signal.setTimestamp(timestamp);
+
+    // Assert
+    assertEquals(1L, signal.getTimestamp());
+  }
+
+  @Test
+  public void setVisibleOnProfileTest() throws Exception {
+    // Arrange
+    Signal signal = new Signal();
+    boolean visibleOnProfile = true;
+
+    // Act
+    signal.setVisibleOnProfile(visibleOnProfile);
+
+    // Assert
+    assertTrue(signal.isVisibleOnProfile());
+  }
+}

--- a/src/test/java/model/StatusTest.java
+++ b/src/test/java/model/StatusTest.java
@@ -1,0 +1,79 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.Status;
+import model.UserStatus;
+import org.junit.Test;
+
+public class StatusTest {
+  @Test
+  public void StatusTest() throws Exception {
+    // Arrange
+    UserStatus status = UserStatus.ENABLED;
+
+    // Act
+    Status status1 = new Status(status);
+
+    // Assert
+    assertEquals("ENABLED", status1.getStatus());
+  }
+
+  @Test
+  public void StatusTest2() throws Exception {
+    // Arrange
+    String status = "aaaaa";
+
+    // Act
+    Status status1 = new Status(status);
+
+    // Assert
+    assertEquals("aaaaa", status1.getStatus());
+  }
+
+  @Test
+  public void StatusTest3() throws Exception {
+    // Arrange and Act
+    Status status = new Status();
+
+    // Assert
+    assertEquals(null, status.getStatus());
+  }
+
+  @Test
+  public void getStatusTest() throws Exception {
+    // Arrange
+    Status status = new Status();
+
+    // Act
+    String actual = status.getStatus();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setStatusTest() throws Exception {
+    // Arrange
+    Status status = new Status();
+    UserStatus status1 = UserStatus.ENABLED;
+
+    // Act
+    status.setStatus(status1);
+
+    // Assert
+    assertEquals("ENABLED", status.getStatus());
+  }
+
+  @Test
+  public void setStatusTest2() throws Exception {
+    // Arrange
+    Status status = new Status();
+    String status1 = "aaaaa";
+
+    // Act
+    status.setStatus(status1);
+
+    // Assert
+    assertEquals("aaaaa", status.getStatus());
+  }
+}

--- a/src/test/java/model/StreamAttributesTest.java
+++ b/src/test/java/model/StreamAttributesTest.java
@@ -1,0 +1,45 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.StreamAttributes;
+import org.junit.Test;
+
+public class StreamAttributesTest {
+  @Test
+  public void StreamAttributesTest() throws Exception {
+    // Arrange and Act
+    StreamAttributes streamAttributes = new StreamAttributes();
+
+    // Assert
+    assertEquals(null, streamAttributes.getMembers());
+  }
+
+  @Test
+  public void getMembersTest() throws Exception {
+    // Arrange
+    StreamAttributes streamAttributes = new StreamAttributes();
+
+    // Act
+    List<Long> actual = streamAttributes.getMembers();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setMembersTest() throws Exception {
+    // Arrange
+    StreamAttributes streamAttributes = new StreamAttributes();
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act
+    streamAttributes.setMembers(arrayList);
+
+    // Assert
+    assertSame(arrayList, streamAttributes.getMembers());
+  }
+}

--- a/src/test/java/model/StreamInfoListTest.java
+++ b/src/test/java/model/StreamInfoListTest.java
@@ -1,0 +1,16 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.StreamInfoList;
+import org.junit.Test;
+
+public class StreamInfoListTest {
+  @Test
+  public void StreamInfoListTest() throws Exception {
+    // Arrange and Act
+    StreamInfoList streamInfoList = new StreamInfoList();
+
+    // Assert
+    assertEquals(0, streamInfoList.size());
+  }
+}

--- a/src/test/java/model/StreamInfoTest.java
+++ b/src/test/java/model/StreamInfoTest.java
@@ -1,0 +1,217 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.StreamInfo;
+import org.junit.Test;
+
+public class StreamInfoTest {
+  @Test
+  public void StreamInfoTest() throws Exception {
+    // Arrange and Act
+    StreamInfo streamInfo = new StreamInfo();
+
+    // Assert
+    assertEquals(null, streamInfo.getOrigin());
+  }
+
+  @Test
+  public void getActiveTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+
+    // Act
+    Boolean actual = streamInfo.getActive();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCrossPodTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+
+    // Act
+    Boolean actual = streamInfo.getCrossPod();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+
+    // Act
+    String actual = streamInfo.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLastMessageDateTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+
+    // Act
+    Long actual = streamInfo.getLastMessageDate();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getOriginTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+
+    // Act
+    String actual = streamInfo.getOrigin();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomAttributesTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+
+    // Act
+    RoomName actual = streamInfo.getRoomAttributes();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamAttributesTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+
+    // Act
+    StreamAttributes actual = streamInfo.getStreamAttributes();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTypeTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+
+    // Act
+    StreamType actual = streamInfo.getStreamType();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setActiveTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+    Boolean active = new Boolean(true);
+
+    // Act
+    streamInfo.setActive(active);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), streamInfo.getActive());
+  }
+
+  @Test
+  public void setCrossPodTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+    Boolean crossPod = new Boolean(true);
+
+    // Act
+    streamInfo.setCrossPod(crossPod);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), streamInfo.getCrossPod());
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+    String id = "aaaaa";
+
+    // Act
+    streamInfo.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", streamInfo.getId());
+  }
+
+  @Test
+  public void setLastMessageDateTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+    Long lastMessageDate = new Long(1L);
+
+    // Act
+    streamInfo.setLastMessageDate(lastMessageDate);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), streamInfo.getLastMessageDate());
+  }
+
+  @Test
+  public void setOriginTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+    String origin = "aaaaa";
+
+    // Act
+    streamInfo.setOrigin(origin);
+
+    // Assert
+    assertEquals("aaaaa", streamInfo.getOrigin());
+  }
+
+  @Test
+  public void setRoomAttributesTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+    RoomName roomName = new RoomName();
+
+    // Act
+    streamInfo.setRoomAttributes(roomName);
+
+    // Assert
+    assertSame(roomName, streamInfo.getRoomAttributes());
+  }
+
+  @Test
+  public void setStreamAttributesTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+    StreamAttributes streamAttributes = new StreamAttributes();
+
+    // Act
+    streamInfo.setStreamAttributes(streamAttributes);
+
+    // Assert
+    assertSame(streamAttributes, streamInfo.getStreamAttributes());
+  }
+
+  @Test
+  public void setStreamTypeTest() throws Exception {
+    // Arrange
+    StreamInfo streamInfo = new StreamInfo();
+    StreamType streamType = new StreamType();
+
+    // Act
+    streamInfo.setStreamType(streamType);
+
+    // Assert
+    assertSame(streamType, streamInfo.getStreamType());
+  }
+}

--- a/src/test/java/model/StreamListItemTest.java
+++ b/src/test/java/model/StreamListItemTest.java
@@ -1,0 +1,182 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.StreamListItem;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class StreamListItemTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void StreamListItemTest() throws Exception {
+    // Arrange and Act
+    StreamListItem streamListItem = new StreamListItem();
+
+    // Assert
+    assertEquals(null, streamListItem.getStreamType());
+  }
+
+  @Test
+  public void getActiveTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+
+    // Act
+    Boolean actual = streamListItem.getActive();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCrossPodTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+
+    // Act
+    Boolean actual = streamListItem.getCrossPod();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+
+    // Act
+    String actual = streamListItem.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomAttributesTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+
+    // Act
+    RoomName actual = streamListItem.getRoomAttributes();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamAttributesTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+
+    // Act
+    StreamAttributes actual = streamListItem.getStreamAttributes();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTypeTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+
+    // Act
+    TypeObject actual = streamListItem.getStreamType();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTypeTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    streamListItem.getType();
+  }
+
+  @Test
+  public void setActiveTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+    Boolean active = new Boolean(true);
+
+    // Act
+    streamListItem.setActive(active);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), streamListItem.getActive());
+  }
+
+  @Test
+  public void setCrossPodTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+    Boolean crossPod = new Boolean(true);
+
+    // Act
+    streamListItem.setCrossPod(crossPod);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), streamListItem.getCrossPod());
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+    String id = "aaaaa";
+
+    // Act
+    streamListItem.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", streamListItem.getId());
+  }
+
+  @Test
+  public void setRoomAttributesTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+    RoomName roomName = new RoomName();
+
+    // Act
+    streamListItem.setRoomAttributes(roomName);
+
+    // Assert
+    assertSame(roomName, streamListItem.getRoomAttributes());
+  }
+
+  @Test
+  public void setStreamAttributesTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+    StreamAttributes streamAttributes = new StreamAttributes();
+
+    // Act
+    streamListItem.setStreamAttributes(streamAttributes);
+
+    // Assert
+    assertSame(streamAttributes, streamListItem.getStreamAttributes());
+  }
+
+  @Test
+  public void setStreamTypeTest() throws Exception {
+    // Arrange
+    StreamListItem streamListItem = new StreamListItem();
+    TypeObject streamType = new TypeObject();
+
+    // Act
+    streamListItem.setStreamType(streamType);
+
+    // Assert
+    assertEquals(null, streamListItem.getType());
+  }
+}

--- a/src/test/java/model/StreamTest.java
+++ b/src/test/java/model/StreamTest.java
@@ -1,0 +1,170 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.Stream;
+import org.junit.Test;
+
+public class StreamTest {
+  @Test
+  public void StreamTest() throws Exception {
+    // Arrange and Act
+    Stream stream = new Stream();
+
+    // Assert
+    assertEquals(null, stream.getStreamType());
+  }
+
+  @Test
+  public void getCrossPodTest() throws Exception {
+    // Arrange
+    Stream stream = new Stream();
+
+    // Act
+    Boolean actual = stream.getCrossPod();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getExternalTest() throws Exception {
+    // Arrange
+    Stream stream = new Stream();
+
+    // Act
+    Boolean actual = stream.getExternal();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMembersTest() throws Exception {
+    // Arrange
+    Stream stream = new Stream();
+
+    // Act
+    List<User> actual = stream.getMembers();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getRoomNameTest() throws Exception {
+    // Arrange
+    Stream stream = new Stream();
+
+    // Act
+    String actual = stream.getRoomName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamIdTest() throws Exception {
+    // Arrange
+    Stream stream = new Stream();
+
+    // Act
+    String actual = stream.getStreamId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTypeTest() throws Exception {
+    // Arrange
+    Stream stream = new Stream();
+
+    // Act
+    String actual = stream.getStreamType();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setCrossPodTest() throws Exception {
+    // Arrange
+    Stream stream = new Stream();
+    Boolean crossPod = new Boolean(true);
+
+    // Act
+    stream.setCrossPod(crossPod);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), stream.getCrossPod());
+  }
+
+  @Test
+  public void setExternalTest() throws Exception {
+    // Arrange
+    Stream stream = new Stream();
+    Boolean external = new Boolean(true);
+
+    // Act
+    stream.setExternal(external);
+
+    // Assert
+    assertEquals(Boolean.valueOf(true), stream.getExternal());
+  }
+
+  @Test
+  public void setMembersTest() throws Exception {
+    // Arrange
+    Stream stream = new Stream();
+    ArrayList<User> arrayList = new ArrayList<User>();
+    arrayList.add(new User());
+
+    // Act
+    stream.setMembers(arrayList);
+
+    // Assert
+    assertSame(arrayList, stream.getMembers());
+  }
+
+  @Test
+  public void setRoomNameTest() throws Exception {
+    // Arrange
+    Stream stream = new Stream();
+    String roomName = "aaaaa";
+
+    // Act
+    stream.setRoomName(roomName);
+
+    // Assert
+    assertEquals("aaaaa", stream.getRoomName());
+  }
+
+  @Test
+  public void setStreamIdTest() throws Exception {
+    // Arrange
+    Stream stream = new Stream();
+    String streamId = "aaaaa";
+
+    // Act
+    stream.setStreamId(streamId);
+
+    // Assert
+    assertEquals("aaaaa", stream.getStreamId());
+  }
+
+  @Test
+  public void setStreamTypeTest() throws Exception {
+    // Arrange
+    Stream stream = new Stream();
+    String streamType = "aaaaa";
+
+    // Act
+    stream.setStreamType(streamType);
+
+    // Assert
+    assertEquals("aaaaa", stream.getStreamType());
+  }
+}

--- a/src/test/java/model/StreamTypeTest.java
+++ b/src/test/java/model/StreamTypeTest.java
@@ -1,0 +1,39 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.StreamType;
+import model.StreamTypes;
+import org.junit.Test;
+
+public class StreamTypeTest {
+  @Test
+  public void StreamTypeTest() throws Exception {
+    // Arrange and Act
+    StreamType streamType = new StreamType();
+
+    // Assert
+    assertEquals(null, streamType.getType());
+  }
+
+  @Test
+  public void getTypeTest() throws Exception {
+    // Arrange
+    StreamType streamType = new StreamType();
+
+    // Act
+    StreamTypes actual = streamType.getType();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setTypeTest() throws Exception {
+    // Arrange
+    StreamType streamType = new StreamType();
+    StreamTypes type = StreamTypes.IM;
+
+    // Act
+    streamType.setType(type);
+  }
+}

--- a/src/test/java/model/StringIdTest.java
+++ b/src/test/java/model/StringIdTest.java
@@ -1,0 +1,41 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.StringId;
+import org.junit.Test;
+
+public class StringIdTest {
+  @Test
+  public void StringIdTest() throws Exception {
+    // Arrange and Act
+    StringId stringId = new StringId();
+
+    // Assert
+    assertEquals(null, stringId.getId());
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    StringId stringId = new StringId();
+
+    // Act
+    String actual = stringId.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    StringId stringId = new StringId();
+    String id = "aaaaa";
+
+    // Act
+    stringId.setId(id);
+
+    // Assert
+    assertEquals("aaaaa", stringId.getId());
+  }
+}

--- a/src/test/java/model/SuppressionResultTest.java
+++ b/src/test/java/model/SuppressionResultTest.java
@@ -1,0 +1,93 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import model.SuppressionResult;
+import org.junit.Test;
+
+public class SuppressionResultTest {
+  @Test
+  public void SuppressionResultTest() throws Exception {
+    // Arrange and Act
+    SuppressionResult suppressionResult = new SuppressionResult();
+
+    // Assert
+    assertEquals(null, suppressionResult.getMessageId());
+  }
+
+  @Test
+  public void getMessageIdTest() throws Exception {
+    // Arrange
+    SuppressionResult suppressionResult = new SuppressionResult();
+
+    // Act
+    String actual = suppressionResult.getMessageId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSuppressionDateTest() throws Exception {
+    // Arrange
+    SuppressionResult suppressionResult = new SuppressionResult();
+
+    // Act
+    long actual = suppressionResult.getSuppressionDate();
+
+    // Assert
+    assertEquals(0L, actual);
+  }
+
+  @Test
+  public void isSuppressedTest() throws Exception {
+    // Arrange
+    SuppressionResult suppressionResult = new SuppressionResult();
+
+    // Act
+    boolean actual = suppressionResult.isSuppressed();
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void setMessageIdTest() throws Exception {
+    // Arrange
+    SuppressionResult suppressionResult = new SuppressionResult();
+    String messageId = "aaaaa";
+
+    // Act
+    suppressionResult.setMessageId(messageId);
+
+    // Assert
+    assertEquals("aaaaa", suppressionResult.getMessageId());
+  }
+
+  @Test
+  public void setSuppressedTest() throws Exception {
+    // Arrange
+    SuppressionResult suppressionResult = new SuppressionResult();
+    boolean suppressed = true;
+
+    // Act
+    suppressionResult.setSuppressed(suppressed);
+
+    // Assert
+    assertTrue(suppressionResult.isSuppressed());
+  }
+
+  @Test
+  public void setSuppressionDateTest() throws Exception {
+    // Arrange
+    SuppressionResult suppressionResult = new SuppressionResult();
+    long suppressionDate = 1L;
+
+    // Act
+    suppressionResult.setSuppressionDate(suppressionDate);
+
+    // Assert
+    assertEquals(1L, suppressionResult.getSuppressionDate());
+  }
+}

--- a/src/test/java/model/TokenTest.java
+++ b/src/test/java/model/TokenTest.java
@@ -1,0 +1,68 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.Token;
+import org.junit.Test;
+
+public class TokenTest {
+  @Test
+  public void TokenTest() throws Exception {
+    // Arrange and Act
+    Token token = new Token();
+
+    // Assert
+    String name = token.getName();
+    assertEquals(null, name);
+    assertEquals(null, token.getToken());
+  }
+
+  @Test
+  public void getNameTest() throws Exception {
+    // Arrange
+    Token token = new Token();
+
+    // Act
+    String actual = token.getName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTokenTest() throws Exception {
+    // Arrange
+    Token token = new Token();
+
+    // Act
+    String actual = token.getToken();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setNameTest() throws Exception {
+    // Arrange
+    Token token = new Token();
+    String name = "aaaaa";
+
+    // Act
+    token.setName(name);
+
+    // Assert
+    assertEquals("aaaaa", token.getName());
+  }
+
+  @Test
+  public void setTokenTest() throws Exception {
+    // Arrange
+    Token token = new Token();
+    String token1 = "aaaaa";
+
+    // Act
+    token.setToken(token1);
+
+    // Assert
+    assertEquals("aaaaa", token.getToken());
+  }
+}

--- a/src/test/java/model/TypeObjectTest.java
+++ b/src/test/java/model/TypeObjectTest.java
@@ -1,0 +1,41 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.TypeObject;
+import org.junit.Test;
+
+public class TypeObjectTest {
+  @Test
+  public void TypeObjectTest() throws Exception {
+    // Arrange and Act
+    TypeObject typeObject = new TypeObject();
+
+    // Assert
+    assertEquals(null, typeObject.getType());
+  }
+
+  @Test
+  public void getTypeTest() throws Exception {
+    // Arrange
+    TypeObject typeObject = new TypeObject();
+
+    // Act
+    String actual = typeObject.getType();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setTypeTest() throws Exception {
+    // Arrange
+    TypeObject typeObject = new TypeObject();
+    String type = "aaaaa";
+
+    // Act
+    typeObject.setType(type);
+
+    // Assert
+    assertEquals("aaaaa", typeObject.getType());
+  }
+}

--- a/src/test/java/model/UserFilterTest.java
+++ b/src/test/java/model/UserFilterTest.java
@@ -1,0 +1,91 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.UserFilter;
+import org.junit.Test;
+
+public class UserFilterTest {
+  @Test
+  public void UserFilterTest() throws Exception {
+    // Arrange and Act
+    UserFilter userFilter = new UserFilter();
+
+    // Assert
+    assertEquals(null, userFilter.getLocation());
+  }
+
+  @Test
+  public void getCompanyTest() throws Exception {
+    // Arrange
+    UserFilter userFilter = new UserFilter();
+
+    // Act
+    String actual = userFilter.getCompany();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLocationTest() throws Exception {
+    // Arrange
+    UserFilter userFilter = new UserFilter();
+
+    // Act
+    String actual = userFilter.getLocation();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTitleTest() throws Exception {
+    // Arrange
+    UserFilter userFilter = new UserFilter();
+
+    // Act
+    String actual = userFilter.getTitle();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setCompanyTest() throws Exception {
+    // Arrange
+    UserFilter userFilter = new UserFilter();
+    String company = "aaaaa";
+
+    // Act
+    userFilter.setCompany(company);
+
+    // Assert
+    assertEquals("aaaaa", userFilter.getCompany());
+  }
+
+  @Test
+  public void setLocationTest() throws Exception {
+    // Arrange
+    UserFilter userFilter = new UserFilter();
+    String location = "aaaaa";
+
+    // Act
+    userFilter.setLocation(location);
+
+    // Assert
+    assertEquals("aaaaa", userFilter.getLocation());
+  }
+
+  @Test
+  public void setTitleTest() throws Exception {
+    // Arrange
+    UserFilter userFilter = new UserFilter();
+    String title = "aaaaa";
+
+    // Act
+    userFilter.setTitle(title);
+
+    // Assert
+    assertEquals("aaaaa", userFilter.getTitle());
+  }
+}

--- a/src/test/java/model/UserInfoListTest.java
+++ b/src/test/java/model/UserInfoListTest.java
@@ -1,0 +1,46 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.UserInfo;
+import model.UserInfoList;
+import org.junit.Test;
+
+public class UserInfoListTest {
+  @Test
+  public void UserInfoListTest() throws Exception {
+    // Arrange and Act
+    UserInfoList userInfoList = new UserInfoList();
+
+    // Assert
+    assertEquals(null, userInfoList.getUsers());
+  }
+
+  @Test
+  public void getUsersTest() throws Exception {
+    // Arrange
+    UserInfoList userInfoList = new UserInfoList();
+
+    // Act
+    List<UserInfo> actual = userInfoList.getUsers();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setUsersTest() throws Exception {
+    // Arrange
+    UserInfoList userInfoList = new UserInfoList();
+    ArrayList<UserInfo> arrayList = new ArrayList<UserInfo>();
+    arrayList.add(new UserInfo());
+
+    // Act
+    userInfoList.setUsers(arrayList);
+
+    // Assert
+    assertSame(arrayList, userInfoList.getUsers());
+  }
+}

--- a/src/test/java/model/UserInfoTest.java
+++ b/src/test/java/model/UserInfoTest.java
@@ -1,0 +1,395 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.UserInfo;
+import org.junit.Test;
+
+public class UserInfoTest {
+  @Test
+  public void UserInfoTest() throws Exception {
+    // Arrange and Act
+    UserInfo userInfo = new UserInfo();
+
+    // Assert
+    assertEquals(null, userInfo.getLocation());
+  }
+
+  @Test
+  public void getAvatarsTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    List<Avatar> actual = userInfo.getAvatars();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getCompanyTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getCompany();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDepartmentTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getDepartment();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDisplayNameTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getDisplayName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getDivisionTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getDivision();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getEmailAddressTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getEmailAddress();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getFirstNameTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getFirstName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    Long actual = userInfo.getId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getJobFunctionTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getJobFunction();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLastNameTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getLastName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLocationTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getLocation();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getMobilePhoneNumberTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getMobilePhoneNumber();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTitleTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getTitle();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUsernameTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getUsername();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getWorkPhoneNumberTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+
+    // Act
+    String actual = userInfo.getWorkPhoneNumber();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAvatarsTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    ArrayList<Avatar> arrayList = new ArrayList<Avatar>();
+    arrayList.add(new Avatar());
+
+    // Act
+    userInfo.setAvatars(arrayList);
+
+    // Assert
+    assertSame(arrayList, userInfo.getAvatars());
+  }
+
+  @Test
+  public void setCompanyTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String company = "aaaaa";
+
+    // Act
+    userInfo.setCompany(company);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getCompany());
+  }
+
+  @Test
+  public void setDepartmentTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String department = "aaaaa";
+
+    // Act
+    userInfo.setDepartment(department);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getDepartment());
+  }
+
+  @Test
+  public void setDisplayNameTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String displayName = "aaaaa";
+
+    // Act
+    userInfo.setDisplayName(displayName);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getDisplayName());
+  }
+
+  @Test
+  public void setDivisionTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String division = "aaaaa";
+
+    // Act
+    userInfo.setDivision(division);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getDivision());
+  }
+
+  @Test
+  public void setEmailAddressTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String emailAddress = "aaaaa";
+
+    // Act
+    userInfo.setEmailAddress(emailAddress);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getEmailAddress());
+  }
+
+  @Test
+  public void setFirstNameTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String firstName = "aaaaa";
+
+    // Act
+    userInfo.setFirstName(firstName);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getFirstName());
+  }
+
+  @Test
+  public void setIdTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    Long id = new Long(1L);
+
+    // Act
+    userInfo.setId(id);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), userInfo.getId());
+  }
+
+  @Test
+  public void setJobFunctionTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String jobFunction = "aaaaa";
+
+    // Act
+    userInfo.setJobFunction(jobFunction);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getJobFunction());
+  }
+
+  @Test
+  public void setLastNameTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String lastName = "aaaaa";
+
+    // Act
+    userInfo.setLastName(lastName);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getLastName());
+  }
+
+  @Test
+  public void setLocationTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String location = "aaaaa";
+
+    // Act
+    userInfo.setLocation(location);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getLocation());
+  }
+
+  @Test
+  public void setMobilePhoneNumberTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String mobilePhoneNumber = "aaaaa";
+
+    // Act
+    userInfo.setMobilePhoneNumber(mobilePhoneNumber);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getMobilePhoneNumber());
+  }
+
+  @Test
+  public void setTitleTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String title = "aaaaa";
+
+    // Act
+    userInfo.setTitle(title);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getTitle());
+  }
+
+  @Test
+  public void setUsernameTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String username = "aaaaa";
+
+    // Act
+    userInfo.setUsername(username);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getUsername());
+  }
+
+  @Test
+  public void setWorkPhoneNumberTest() throws Exception {
+    // Arrange
+    UserInfo userInfo = new UserInfo();
+    String workPhoneNumber = "aaaaa";
+
+    // Act
+    userInfo.setWorkPhoneNumber(workPhoneNumber);
+
+    // Assert
+    assertEquals("aaaaa", userInfo.getWorkPhoneNumber());
+  }
+}

--- a/src/test/java/model/UserKeyTest.java
+++ b/src/test/java/model/UserKeyTest.java
@@ -1,0 +1,91 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.UserKey;
+import org.junit.Test;
+
+public class UserKeyTest {
+  @Test
+  public void UserKeyTest() throws Exception {
+    // Arrange and Act
+    UserKey userKey = new UserKey();
+
+    // Assert
+    assertEquals(null, userKey.getKey());
+  }
+
+  @Test
+  public void getActionTest() throws Exception {
+    // Arrange
+    UserKey userKey = new UserKey();
+
+    // Act
+    String actual = userKey.getAction();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getExpirationDateTest() throws Exception {
+    // Arrange
+    UserKey userKey = new UserKey();
+
+    // Act
+    Long actual = userKey.getExpirationDate();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getKeyTest() throws Exception {
+    // Arrange
+    UserKey userKey = new UserKey();
+
+    // Act
+    String actual = userKey.getKey();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setActionTest() throws Exception {
+    // Arrange
+    UserKey userKey = new UserKey();
+    String action = "aaaaa";
+
+    // Act
+    userKey.setAction(action);
+
+    // Assert
+    assertEquals("aaaaa", userKey.getAction());
+  }
+
+  @Test
+  public void setExpirationDateTest() throws Exception {
+    // Arrange
+    UserKey userKey = new UserKey();
+    Long expirationDate = new Long(1L);
+
+    // Act
+    userKey.setExpirationDate(expirationDate);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), userKey.getExpirationDate());
+  }
+
+  @Test
+  public void setKeyTest() throws Exception {
+    // Arrange
+    UserKey userKey = new UserKey();
+    String key = "aaaaa";
+
+    // Act
+    userKey.setKey(key);
+
+    // Assert
+    assertEquals("aaaaa", userKey.getKey());
+  }
+}

--- a/src/test/java/model/UserPresenceTest.java
+++ b/src/test/java/model/UserPresenceTest.java
@@ -1,0 +1,91 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.UserPresence;
+import org.junit.Test;
+
+public class UserPresenceTest {
+  @Test
+  public void UserPresenceTest() throws Exception {
+    // Arrange and Act
+    UserPresence userPresence = new UserPresence();
+
+    // Assert
+    assertEquals(null, userPresence.getTimestamp());
+  }
+
+  @Test
+  public void getCategoryTest() throws Exception {
+    // Arrange
+    UserPresence userPresence = new UserPresence();
+
+    // Act
+    String actual = userPresence.getCategory();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getTimestampTest() throws Exception {
+    // Arrange
+    UserPresence userPresence = new UserPresence();
+
+    // Act
+    Long actual = userPresence.getTimestamp();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserIdTest() throws Exception {
+    // Arrange
+    UserPresence userPresence = new UserPresence();
+
+    // Act
+    Long actual = userPresence.getUserId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setCategoryTest() throws Exception {
+    // Arrange
+    UserPresence userPresence = new UserPresence();
+    String category = "aaaaa";
+
+    // Act
+    userPresence.setCategory(category);
+
+    // Assert
+    assertEquals("aaaaa", userPresence.getCategory());
+  }
+
+  @Test
+  public void setTimestampTest() throws Exception {
+    // Arrange
+    UserPresence userPresence = new UserPresence();
+    Long timestamp = new Long(1L);
+
+    // Act
+    userPresence.setTimestamp(timestamp);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), userPresence.getTimestamp());
+  }
+
+  @Test
+  public void setUserIdTest() throws Exception {
+    // Arrange
+    UserPresence userPresence = new UserPresence();
+    Long userId = new Long(1L);
+
+    // Act
+    userPresence.setUserId(userId);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), userPresence.getUserId());
+  }
+}

--- a/src/test/java/model/UserSearchResultTest.java
+++ b/src/test/java/model/UserSearchResultTest.java
@@ -1,0 +1,173 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import model.UserSearchResult;
+import org.junit.Test;
+
+public class UserSearchResultTest {
+  @Test
+  public void UserSearchResultTest() throws Exception {
+    // Arrange and Act
+    UserSearchResult userSearchResult = new UserSearchResult();
+
+    // Assert
+    assertEquals(null, userSearchResult.getQuery());
+  }
+
+  @Test
+  public void getCountTest() throws Exception {
+    // Arrange
+    UserSearchResult userSearchResult = new UserSearchResult();
+
+    // Act
+    int actual = userSearchResult.getCount();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getFiltersTest() throws Exception {
+    // Arrange
+    UserSearchResult userSearchResult = new UserSearchResult();
+
+    // Act
+    Map<String, String> actual = userSearchResult.getFilters();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLimitTest() throws Exception {
+    // Arrange
+    UserSearchResult userSearchResult = new UserSearchResult();
+
+    // Act
+    int actual = userSearchResult.getLimit();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getQueryTest() throws Exception {
+    // Arrange
+    UserSearchResult userSearchResult = new UserSearchResult();
+
+    // Act
+    String actual = userSearchResult.getQuery();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSkipTest() throws Exception {
+    // Arrange
+    UserSearchResult userSearchResult = new UserSearchResult();
+
+    // Act
+    int actual = userSearchResult.getSkip();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getUsersTest() throws Exception {
+    // Arrange
+    UserSearchResult userSearchResult = new UserSearchResult();
+
+    // Act
+    List<UserInfo> actual = userSearchResult.getUsers();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setCountTest() throws Exception {
+    // Arrange
+    UserSearchResult userSearchResult = new UserSearchResult();
+    int count = 1;
+
+    // Act
+    userSearchResult.setCount(count);
+
+    // Assert
+    assertEquals(1, userSearchResult.getCount());
+  }
+
+  @Test
+  public void setFiltersTest() throws Exception {
+    // Arrange
+    UserSearchResult userSearchResult = new UserSearchResult();
+    HashMap<String, String> hashMap = new HashMap<String, String>();
+    hashMap.put("aaaaa", "aaaaa");
+
+    // Act
+    userSearchResult.setFilters(hashMap);
+
+    // Assert
+    assertSame(hashMap, userSearchResult.getFilters());
+  }
+
+  @Test
+  public void setLimitTest() throws Exception {
+    // Arrange
+    UserSearchResult userSearchResult = new UserSearchResult();
+    int limit = 1;
+
+    // Act
+    userSearchResult.setLimit(limit);
+
+    // Assert
+    assertEquals(1, userSearchResult.getLimit());
+  }
+
+  @Test
+  public void setQueryTest() throws Exception {
+    // Arrange
+    UserSearchResult userSearchResult = new UserSearchResult();
+    String query = "aaaaa";
+
+    // Act
+    userSearchResult.setQuery(query);
+
+    // Assert
+    assertEquals("aaaaa", userSearchResult.getQuery());
+  }
+
+  @Test
+  public void setSkipTest() throws Exception {
+    // Arrange
+    UserSearchResult userSearchResult = new UserSearchResult();
+    int skip = 1;
+
+    // Act
+    userSearchResult.setSkip(skip);
+
+    // Assert
+    assertEquals(1, userSearchResult.getSkip());
+  }
+
+  @Test
+  public void setUsersTest() throws Exception {
+    // Arrange
+    UserSearchResult userSearchResult = new UserSearchResult();
+    ArrayList<UserInfo> arrayList = new ArrayList<UserInfo>();
+    arrayList.add(new UserInfo());
+
+    // Act
+    userSearchResult.setUsers(arrayList);
+
+    // Assert
+    assertSame(arrayList, userSearchResult.getUsers());
+  }
+}

--- a/src/test/java/model/UserTest.java
+++ b/src/test/java/model/UserTest.java
@@ -1,0 +1,166 @@
+package model;
+
+import static org.junit.Assert.assertEquals;
+import model.User;
+import org.junit.Test;
+
+public class UserTest {
+  @Test
+  public void UserTest() throws Exception {
+    // Arrange and Act
+    User user = new User();
+
+    // Assert
+    assertEquals(null, user.getLastName());
+  }
+
+  @Test
+  public void getDisplayNameTest() throws Exception {
+    // Arrange
+    User user = new User();
+
+    // Act
+    String actual = user.getDisplayName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getEmailTest() throws Exception {
+    // Arrange
+    User user = new User();
+
+    // Act
+    String actual = user.getEmail();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getFirstNameTest() throws Exception {
+    // Arrange
+    User user = new User();
+
+    // Act
+    String actual = user.getFirstName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLastNameTest() throws Exception {
+    // Arrange
+    User user = new User();
+
+    // Act
+    String actual = user.getLastName();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUserIdTest() throws Exception {
+    // Arrange
+    User user = new User();
+
+    // Act
+    Long actual = user.getUserId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getUsernameTest() throws Exception {
+    // Arrange
+    User user = new User();
+
+    // Act
+    String actual = user.getUsername();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setDisplayNameTest() throws Exception {
+    // Arrange
+    User user = new User();
+    String displayName = "aaaaa";
+
+    // Act
+    user.setDisplayName(displayName);
+
+    // Assert
+    assertEquals("aaaaa", user.getDisplayName());
+  }
+
+  @Test
+  public void setEmailTest() throws Exception {
+    // Arrange
+    User user = new User();
+    String email = "aaaaa";
+
+    // Act
+    user.setEmail(email);
+
+    // Assert
+    assertEquals("aaaaa", user.getEmail());
+  }
+
+  @Test
+  public void setFirstNameTest() throws Exception {
+    // Arrange
+    User user = new User();
+    String firstName = "aaaaa";
+
+    // Act
+    user.setFirstName(firstName);
+
+    // Assert
+    assertEquals("aaaaa", user.getFirstName());
+  }
+
+  @Test
+  public void setLastNameTest() throws Exception {
+    // Arrange
+    User user = new User();
+    String lastName = "aaaaa";
+
+    // Act
+    user.setLastName(lastName);
+
+    // Assert
+    assertEquals("aaaaa", user.getLastName());
+  }
+
+  @Test
+  public void setUserIdTest() throws Exception {
+    // Arrange
+    User user = new User();
+    Long userId = new Long(1L);
+
+    // Act
+    user.setUserId(userId);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), user.getUserId());
+  }
+
+  @Test
+  public void setUsernameTest() throws Exception {
+    // Arrange
+    User user = new User();
+    String username = "aaaaa";
+
+    // Act
+    user.setUsername(username);
+
+    // Assert
+    assertEquals("aaaaa", user.getUsername());
+  }
+}

--- a/src/test/java/model/events/AdminStreamInfoListTest.java
+++ b/src/test/java/model/events/AdminStreamInfoListTest.java
@@ -1,0 +1,147 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.AdminStreamFilter;
+import model.AdminStreamInfo;
+import model.events.AdminStreamInfoList;
+import org.junit.Test;
+
+public class AdminStreamInfoListTest {
+  @Test
+  public void AdminStreamInfoListTest() throws Exception {
+    // Arrange and Act
+    AdminStreamInfoList adminStreamInfoList = new AdminStreamInfoList();
+
+    // Assert
+    assertEquals(0, adminStreamInfoList.getSkip());
+  }
+
+  @Test
+  public void getCountTest() throws Exception {
+    // Arrange
+    AdminStreamInfoList adminStreamInfoList = new AdminStreamInfoList();
+
+    // Act
+    int actual = adminStreamInfoList.getCount();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getFilterTest() throws Exception {
+    // Arrange
+    AdminStreamInfoList adminStreamInfoList = new AdminStreamInfoList();
+
+    // Act
+    AdminStreamFilter actual = adminStreamInfoList.getFilter();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getLimitTest() throws Exception {
+    // Arrange
+    AdminStreamInfoList adminStreamInfoList = new AdminStreamInfoList();
+
+    // Act
+    int actual = adminStreamInfoList.getLimit();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getSkipTest() throws Exception {
+    // Arrange
+    AdminStreamInfoList adminStreamInfoList = new AdminStreamInfoList();
+
+    // Act
+    int actual = adminStreamInfoList.getSkip();
+
+    // Assert
+    assertEquals(0, actual);
+  }
+
+  @Test
+  public void getStreamsTest() throws Exception {
+    // Arrange
+    AdminStreamInfoList adminStreamInfoList = new AdminStreamInfoList();
+
+    // Act
+    List<AdminStreamInfo> actual = adminStreamInfoList.getStreams();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setCountTest() throws Exception {
+    // Arrange
+    AdminStreamInfoList adminStreamInfoList = new AdminStreamInfoList();
+    int count = 1;
+
+    // Act
+    adminStreamInfoList.setCount(count);
+
+    // Assert
+    assertEquals(1, adminStreamInfoList.getCount());
+  }
+
+  @Test
+  public void setFilterTest() throws Exception {
+    // Arrange
+    AdminStreamInfoList adminStreamInfoList = new AdminStreamInfoList();
+    AdminStreamFilter adminStreamFilter = new AdminStreamFilter();
+
+    // Act
+    adminStreamInfoList.setFilter(adminStreamFilter);
+
+    // Assert
+    assertSame(adminStreamFilter, adminStreamInfoList.getFilter());
+  }
+
+  @Test
+  public void setLimitTest() throws Exception {
+    // Arrange
+    AdminStreamInfoList adminStreamInfoList = new AdminStreamInfoList();
+    int limit = 1;
+
+    // Act
+    adminStreamInfoList.setLimit(limit);
+
+    // Assert
+    assertEquals(1, adminStreamInfoList.getLimit());
+  }
+
+  @Test
+  public void setSkipTest() throws Exception {
+    // Arrange
+    AdminStreamInfoList adminStreamInfoList = new AdminStreamInfoList();
+    int skip = 1;
+
+    // Act
+    adminStreamInfoList.setSkip(skip);
+
+    // Assert
+    assertEquals(1, adminStreamInfoList.getSkip());
+  }
+
+  @Test
+  public void setStreamsTest() throws Exception {
+    // Arrange
+    AdminStreamInfoList adminStreamInfoList = new AdminStreamInfoList();
+    ArrayList<AdminStreamInfo> arrayList = new ArrayList<AdminStreamInfo>();
+    arrayList.add(new AdminStreamInfo());
+
+    // Act
+    adminStreamInfoList.setStreams(arrayList);
+
+    // Assert
+    assertSame(arrayList, adminStreamInfoList.getStreams());
+  }
+}

--- a/src/test/java/model/events/ConnectionAcceptedTest.java
+++ b/src/test/java/model/events/ConnectionAcceptedTest.java
@@ -1,0 +1,43 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.User;
+import model.events.ConnectionAccepted;
+import org.junit.Test;
+
+public class ConnectionAcceptedTest {
+  @Test
+  public void ConnectionAcceptedTest() throws Exception {
+    // Arrange and Act
+    ConnectionAccepted connectionAccepted = new ConnectionAccepted();
+
+    // Assert
+    assertEquals(null, connectionAccepted.getFromUser());
+  }
+
+  @Test
+  public void getFromUserTest() throws Exception {
+    // Arrange
+    ConnectionAccepted connectionAccepted = new ConnectionAccepted();
+
+    // Act
+    User actual = connectionAccepted.getFromUser();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setFromUserTest() throws Exception {
+    // Arrange
+    ConnectionAccepted connectionAccepted = new ConnectionAccepted();
+    User user = new User();
+
+    // Act
+    connectionAccepted.setFromUser(user);
+
+    // Assert
+    assertSame(user, connectionAccepted.getFromUser());
+  }
+}

--- a/src/test/java/model/events/ConnectionRequestedTest.java
+++ b/src/test/java/model/events/ConnectionRequestedTest.java
@@ -1,0 +1,43 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.User;
+import model.events.ConnectionRequested;
+import org.junit.Test;
+
+public class ConnectionRequestedTest {
+  @Test
+  public void ConnectionRequestedTest() throws Exception {
+    // Arrange and Act
+    ConnectionRequested connectionRequested = new ConnectionRequested();
+
+    // Assert
+    assertEquals(null, connectionRequested.getToUser());
+  }
+
+  @Test
+  public void getToUserTest() throws Exception {
+    // Arrange
+    ConnectionRequested connectionRequested = new ConnectionRequested();
+
+    // Act
+    User actual = connectionRequested.getToUser();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setToUserTest() throws Exception {
+    // Arrange
+    ConnectionRequested connectionRequested = new ConnectionRequested();
+    User user = new User();
+
+    // Act
+    connectionRequested.setToUser(user);
+
+    // Assert
+    assertSame(user, connectionRequested.getToUser());
+  }
+}

--- a/src/test/java/model/events/IMCreatedTest.java
+++ b/src/test/java/model/events/IMCreatedTest.java
@@ -1,0 +1,43 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.Stream;
+import model.events.IMCreated;
+import org.junit.Test;
+
+public class IMCreatedTest {
+  @Test
+  public void IMCreatedTest() throws Exception {
+    // Arrange and Act
+    IMCreated iMCreated = new IMCreated();
+
+    // Assert
+    assertEquals(null, iMCreated.getStream());
+  }
+
+  @Test
+  public void getStreamTest() throws Exception {
+    // Arrange
+    IMCreated iMCreated = new IMCreated();
+
+    // Act
+    Stream actual = iMCreated.getStream();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setStreamTest() throws Exception {
+    // Arrange
+    IMCreated iMCreated = new IMCreated();
+    Stream stream = new Stream();
+
+    // Act
+    iMCreated.setStream(stream);
+
+    // Assert
+    assertSame(stream, iMCreated.getStream());
+  }
+}

--- a/src/test/java/model/events/MessageSentTest.java
+++ b/src/test/java/model/events/MessageSentTest.java
@@ -1,0 +1,43 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.InboundMessage;
+import model.events.MessageSent;
+import org.junit.Test;
+
+public class MessageSentTest {
+  @Test
+  public void MessageSentTest() throws Exception {
+    // Arrange and Act
+    MessageSent messageSent = new MessageSent();
+
+    // Assert
+    assertEquals(null, messageSent.getMessage());
+  }
+
+  @Test
+  public void getMessageTest() throws Exception {
+    // Arrange
+    MessageSent messageSent = new MessageSent();
+
+    // Act
+    InboundMessage actual = messageSent.getMessage();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setMessageTest() throws Exception {
+    // Arrange
+    MessageSent messageSent = new MessageSent();
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    messageSent.setMessage(inboundMessage);
+
+    // Assert
+    assertSame(inboundMessage, messageSent.getMessage());
+  }
+}

--- a/src/test/java/model/events/MessageSuppressedTest.java
+++ b/src/test/java/model/events/MessageSuppressedTest.java
@@ -1,0 +1,68 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.Stream;
+import model.events.MessageSuppressed;
+import org.junit.Test;
+
+public class MessageSuppressedTest {
+  @Test
+  public void MessageSuppressedTest() throws Exception {
+    // Arrange and Act
+    MessageSuppressed messageSuppressed = new MessageSuppressed();
+
+    // Assert
+    assertEquals(null, messageSuppressed.getMessageId());
+  }
+
+  @Test
+  public void getMessageIdTest() throws Exception {
+    // Arrange
+    MessageSuppressed messageSuppressed = new MessageSuppressed();
+
+    // Act
+    String actual = messageSuppressed.getMessageId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTest() throws Exception {
+    // Arrange
+    MessageSuppressed messageSuppressed = new MessageSuppressed();
+
+    // Act
+    Stream actual = messageSuppressed.getStream();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setMessageIdTest() throws Exception {
+    // Arrange
+    MessageSuppressed messageSuppressed = new MessageSuppressed();
+    String messageId = "aaaaa";
+
+    // Act
+    messageSuppressed.setMessageId(messageId);
+
+    // Assert
+    assertEquals("aaaaa", messageSuppressed.getMessageId());
+  }
+
+  @Test
+  public void setStreamTest() throws Exception {
+    // Arrange
+    MessageSuppressed messageSuppressed = new MessageSuppressed();
+    Stream stream = new Stream();
+
+    // Act
+    messageSuppressed.setStream(stream);
+
+    // Assert
+    assertSame(stream, messageSuppressed.getStream());
+  }
+}

--- a/src/test/java/model/events/RoomCreatedTest.java
+++ b/src/test/java/model/events/RoomCreatedTest.java
@@ -1,0 +1,69 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.RoomProperties;
+import model.Stream;
+import model.events.RoomCreated;
+import org.junit.Test;
+
+public class RoomCreatedTest {
+  @Test
+  public void RoomCreatedTest() throws Exception {
+    // Arrange and Act
+    RoomCreated roomCreated = new RoomCreated();
+
+    // Assert
+    assertEquals(null, roomCreated.getRoomProperties());
+  }
+
+  @Test
+  public void getRoomPropertiesTest() throws Exception {
+    // Arrange
+    RoomCreated roomCreated = new RoomCreated();
+
+    // Act
+    RoomProperties actual = roomCreated.getRoomProperties();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTest() throws Exception {
+    // Arrange
+    RoomCreated roomCreated = new RoomCreated();
+
+    // Act
+    Stream actual = roomCreated.getStream();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setRoomPropertiesTest() throws Exception {
+    // Arrange
+    RoomCreated roomCreated = new RoomCreated();
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    roomCreated.setRoomProperties(roomProperties);
+
+    // Assert
+    assertSame(roomProperties, roomCreated.getRoomProperties());
+  }
+
+  @Test
+  public void setStreamTest() throws Exception {
+    // Arrange
+    RoomCreated roomCreated = new RoomCreated();
+    Stream stream = new Stream();
+
+    // Act
+    roomCreated.setStream(stream);
+
+    // Assert
+    assertSame(stream, roomCreated.getStream());
+  }
+}

--- a/src/test/java/model/events/RoomDeactivatedTest.java
+++ b/src/test/java/model/events/RoomDeactivatedTest.java
@@ -1,0 +1,43 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.Stream;
+import model.events.RoomDeactivated;
+import org.junit.Test;
+
+public class RoomDeactivatedTest {
+  @Test
+  public void RoomDeactivatedTest() throws Exception {
+    // Arrange and Act
+    RoomDeactivated roomDeactivated = new RoomDeactivated();
+
+    // Assert
+    assertEquals(null, roomDeactivated.getStream());
+  }
+
+  @Test
+  public void getStreamTest() throws Exception {
+    // Arrange
+    RoomDeactivated roomDeactivated = new RoomDeactivated();
+
+    // Act
+    Stream actual = roomDeactivated.getStream();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setStreamTest() throws Exception {
+    // Arrange
+    RoomDeactivated roomDeactivated = new RoomDeactivated();
+    Stream stream = new Stream();
+
+    // Act
+    roomDeactivated.setStream(stream);
+
+    // Assert
+    assertSame(stream, roomDeactivated.getStream());
+  }
+}

--- a/src/test/java/model/events/RoomMemberDemotedFromOwnerTest.java
+++ b/src/test/java/model/events/RoomMemberDemotedFromOwnerTest.java
@@ -1,0 +1,69 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.Stream;
+import model.User;
+import model.events.RoomMemberDemotedFromOwner;
+import org.junit.Test;
+
+public class RoomMemberDemotedFromOwnerTest {
+  @Test
+  public void RoomMemberDemotedFromOwnerTest() throws Exception {
+    // Arrange and Act
+    RoomMemberDemotedFromOwner roomMemberDemotedFromOwner = new RoomMemberDemotedFromOwner();
+
+    // Assert
+    assertEquals(null, roomMemberDemotedFromOwner.getAffectedUser());
+  }
+
+  @Test
+  public void getAffectedUserTest() throws Exception {
+    // Arrange
+    RoomMemberDemotedFromOwner roomMemberDemotedFromOwner = new RoomMemberDemotedFromOwner();
+
+    // Act
+    User actual = roomMemberDemotedFromOwner.getAffectedUser();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTest() throws Exception {
+    // Arrange
+    RoomMemberDemotedFromOwner roomMemberDemotedFromOwner = new RoomMemberDemotedFromOwner();
+
+    // Act
+    Stream actual = roomMemberDemotedFromOwner.getStream();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAffectedUserTest() throws Exception {
+    // Arrange
+    RoomMemberDemotedFromOwner roomMemberDemotedFromOwner = new RoomMemberDemotedFromOwner();
+    User user = new User();
+
+    // Act
+    roomMemberDemotedFromOwner.setAffectedUser(user);
+
+    // Assert
+    assertSame(user, roomMemberDemotedFromOwner.getAffectedUser());
+  }
+
+  @Test
+  public void setStreamTest() throws Exception {
+    // Arrange
+    RoomMemberDemotedFromOwner roomMemberDemotedFromOwner = new RoomMemberDemotedFromOwner();
+    Stream stream = new Stream();
+
+    // Act
+    roomMemberDemotedFromOwner.setStream(stream);
+
+    // Assert
+    assertSame(stream, roomMemberDemotedFromOwner.getStream());
+  }
+}

--- a/src/test/java/model/events/RoomMemberPromotedToOwnerTest.java
+++ b/src/test/java/model/events/RoomMemberPromotedToOwnerTest.java
@@ -1,0 +1,69 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.Stream;
+import model.User;
+import model.events.RoomMemberPromotedToOwner;
+import org.junit.Test;
+
+public class RoomMemberPromotedToOwnerTest {
+  @Test
+  public void RoomMemberPromotedToOwnerTest() throws Exception {
+    // Arrange and Act
+    RoomMemberPromotedToOwner roomMemberPromotedToOwner = new RoomMemberPromotedToOwner();
+
+    // Assert
+    assertEquals(null, roomMemberPromotedToOwner.getAffectedUser());
+  }
+
+  @Test
+  public void getAffectedUserTest() throws Exception {
+    // Arrange
+    RoomMemberPromotedToOwner roomMemberPromotedToOwner = new RoomMemberPromotedToOwner();
+
+    // Act
+    User actual = roomMemberPromotedToOwner.getAffectedUser();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTest() throws Exception {
+    // Arrange
+    RoomMemberPromotedToOwner roomMemberPromotedToOwner = new RoomMemberPromotedToOwner();
+
+    // Act
+    Stream actual = roomMemberPromotedToOwner.getStream();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAffectedUserTest() throws Exception {
+    // Arrange
+    RoomMemberPromotedToOwner roomMemberPromotedToOwner = new RoomMemberPromotedToOwner();
+    User user = new User();
+
+    // Act
+    roomMemberPromotedToOwner.setAffectedUser(user);
+
+    // Assert
+    assertSame(user, roomMemberPromotedToOwner.getAffectedUser());
+  }
+
+  @Test
+  public void setStreamTest() throws Exception {
+    // Arrange
+    RoomMemberPromotedToOwner roomMemberPromotedToOwner = new RoomMemberPromotedToOwner();
+    Stream stream = new Stream();
+
+    // Act
+    roomMemberPromotedToOwner.setStream(stream);
+
+    // Assert
+    assertSame(stream, roomMemberPromotedToOwner.getStream());
+  }
+}

--- a/src/test/java/model/events/RoomReactivatedTest.java
+++ b/src/test/java/model/events/RoomReactivatedTest.java
@@ -1,0 +1,43 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.Stream;
+import model.events.RoomReactivated;
+import org.junit.Test;
+
+public class RoomReactivatedTest {
+  @Test
+  public void RoomReactivatedTest() throws Exception {
+    // Arrange and Act
+    RoomReactivated roomReactivated = new RoomReactivated();
+
+    // Assert
+    assertEquals(null, roomReactivated.getStream());
+  }
+
+  @Test
+  public void getStreamTest() throws Exception {
+    // Arrange
+    RoomReactivated roomReactivated = new RoomReactivated();
+
+    // Act
+    Stream actual = roomReactivated.getStream();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setStreamTest() throws Exception {
+    // Arrange
+    RoomReactivated roomReactivated = new RoomReactivated();
+    Stream stream = new Stream();
+
+    // Act
+    roomReactivated.setStream(stream);
+
+    // Assert
+    assertSame(stream, roomReactivated.getStream());
+  }
+}

--- a/src/test/java/model/events/RoomUpdatedTest.java
+++ b/src/test/java/model/events/RoomUpdatedTest.java
@@ -1,0 +1,69 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.RoomProperties;
+import model.Stream;
+import model.events.RoomUpdated;
+import org.junit.Test;
+
+public class RoomUpdatedTest {
+  @Test
+  public void RoomUpdatedTest() throws Exception {
+    // Arrange and Act
+    RoomUpdated roomUpdated = new RoomUpdated();
+
+    // Assert
+    assertEquals(null, roomUpdated.getNewRoomProperties());
+  }
+
+  @Test
+  public void getNewRoomPropertiesTest() throws Exception {
+    // Arrange
+    RoomUpdated roomUpdated = new RoomUpdated();
+
+    // Act
+    RoomProperties actual = roomUpdated.getNewRoomProperties();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTest() throws Exception {
+    // Arrange
+    RoomUpdated roomUpdated = new RoomUpdated();
+
+    // Act
+    Stream actual = roomUpdated.getStream();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setNewRoomPropertiesTest() throws Exception {
+    // Arrange
+    RoomUpdated roomUpdated = new RoomUpdated();
+    RoomProperties roomProperties = new RoomProperties();
+
+    // Act
+    roomUpdated.setNewRoomProperties(roomProperties);
+
+    // Assert
+    assertSame(roomProperties, roomUpdated.getNewRoomProperties());
+  }
+
+  @Test
+  public void setStreamTest() throws Exception {
+    // Arrange
+    RoomUpdated roomUpdated = new RoomUpdated();
+    Stream stream = new Stream();
+
+    // Act
+    roomUpdated.setStream(stream);
+
+    // Assert
+    assertSame(stream, roomUpdated.getStream());
+  }
+}

--- a/src/test/java/model/events/SharedPostTest.java
+++ b/src/test/java/model/events/SharedPostTest.java
@@ -1,0 +1,68 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.InboundMessage;
+import model.events.SharedPost;
+import org.junit.Test;
+
+public class SharedPostTest {
+  @Test
+  public void SharedPostTest() throws Exception {
+    // Arrange and Act
+    SharedPost sharedPost = new SharedPost();
+
+    // Assert
+    assertEquals(null, sharedPost.getMessage());
+  }
+
+  @Test
+  public void getMessageTest() throws Exception {
+    // Arrange
+    SharedPost sharedPost = new SharedPost();
+
+    // Act
+    InboundMessage actual = sharedPost.getMessage();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getSharedMessageTest() throws Exception {
+    // Arrange
+    SharedPost sharedPost = new SharedPost();
+
+    // Act
+    InboundMessage actual = sharedPost.getSharedMessage();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setMessageTest() throws Exception {
+    // Arrange
+    SharedPost sharedPost = new SharedPost();
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    sharedPost.setMessage(inboundMessage);
+
+    // Assert
+    assertSame(inboundMessage, sharedPost.getMessage());
+  }
+
+  @Test
+  public void setSharedMessageTest() throws Exception {
+    // Arrange
+    SharedPost sharedPost = new SharedPost();
+    InboundMessage inboundMessage = new InboundMessage();
+
+    // Act
+    sharedPost.setSharedMessage(inboundMessage);
+
+    // Assert
+    assertSame(inboundMessage, sharedPost.getSharedMessage());
+  }
+}

--- a/src/test/java/model/events/SymphonyElementsActionTest.java
+++ b/src/test/java/model/events/SymphonyElementsActionTest.java
@@ -1,0 +1,122 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.HashMap;
+import java.util.Map;
+import model.events.SymphonyElementsAction;
+import org.junit.Test;
+
+public class SymphonyElementsActionTest {
+  @Test
+  public void SymphonyElementsActionTest() throws Exception {
+    // Arrange and Act
+    SymphonyElementsAction symphonyElementsAction = new SymphonyElementsAction();
+
+    // Assert
+    assertEquals(null, symphonyElementsAction.getStreamType());
+  }
+
+  @Test
+  public void getFormIdTest() throws Exception {
+    // Arrange
+    SymphonyElementsAction symphonyElementsAction = new SymphonyElementsAction();
+
+    // Act
+    String actual = symphonyElementsAction.getFormId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getFormValuesTest() throws Exception {
+    // Arrange
+    SymphonyElementsAction symphonyElementsAction = new SymphonyElementsAction();
+
+    // Act
+    Map<String, Object> actual = symphonyElementsAction.getFormValues();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamIdTest() throws Exception {
+    // Arrange
+    SymphonyElementsAction symphonyElementsAction = new SymphonyElementsAction();
+
+    // Act
+    String actual = symphonyElementsAction.getStreamId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTypeTest() throws Exception {
+    // Arrange
+    SymphonyElementsAction symphonyElementsAction = new SymphonyElementsAction();
+
+    // Act
+    String actual = symphonyElementsAction.getStreamType();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setFormIdTest() throws Exception {
+    // Arrange
+    SymphonyElementsAction symphonyElementsAction = new SymphonyElementsAction();
+    String formId = "aaaaa";
+
+    // Act
+    symphonyElementsAction.setFormId(formId);
+
+    // Assert
+    assertEquals("aaaaa", symphonyElementsAction.getFormId());
+  }
+
+  @Test
+  public void setFormStreamTest() throws Exception {
+    // Arrange
+    SymphonyElementsAction symphonyElementsAction = new SymphonyElementsAction();
+    HashMap<String, String> hashMap = new HashMap<String, String>();
+    hashMap.put("aaaaa", "aaaaa");
+
+    // Act
+    symphonyElementsAction.setFormStream(hashMap);
+
+    // Assert
+    assertEquals(null, symphonyElementsAction.getStreamId());
+  }
+
+  @Test
+  public void setFormValuesTest() throws Exception {
+    // Arrange
+    SymphonyElementsAction symphonyElementsAction = new SymphonyElementsAction();
+    HashMap<String, Object> hashMap = new HashMap<String, Object>();
+    hashMap.put("aaaaa", "aaaaa");
+
+    // Act
+    symphonyElementsAction.setFormValues(hashMap);
+
+    // Assert
+    assertSame(hashMap, symphonyElementsAction.getFormValues());
+  }
+
+  @Test
+  public void setStreamTest() throws Exception {
+    // Arrange
+    SymphonyElementsAction symphonyElementsAction = new SymphonyElementsAction();
+    HashMap<String, String> hashMap = new HashMap<String, String>();
+    hashMap.put("aaaaa", "aaaaa");
+
+    // Act
+    symphonyElementsAction.setStream(hashMap);
+
+    // Assert
+    assertEquals(null, symphonyElementsAction.getStreamType());
+  }
+}

--- a/src/test/java/model/events/UserJoinedRoomTest.java
+++ b/src/test/java/model/events/UserJoinedRoomTest.java
@@ -1,0 +1,69 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.Stream;
+import model.User;
+import model.events.UserJoinedRoom;
+import org.junit.Test;
+
+public class UserJoinedRoomTest {
+  @Test
+  public void UserJoinedRoomTest() throws Exception {
+    // Arrange and Act
+    UserJoinedRoom userJoinedRoom = new UserJoinedRoom();
+
+    // Assert
+    assertEquals(null, userJoinedRoom.getAffectedUser());
+  }
+
+  @Test
+  public void getAffectedUserTest() throws Exception {
+    // Arrange
+    UserJoinedRoom userJoinedRoom = new UserJoinedRoom();
+
+    // Act
+    User actual = userJoinedRoom.getAffectedUser();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTest() throws Exception {
+    // Arrange
+    UserJoinedRoom userJoinedRoom = new UserJoinedRoom();
+
+    // Act
+    Stream actual = userJoinedRoom.getStream();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAffectedUserTest() throws Exception {
+    // Arrange
+    UserJoinedRoom userJoinedRoom = new UserJoinedRoom();
+    User user = new User();
+
+    // Act
+    userJoinedRoom.setAffectedUser(user);
+
+    // Assert
+    assertSame(user, userJoinedRoom.getAffectedUser());
+  }
+
+  @Test
+  public void setStreamTest() throws Exception {
+    // Arrange
+    UserJoinedRoom userJoinedRoom = new UserJoinedRoom();
+    Stream stream = new Stream();
+
+    // Act
+    userJoinedRoom.setStream(stream);
+
+    // Assert
+    assertSame(stream, userJoinedRoom.getStream());
+  }
+}

--- a/src/test/java/model/events/UserLeftRoomTest.java
+++ b/src/test/java/model/events/UserLeftRoomTest.java
@@ -1,0 +1,69 @@
+package model.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import model.Stream;
+import model.User;
+import model.events.UserLeftRoom;
+import org.junit.Test;
+
+public class UserLeftRoomTest {
+  @Test
+  public void UserLeftRoomTest() throws Exception {
+    // Arrange and Act
+    UserLeftRoom userLeftRoom = new UserLeftRoom();
+
+    // Assert
+    assertEquals(null, userLeftRoom.getAffectedUser());
+  }
+
+  @Test
+  public void getAffectedUserTest() throws Exception {
+    // Arrange
+    UserLeftRoom userLeftRoom = new UserLeftRoom();
+
+    // Act
+    User actual = userLeftRoom.getAffectedUser();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getStreamTest() throws Exception {
+    // Arrange
+    UserLeftRoom userLeftRoom = new UserLeftRoom();
+
+    // Act
+    Stream actual = userLeftRoom.getStream();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setAffectedUserTest() throws Exception {
+    // Arrange
+    UserLeftRoom userLeftRoom = new UserLeftRoom();
+    User user = new User();
+
+    // Act
+    userLeftRoom.setAffectedUser(user);
+
+    // Assert
+    assertSame(user, userLeftRoom.getAffectedUser());
+  }
+
+  @Test
+  public void setStreamTest() throws Exception {
+    // Arrange
+    UserLeftRoom userLeftRoom = new UserLeftRoom();
+    Stream stream = new Stream();
+
+    // Act
+    userLeftRoom.setStream(stream);
+
+    // Assert
+    assertSame(stream, userLeftRoom.getStream());
+  }
+}

--- a/src/test/java/services/DatafeedEventsServiceTest.java
+++ b/src/test/java/services/DatafeedEventsServiceTest.java
@@ -1,0 +1,57 @@
+package services;
+
+import static org.junit.Assert.assertEquals;
+import clients.SymBotClient;
+import listeners.ConnectionListener;
+import listeners.DatafeedListener;
+import listeners.ElementsListener;
+import listeners.IMListener;
+import listeners.RoomListener;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.powermock.reflect.Whitebox;
+import services.DatafeedEventsService;
+
+public class DatafeedEventsServiceTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void DatafeedEventsServiceTest() throws Exception {
+    // Arrange
+    SymBotClient client = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    new DatafeedEventsService(client);
+  }
+
+  @Test
+  public void addListenersTest() throws Exception {
+    // Arrange
+    DatafeedEventsService datafeedEventsService = Whitebox.newInstance(DatafeedEventsService.class);
+    DatafeedListener[] datafeedListenerArray = new DatafeedListener[]{Whitebox.newInstance(DatafeedListener.class),
+        Whitebox.newInstance(DatafeedListener.class), Whitebox.newInstance(DatafeedListener.class)};
+
+    // Act
+    datafeedEventsService.addListeners(datafeedListenerArray);
+
+    // Assert
+    assertEquals(3, datafeedListenerArray.length);
+  }
+
+  @Test
+  public void removeListenersTest() throws Exception {
+    // Arrange
+    DatafeedEventsService datafeedEventsService = Whitebox.newInstance(DatafeedEventsService.class);
+    DatafeedListener[] datafeedListenerArray = new DatafeedListener[]{Whitebox.newInstance(DatafeedListener.class),
+        Whitebox.newInstance(DatafeedListener.class), Whitebox.newInstance(DatafeedListener.class)};
+
+    // Act
+    datafeedEventsService.removeListeners(datafeedListenerArray);
+
+    // Assert
+    assertEquals(3, datafeedListenerArray.length);
+  }
+}

--- a/src/test/java/services/FirehoseServiceTest.java
+++ b/src/test/java/services/FirehoseServiceTest.java
@@ -1,0 +1,44 @@
+package services;
+
+import clients.SymBotClient;
+import listeners.FirehoseListener;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.powermock.reflect.Whitebox;
+import services.FirehoseService;
+
+public class FirehoseServiceTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void FirehoseServiceTest() throws Exception {
+    // Arrange
+    SymBotClient client = null;
+    String firehoseId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    new FirehoseService(client, firehoseId);
+  }
+
+  @Test
+  public void FirehoseServiceTest2() throws Exception {
+    // Arrange
+    SymBotClient client = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    new FirehoseService(client);
+  }
+
+  @Test
+  public void readFirehoseTest() throws Exception {
+    // Arrange
+    FirehoseService firehoseService = Whitebox.newInstance(FirehoseService.class);
+
+    // Act
+    firehoseService.readFirehose();
+  }
+}

--- a/src/test/java/utils/CertificateUtilsTest.java
+++ b/src/test/java/utils/CertificateUtilsTest.java
@@ -1,0 +1,22 @@
+package utils;
+
+import java.security.cert.X509Certificate;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import utils.CertificateUtils;
+
+public class CertificateUtilsTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void parseX509CertificateTest() throws Exception {
+    // Arrange
+    String certString = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    CertificateUtils.parseX509Certificate(certString);
+  }
+}

--- a/src/test/java/utils/DataProviderTest.java
+++ b/src/test/java/utils/DataProviderTest.java
@@ -1,0 +1,74 @@
+package utils;
+
+import static org.junit.Assert.assertEquals;
+import clients.SymBotClient;
+import java.net.URI;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.symphonyoss.symphony.messageml.util.IUserPresentation;
+import utils.DataProvider;
+
+public class DataProviderTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void getUserPresentationTest() throws Exception {
+    // Arrange
+    DataProvider dataProvider = new DataProvider(null);
+    Long uid = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    dataProvider.getUserPresentation(uid);
+  }
+
+  @Test
+  public void getUserPresentationTest2() throws Exception {
+    // Arrange
+    DataProvider dataProvider = new DataProvider(null);
+    String email = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    dataProvider.getUserPresentation(email);
+  }
+
+  @Test
+  public void setUserPresentationTest() throws Exception {
+    // Arrange
+    DataProvider dataProvider = new DataProvider(null);
+    long id = 1L;
+    String screenName = "aaaaa";
+    String prettyName = "aaaaa";
+    String email = "aaaaa";
+
+    // Act
+    dataProvider.setUserPresentation(id, screenName, prettyName, email);
+  }
+
+  @Test
+  public void setUserPresentationTest2() throws Exception {
+    // Arrange
+    DataProvider dataProvider = new DataProvider(null);
+    UserPresentation userPresentation = new UserPresentation(1L, "aaaaa", "aaaaa");
+
+    // Act
+    dataProvider.setUserPresentation(userPresentation);
+
+    // Assert
+    assertEquals(1L, userPresentation.getId());
+  }
+
+  @Test
+  public void validateURITest() throws Exception {
+    // Arrange
+    DataProvider dataProvider = new DataProvider(null);
+    URI uri = new URI("aaaaa");
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    dataProvider.validateURI(uri);
+  }
+}

--- a/src/test/java/utils/FormBuilderTest.java
+++ b/src/test/java/utils/FormBuilderTest.java
@@ -1,0 +1,239 @@
+package utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import model.DropdownMenuOption;
+import model.FormButtonType;
+import model.TableSelectPosition;
+import model.TableSelectType;
+import org.junit.Test;
+import utils.FormBuilder;
+
+public class FormBuilderTest {
+  @Test
+  public void addButtonTest() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+    String name = "aaaaa";
+    String display = "aaaaa";
+    FormButtonType type = FormButtonType.ACTION;
+
+    // Act
+    FormBuilder actual = formBuilder.addButton(name, display, type);
+
+    // Assert
+    assertSame(formBuilder, actual);
+  }
+
+  @Test
+  public void addCheckBoxTest() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+    String name = "aaaaa";
+    String display = "aaaaa";
+    String value = "aaaaa";
+    boolean checked = true;
+
+    // Act
+    FormBuilder actual = formBuilder.addCheckBox(name, display, value, checked);
+
+    // Assert
+    assertSame(formBuilder, actual);
+  }
+
+  @Test
+  public void addDivTest() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+    String contents = "aaaaa";
+
+    // Act
+    FormBuilder actual = formBuilder.addDiv(contents);
+
+    // Assert
+    assertSame(formBuilder, actual);
+  }
+
+  @Test
+  public void addDropdownMenuTest() throws Exception {
+    // Arrange
+    String string = "aaaaa";
+    FormBuilder formBuilder = new FormBuilder(string);
+    String name = "aaaaa";
+    boolean required = true;
+    ArrayList<DropdownMenuOption> arrayList = new ArrayList<DropdownMenuOption>();
+    arrayList.add(new DropdownMenuOption("aaaaa", string, true));
+
+    // Act
+    formBuilder.addDropdownMenu(name, required, arrayList);
+
+    // Assert
+    assertEquals(1, arrayList.size());
+  }
+
+  @Test
+  public void addHeaderTest() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+    int size = 1;
+    String text = "aaaaa";
+
+    // Act
+    FormBuilder actual = formBuilder.addHeader(size, text);
+
+    // Assert
+    assertSame(formBuilder, actual);
+  }
+
+  @Test
+  public void addLineBreakTest() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+
+    // Act
+    FormBuilder actual = formBuilder.addLineBreak();
+
+    // Assert
+    assertSame(formBuilder, actual);
+  }
+
+  @Test
+  public void addLineBreaksTest() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+    int quantity = 1;
+
+    // Act
+    FormBuilder actual = formBuilder.addLineBreaks(quantity);
+
+    // Assert
+    assertSame(formBuilder, actual);
+  }
+
+  @Test
+  public void addPersonSelectorTest() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+    String name = "aaaaa";
+    String placeholder = "aaaaa";
+    boolean required = true;
+
+    // Act
+    FormBuilder actual = formBuilder.addPersonSelector(name, placeholder, required);
+
+    // Assert
+    assertSame(formBuilder, actual);
+  }
+
+  @Test
+  public void addRadioButtonTest() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+    String name = "aaaaa";
+    String display = "aaaaa";
+    String value = "aaaaa";
+    boolean checked = true;
+
+    // Act
+    FormBuilder actual = formBuilder.addRadioButton(name, display, value, checked);
+
+    // Assert
+    assertSame(formBuilder, actual);
+  }
+
+  @Test
+  public void addTableSelectTest() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+    String name = "aaaaa";
+    String selectorDisplay = "aaaaa";
+    TableSelectPosition position = TableSelectPosition.LEFT;
+    TableSelectType type = TableSelectType.BUTTON;
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("akaaa");
+    ArrayList<List<String>> arrayList1 = new ArrayList<List<String>>();
+    arrayList1.add(arrayList);
+    ArrayList<String> arrayList2 = new ArrayList<String>();
+    arrayList2.add("aaaaa");
+
+    // Act
+    formBuilder.addTableSelect(name, selectorDisplay, position, type, arrayList, arrayList1, arrayList2);
+
+    // Assert
+    assertEquals(1, arrayList.size());
+  }
+
+  @Test
+  public void addTextAreaTest() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+    String name = "aaaaa";
+    String display = "aaaaa";
+    String placeholder = "aaaaa";
+    boolean required = true;
+
+    // Act
+    FormBuilder actual = formBuilder.addTextArea(name, display, placeholder, required);
+
+    // Assert
+    assertSame(formBuilder, actual);
+  }
+
+  @Test
+  public void addTextFieldTest() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+    String name = "aaaaa";
+    String display = "aaaaa";
+    String placeholder = "aaaaa";
+    boolean required = true;
+    boolean masked = true;
+    int minlength = 1;
+    int maxLength = 1;
+
+    // Act
+    FormBuilder actual = formBuilder.addTextField(name, display, placeholder, required, masked, minlength, maxLength);
+
+    // Assert
+    assertSame(formBuilder, actual);
+  }
+
+  @Test
+  public void addTextFieldTest2() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+    String name = "aaaaa";
+    String display = "aaaaa";
+    String placeholder = "aaaaa";
+    boolean required = true;
+
+    // Act
+    FormBuilder actual = formBuilder.addTextField(name, display, placeholder, required);
+
+    // Assert
+    assertSame(formBuilder, actual);
+  }
+
+  @Test
+  public void builderTest() throws Exception {
+    // Arrange
+    String formId = "aaaaa";
+
+    // Act
+    FormBuilder.builder(formId);
+  }
+
+  @Test
+  public void formatElementTest() throws Exception {
+    // Arrange
+    FormBuilder formBuilder = new FormBuilder("aaaaa");
+
+    // Act
+    String actual = formBuilder.formatElement();
+
+    // Assert
+    assertEquals("<form id=\"aaaaa\"></form>", actual);
+  }
+}

--- a/src/test/java/utils/HttpClientBuilderHelperTest.java
+++ b/src/test/java/utils/HttpClientBuilderHelperTest.java
@@ -1,0 +1,106 @@
+package utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import configuration.SymConfig;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Configuration;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.JerseyClient;
+import org.glassfish.jersey.client.spi.Connector;
+import org.glassfish.jersey.client.spi.ConnectorProvider;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import utils.HttpClientBuilderHelper;
+
+public class HttpClientBuilderHelperTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void getAgentClientConfigTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    ClientConfig actual = HttpClientBuilderHelper.getAgentClientConfig(symConfig);
+
+    // Assert
+    ScheduledExecutorService scheduledExecutorService = actual.getScheduledExecutorService();
+    RuntimeType runtimeType = actual.getRuntimeType();
+    JerseyClient client = actual.getClient();
+    Connector connector = actual.getConnector();
+    assertEquals(null, scheduledExecutorService);
+    assertTrue(actual.getConnectorProvider() instanceof org.glassfish.jersey.client.HttpUrlConnectorProvider);
+    assertEquals(null, connector);
+    assertEquals(null, client);
+    assertEquals(RuntimeType.CLIENT, runtimeType);
+    assertEquals(35000, symConfig.getConnectionTimeout());
+  }
+
+  @Test
+  public void getHttpClientAppBuilderTest() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    HttpClientBuilderHelper.getHttpClientAppBuilder(config);
+  }
+
+  @Test
+  public void getHttpClientBotBuilderTest() throws Exception {
+    // Arrange
+    SymConfig config = new SymConfig();
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    HttpClientBuilderHelper.getHttpClientBotBuilder(config);
+  }
+
+  @Test
+  public void getKMClientConfigTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    ClientConfig actual = HttpClientBuilderHelper.getKMClientConfig(symConfig);
+
+    // Assert
+    ScheduledExecutorService scheduledExecutorService = actual.getScheduledExecutorService();
+    RuntimeType runtimeType = actual.getRuntimeType();
+    JerseyClient client = actual.getClient();
+    Connector connector = actual.getConnector();
+    assertEquals(null, scheduledExecutorService);
+    assertTrue(actual.getConnectorProvider() instanceof org.glassfish.jersey.client.HttpUrlConnectorProvider);
+    assertEquals(null, connector);
+    assertEquals(null, client);
+    assertEquals(RuntimeType.CLIENT, runtimeType);
+    assertEquals(35000, symConfig.getConnectionTimeout());
+  }
+
+  @Test
+  public void getPodClientConfigTest() throws Exception {
+    // Arrange
+    SymConfig symConfig = new SymConfig();
+
+    // Act
+    ClientConfig actual = HttpClientBuilderHelper.getPodClientConfig(symConfig);
+
+    // Assert
+    ScheduledExecutorService scheduledExecutorService = actual.getScheduledExecutorService();
+    RuntimeType runtimeType = actual.getRuntimeType();
+    JerseyClient client = actual.getClient();
+    Connector connector = actual.getConnector();
+    assertEquals(null, scheduledExecutorService);
+    assertTrue(actual.getConnectorProvider() instanceof org.glassfish.jersey.client.HttpUrlConnectorProvider);
+    assertEquals(null, connector);
+    assertEquals(null, client);
+    assertEquals(RuntimeType.CLIENT, runtimeType);
+    assertEquals(35000, symConfig.getConnectionTimeout());
+  }
+}

--- a/src/test/java/utils/JwtHelperTest.java
+++ b/src/test/java/utils/JwtHelperTest.java
@@ -1,0 +1,62 @@
+package utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
+import model.UserInfo;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import sun.security.pkcs.PKCS8Key;
+import utils.JwtHelper;
+
+public class JwtHelperTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void createSignedJwtTest() throws Exception {
+    // Arrange
+    String user = "aaaaa";
+    long expiration = 1L;
+    PKCS8Key privateKey = new PKCS8Key();
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    JwtHelper.createSignedJwt(user, expiration, privateKey);
+  }
+
+  @Test
+  public void parseRSAPrivateKeyTest() throws Exception {
+    // Arrange
+    ByteArrayInputStream pemPrivateKeyFile = new ByteArrayInputStream(
+        new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+    // Act and Assert
+    thrown.expect(GeneralSecurityException.class);
+    JwtHelper.parseRSAPrivateKey(pemPrivateKeyFile);
+  }
+
+  @Test
+  public void parseRSAPrivateKeyTest2() throws Exception {
+    // Arrange
+    File pemPrivateKeyFile = new File("aaaaa");
+
+    // Act and Assert
+    thrown.expect(FileNotFoundException.class);
+    JwtHelper.parseRSAPrivateKey(pemPrivateKeyFile);
+  }
+
+  @Test
+  public void validateJwtTest() throws Exception {
+    // Arrange
+    String jwt = "aaaaa";
+    String certificate = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    JwtHelper.validateJwt(jwt, certificate);
+  }
+}

--- a/src/test/java/utils/SymMessageParserTest.java
+++ b/src/test/java/utils/SymMessageParserTest.java
@@ -1,0 +1,55 @@
+package utils;
+
+import static org.junit.Assert.assertEquals;
+import clients.SymBotClient;
+import java.util.List;
+import model.InboundMessage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.powermock.reflect.Whitebox;
+import utils.SymMessageParser;
+
+public class SymMessageParserTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void createInstanceTest() throws Exception {
+    // Arrange
+    SymBotClient botClient = null;
+
+    // Act
+    SymMessageParser.createInstance(botClient);
+  }
+
+  @Test
+  public void getCashtagsTest() throws Exception {
+    // Arrange
+    InboundMessage message = new InboundMessage();
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymMessageParser.getCashtags(message);
+  }
+
+  @Test
+  public void getHashtagsTest() throws Exception {
+    // Arrange
+    InboundMessage message = new InboundMessage();
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymMessageParser.getHashtags(message);
+  }
+
+  @Test
+  public void getMentionsTest() throws Exception {
+    // Arrange
+    InboundMessage message = new InboundMessage();
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    SymMessageParser.getMentions(message);
+  }
+}

--- a/src/test/java/utils/TagBuilderTest.java
+++ b/src/test/java/utils/TagBuilderTest.java
@@ -1,0 +1,68 @@
+package utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import org.junit.Test;
+import utils.TagBuilder;
+
+public class TagBuilderTest {
+  @Test
+  public void addFieldTest() throws Exception {
+    // Arrange
+    TagBuilder tagBuilder = new TagBuilder("aaaaa");
+    String fieldName = "aaaaa";
+    String fieldValue = "aaaaa";
+
+    // Act
+    TagBuilder actual = tagBuilder.addField(fieldName, fieldValue);
+
+    // Assert
+    assertSame(tagBuilder, actual);
+  }
+
+  @Test
+  public void buildSelfClosingTest() throws Exception {
+    // Arrange
+    TagBuilder tagBuilder = new TagBuilder("aaaaa");
+
+    // Act
+    String actual = tagBuilder.buildSelfClosing();
+
+    // Assert
+    assertEquals("<aaaaa />", actual);
+  }
+
+  @Test
+  public void buildTest() throws Exception {
+    // Arrange
+    TagBuilder tagBuilder = new TagBuilder("aaaaa");
+
+    // Act
+    String actual = tagBuilder.build();
+
+    // Assert
+    assertEquals("<aaaaa>null</aaaaa>", actual);
+  }
+
+  @Test
+  public void builderTest() throws Exception {
+    // Arrange
+    String tagName = "aaaaa";
+
+    // Act
+    TagBuilder.builder(tagName);
+  }
+
+  @Test
+  public void setContentsTest() throws Exception {
+    // Arrange
+    TagBuilder tagBuilder = new TagBuilder("aaaaa");
+    String contents = "aaaaa";
+
+    // Act
+    TagBuilder actual = tagBuilder.setContents(contents);
+
+    // Assert
+    assertSame(tagBuilder, actual);
+  }
+}

--- a/src/test/java/utils/UserPresentationTest.java
+++ b/src/test/java/utils/UserPresentationTest.java
@@ -1,0 +1,96 @@
+package utils;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import utils.UserPresentation;
+
+public class UserPresentationTest {
+  @Test
+  public void UserPresentationTest() throws Exception {
+    // Arrange
+    long id = 1L;
+    String screenName = "aaaaa";
+    String prettyName = "aaaaa";
+    String email = "aaaaa";
+
+    // Act
+    UserPresentation userPresentation = new UserPresentation(id, screenName, prettyName, email);
+
+    // Assert
+    long id1 = userPresentation.getId();
+    String prettyName1 = userPresentation.getPrettyName();
+    String screenName1 = userPresentation.getScreenName();
+    assertEquals(1L, id1);
+    assertEquals("aaaaa", userPresentation.getEmail());
+    assertEquals("aaaaa", screenName1);
+    assertEquals("aaaaa", prettyName1);
+  }
+
+  @Test
+  public void UserPresentationTest2() throws Exception {
+    // Arrange
+    long id = 1L;
+    String screenName = "aaaaa";
+    String prettyName = "aaaaa";
+
+    // Act
+    UserPresentation userPresentation = new UserPresentation(id, screenName, prettyName);
+
+    // Assert
+    long id1 = userPresentation.getId();
+    String prettyName1 = userPresentation.getPrettyName();
+    String screenName1 = userPresentation.getScreenName();
+    assertEquals(1L, id1);
+    assertEquals(null, userPresentation.getEmail());
+    assertEquals("aaaaa", screenName1);
+    assertEquals("aaaaa", prettyName1);
+  }
+
+  @Test
+  public void getEmailTest() throws Exception {
+    // Arrange
+    UserPresentation userPresentation = new UserPresentation(1L, "aaaaa", "aaaaa");
+
+    // Act
+    String actual = userPresentation.getEmail();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    UserPresentation userPresentation = new UserPresentation(1L, "aaaaa", "aaaaa");
+
+    // Act
+    long actual = userPresentation.getId();
+
+    // Assert
+    assertEquals(1L, actual);
+  }
+
+  @Test
+  public void getPrettyNameTest() throws Exception {
+    // Arrange
+    UserPresentation userPresentation = new UserPresentation(1L, "aaaaa", "aaaaa");
+
+    // Act
+    String actual = userPresentation.getPrettyName();
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void getScreenNameTest() throws Exception {
+    // Arrange
+    UserPresentation userPresentation = new UserPresentation(1L, "aaaaa", "aaaaa");
+
+    // Act
+    String actual = userPresentation.getScreenName();
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+}


### PR DESCRIPTION
We have written unit tests using Diffblue Cover's "Essential Tests" feature. 

An Essential Test is a unit test that tests one code-path through a given method. Any objects under tests are initiated with random type specific example data. 

These tests account for `56.24%` (line coverage measured using JaCoCo, when excluding coverage from pre-existing tests) of your project. When including your pre-existing tests, the new coverage figure increases to `68.18%`. The tests were written in approximately 25 seconds.

Please let us know any feedback you have on the tests.