### PR TITLE
PLAT-8660 Set Cache-Control header value to no-cache

### DIFF
--- a/src/main/java/utils/HttpClientBuilderHelper.java
+++ b/src/main/java/utils/HttpClientBuilderHelper.java
@@ -12,6 +12,8 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import utils.jersey.NoCacheFeature;
+
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class HttpClientBuilderHelper {
@@ -24,6 +26,9 @@ public class HttpClientBuilderHelper {
         if (config.getTruststorePath() != null && jksStore != null) {
             loadTrustStore(config, jksStore, clientBuilder);
         }
+
+        clientBuilder.register(NoCacheFeature.class);
+
         return clientBuilder;
     }
 
@@ -43,6 +48,8 @@ public class HttpClientBuilderHelper {
         if (config.getTruststorePath() != null && jksStore != null) {
             loadTrustStore(config, jksStore, clientBuilder);
         }
+        clientBuilder.register(NoCacheFeature.class);
+
         return clientBuilder;
     }
 
@@ -62,6 +69,9 @@ public class HttpClientBuilderHelper {
         if (config.getTruststorePath() != null && jksStore != null) {
             loadTrustStore(config, jksStore, clientBuilder);
         }
+
+        clientBuilder.register(NoCacheFeature.class);
+
         return clientBuilder;
     }
 
@@ -110,6 +120,8 @@ public class HttpClientBuilderHelper {
                 clientConfig.property(ClientProperties.PROXY_PASSWORD, proxyPass);
             }
         }
+
+        clientConfig.register(NoCacheFeature.class);
 
         return clientConfig;
     }

--- a/src/main/java/utils/jersey/NoCacheFeature.java
+++ b/src/main/java/utils/jersey/NoCacheFeature.java
@@ -1,0 +1,20 @@
+package utils.jersey;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+
+/**
+ * Simple Jersey {@link javax.ws.rs.client.Client} feature that set Cache-Control header value to no-cache. That feature
+ * can be applied to any ongoing request.
+ *
+ * @author Thibault Pensec
+ * @since 24/02/2020
+ */
+public class NoCacheFeature implements ClientRequestFilter {
+
+  @Override
+  public void filter(ClientRequestContext requestContext) {
+    requestContext.getHeaders().add(HttpHeaders.CACHE_CONTROL, "no-cache");
+  }
+}


### PR DESCRIPTION
### What has been done

Added Cache-Control no-cache to all API calls to avoid the sessionToken to be cached.

Opened in favour of https://github.com/SymphonyPlatformSolutions/symphony-api-client-java/pull/91