### PR TITLE
PLAT-8662 Enhanced exception handling in DatafeedEventsService

### DIFF
--- a/src/main/java/clients/symphony/api/StreamsClient.java
+++ b/src/main/java/clients/symphony/api/StreamsClient.java
@@ -328,11 +328,11 @@ public class StreamsClient extends APIClient {
     public List<StreamListItem> getUserStreams(List<String> streamTypes, boolean includeInactiveStreams, int skip, int limit)
         throws SymClientException {
 
-        if(skip < 0) {
+        if (skip < 0) {
             throw new IllegalArgumentException("skip must be equal or greater than 0.");
         }
 
-        if(limit < 0) {
+        if (limit < 0) {
             throw new IllegalArgumentException("limit must be equal or greater than 0.");
         }
 

--- a/src/main/java/services/DatafeedEventsService.java
+++ b/src/main/java/services/DatafeedEventsService.java
@@ -41,7 +41,6 @@ public class DatafeedEventsService {
     private static int THREADPOOL_SIZE;
     private static int TIMEOUT_NO_OF_SECS;
 
-
     public DatafeedEventsService(SymBotClient client) {
         this.roomListeners = new ArrayList<>();
         this.imListeners = new ArrayList<>();
@@ -244,7 +243,7 @@ public class DatafeedEventsService {
             TimeUnit.SECONDS.sleep(TIMEOUT_NO_OF_SECS);
 
             // exponential backoff until we reach the MAX_BACKOFF_TIME (5 minutes)
-            if(TIMEOUT_NO_OF_SECS*2 <= MAX_BACKOFF_TIME) {
+            if (TIMEOUT_NO_OF_SECS * 2 <= MAX_BACKOFF_TIME) {
                 TIMEOUT_NO_OF_SECS *= 2;
             } else {
                 TIMEOUT_NO_OF_SECS = MAX_BACKOFF_TIME;

--- a/src/main/java/services/DatafeedEventsService.java
+++ b/src/main/java/services/DatafeedEventsService.java
@@ -83,7 +83,7 @@ public class DatafeedEventsService {
             try {
                 datafeedId = datafeedClient.createDatafeed();
                 resetTimeout();
-            } catch (ProcessingException e) {
+            } catch (Exception e) {
                 handleError(e);
             }
         }
@@ -219,7 +219,7 @@ public class DatafeedEventsService {
         } else if (errMsg.contains("Could not find a datafeed with the")) {
             logger.error(errMsg);
         } else {
-            logger.error("HandlerError error", e);
+            logger.error("An unknown error happened, type : " + e.getClass(), e);
         }
 
         sleep();
@@ -231,7 +231,7 @@ public class DatafeedEventsService {
             }
             datafeedId = datafeedClient.createDatafeed();
             resetTimeout();
-        } catch (SymClientException e1) {
+        } catch (Exception e1) {
             sleep();
             handleError(e);
         }


### PR DESCRIPTION
### Purpose

The Datafeed loop has failed because of an unknown exception has happened : `SocketTimeoutException`. 

### What has been done

The `ProcessingException` and the `SymClientException` that were previously caught have been replaced `Exception` to make sure that the error handling will be processed for any kind of exception.