### PR TITLE
PLAT-8645 Added missing params (skip and limit) to streams list

### DIFF
--- a/src/main/java/clients/symphony/api/StreamsClient.java
+++ b/src/main/java/clients/symphony/api/StreamsClient.java
@@ -306,6 +306,7 @@ public class StreamsClient extends APIClient {
      * @param includeInactiveStreams Whether to include inactive conversations.
      * @return a list of all the streams
      * @throws SymClientException the generic client exception
+     * @throws IllegalArgumentException on illegal skip or limit parameter
      */
     public List<StreamListItem> getUserStreams(List<String> streamTypes, boolean includeInactiveStreams)
         throws SymClientException {
@@ -322,6 +323,7 @@ public class StreamsClient extends APIClient {
      * @param limit Maximum number of streams to return. If 0, all user streams will be returned.
      * @return a list of all the streams
      * @throws SymClientException the generic client exception
+     * @throws IllegalArgumentException on illegal skip or limit parameter
      */
     public List<StreamListItem> getUserStreams(List<String> streamTypes, boolean includeInactiveStreams, int skip, int limit)
         throws SymClientException {

--- a/src/main/java/clients/symphony/api/StreamsClient.java
+++ b/src/main/java/clients/symphony/api/StreamsClient.java
@@ -294,8 +294,47 @@ public class StreamsClient extends APIClient {
         }
     }
 
+    /**
+     * Returns a list of all the streams of which the requesting user is a member,
+     * sorted by creation date (ascending - oldest to newest).
+     *
+     * <p>
+     *   skip and limit parameters are set to default : skip=0 and limit=50.
+     * </p>
+     *
+     * @param streamTypes A list of stream types that will be returned.
+     * @param includeInactiveStreams Whether to include inactive conversations.
+     * @return a list of all the streams
+     * @throws SymClientException the generic client exception
+     */
     public List<StreamListItem> getUserStreams(List<String> streamTypes, boolean includeInactiveStreams)
         throws SymClientException {
+        return this.getUserStreams(streamTypes, includeInactiveStreams, 0, 50);
+    }
+
+    /**
+     * Returns a list of all the streams of which the requesting user is a member,
+     * sorted by creation date (ascending - oldest to newest).
+     *
+     * @param streamTypes A list of stream types that will be returned.
+     * @param includeInactiveStreams Whether to include inactive conversations.
+     * @param skip Number of stream results to skip.
+     * @param limit Maximum number of streams to return. If 0, all user streams will be returned.
+     * @return a list of all the streams
+     * @throws SymClientException the generic client exception
+     */
+    public List<StreamListItem> getUserStreams(List<String> streamTypes, boolean includeInactiveStreams, int skip, int limit)
+        throws SymClientException {
+
+        if(skip < 0) {
+            throw new IllegalArgumentException("skip must be equal or greater than 0.");
+        }
+
+
+        if(limit < 0) {
+            throw new IllegalArgumentException("limit must be equal or greater than 0.");
+        }
+
         List<Map> inputStreamTypes = new ArrayList<>();
         if (streamTypes != null) {
             for (String type : streamTypes) {
@@ -311,6 +350,8 @@ public class StreamsClient extends APIClient {
         Invocation.Builder builder = botClient.getPodClient()
             .target(botClient.getConfig().getPodUrl())
             .path(PodConstants.LISTUSERSTREAMS)
+            .queryParam("skip", skip)
+            .queryParam("limit", limit)
             .request(MediaType.APPLICATION_JSON)
             .header("sessionToken", botClient.getSymAuth().getSessionToken());
 

--- a/src/main/java/clients/symphony/api/StreamsClient.java
+++ b/src/main/java/clients/symphony/api/StreamsClient.java
@@ -330,7 +330,6 @@ public class StreamsClient extends APIClient {
             throw new IllegalArgumentException("skip must be equal or greater than 0.");
         }
 
-
         if(limit < 0) {
             throw new IllegalArgumentException("limit must be equal or greater than 0.");
         }

--- a/src/test/java/it/clients/symphony/api/StreamsClientTest.java
+++ b/src/test/java/it/clients/symphony/api/StreamsClientTest.java
@@ -3,6 +3,8 @@ package it.clients.symphony.api;
 import clients.symphony.api.StreamsClient;
 import clients.symphony.api.constants.PodConstants;
 import it.commons.BotTest;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -458,7 +460,7 @@ public class StreamsClientTest extends BotTest {
 
   @Test
   public void getUserStreamsSuccess() {
-    stubFor(post(urlEqualTo(PodConstants.LISTUSERSTREAMS))
+    stubFor(post(urlEqualTo(PodConstants.LISTUSERSTREAMS + "?skip=0&limit=50"))
         .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
         .willReturn(aResponse()
             .withStatus(200)
@@ -484,5 +486,15 @@ public class StreamsClientTest extends BotTest {
 
     assertNotNull(streamsList);
     assertEquals(1, streamsList.size());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void failToGetUserStreamsWithIllegalSkipValue() {
+    this.streamsClient.getUserStreams(Collections.emptyList(), true, -1, 0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void failToGetUserStreamsWithIllegalLimitValue() {
+    this.streamsClient.getUserStreams(Collections.emptyList(), true, 0, -1);
   }
 }


### PR DESCRIPTION
Related endpoint : [#list-user-streams](https://developers.symphony.com/restapi/reference#list-user-streams)

### Purpose

When using the `StreamsClient.getUserStreams` function to list the user streams, there is no provision to allow the user to pass the `skip` or `limit` parameter, making the function limited to returning the 50 first rooms.

### What has been done

Prototype of the existing `getUserStreams(List<String>, boolean)` has been preserved for backward compatibility purpose. An additional method has been introduced including the `limit` and `skip` parameters : 

```java
public List<StreamListItem> getUserStreams(List<String>, boolean, int skip, int limit);
```

This method also checks that those parameters are not lower than 0. 