### PR TITLE
PLAT-9037 Adding 'quickws' to be accepted as a valid uri scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ can exclude the bot certificate section, all extension app sections and all opti
     
     // Optional: Request filter pattern to verify JWT
     "authenticationFilterUrlPattern": "/v1/",
+    
+    // Optional: If custom URI schemes need to be supported by MessageML parser 
+                 By setting this property, the default schemes (http and https) will be overridden
+    "supportedUriSchemes": ["http", "https", "customScheme"],
 }
 ```
 

--- a/src/main/java/configuration/SymConfig.java
+++ b/src/main/java/configuration/SymConfig.java
@@ -2,6 +2,8 @@ package configuration;
 
 import clients.symphony.api.constants.CommonConstants;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.ArrayList;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -45,6 +47,7 @@ public class SymConfig {
     private String authenticationFilterUrlPattern;
     private boolean showFirehoseErrors;
     private int connectionTimeout;
+    private ArrayList<String> supportedUriSchemes = new ArrayList<>();
 
     public String getSessionAuthHost() {
         return sessionAuthHost;
@@ -376,5 +379,9 @@ public class SymConfig {
     public String getSessionAuthUrl() {
         String port = (sessionAuthPort == 443) ? "" : ":" + sessionAuthPort;
         return CommonConstants.HTTPS_PREFIX + sessionAuthHost + port;
+    }
+    
+    public ArrayList<String> getSupportedUriSchemes() {
+        return supportedUriSchemes;
     }
 }

--- a/src/main/java/utils/DataProvider.java
+++ b/src/main/java/utils/DataProvider.java
@@ -22,6 +22,7 @@ public class DataProvider implements IDataProvider {
     public DataProvider(SymBotClient botClient) {
         STANDARD_URI_SCHEMES.add("http");
         STANDARD_URI_SCHEMES.add("https");
+        STANDARD_URI_SCHEMES.add("quickws");
         this.botClient = botClient;
     }
 

--- a/src/main/java/utils/DataProvider.java
+++ b/src/main/java/utils/DataProvider.java
@@ -20,10 +20,17 @@ public class DataProvider implements IDataProvider {
     private SymBotClient botClient;
 
     public DataProvider(SymBotClient botClient) {
-        STANDARD_URI_SCHEMES.add("http");
-        STANDARD_URI_SCHEMES.add("https");
-        STANDARD_URI_SCHEMES.add("quickws");
         this.botClient = botClient;
+        
+        if(!this.botClient.getConfig().getSupportedUriSchemes().isEmpty()) {
+            for (String uriScheme : this.botClient.getConfig().getSupportedUriSchemes()) {
+                STANDARD_URI_SCHEMES.add(uriScheme);
+            }
+        }
+        else {
+            STANDARD_URI_SCHEMES.add("http");
+            STANDARD_URI_SCHEMES.add("https");
+        }
     }
 
     @Override


### PR DESCRIPTION
Bug details on https://perzoinc.atlassian.net/browse/PLAT-9037
I'm adding the 'quickws' to be accepted as a valid URI scheme on Java SDK implementation of IDataProvider's validateURI method.