### PR TITLE
SDK-75 Fixed random SSL issues for RSA authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ can exclude the bot certificate section, all extension app sections and all opti
     // Optional: If custom URI schemes need to be supported by MessageML parser 
                  By setting this property, the default schemes (http and https) will be overridden
     "supportedUriSchemes": ["http", "https", "customScheme"],
+  
+    // Optional/experimental: exponential backoff configuration for retryiable actions
+    "retry": {
+        "maxAttempts": 10,
+        "initialIntervalMillis": 500,
+        "multiplier": 1.5
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ can exclude the bot certificate section, all extension app sections and all opti
                  By setting this property, the default schemes (http and https) will be overridden
     "supportedUriSchemes": ["http", "https", "customScheme"],
   
-    // Optional/experimental: exponential backoff configuration for retryiable actions
+    // Optional/experimental: exponential backoff configuration for retries
     "retry": {
         "maxAttempts": 10,
         "initialIntervalMillis": 500,

--- a/pom.xml
+++ b/pom.xml
@@ -9,38 +9,151 @@
     <url>https://github.com/SymphonyPlatformSolutions/symphony-api-client-java</url>
     <description>Symphony API Client provided by Symphony Platform Solutions team</description>
 
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <name>Symphony Platform Solutions</name>
-            <email>platformsolutions@symphony.com</email>
-            <organization>Symphony Communication Services</organization>
-            <organizationUrl>https://symphony.com/</organizationUrl>
-        </developer>
-    </developers>
-
-    <scm>
-        <connection>scm:git:git://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git</connection>
-        <developerConnection>scm:git:ssh://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git</developerConnection>
-        <url>https://github.com/SymphonyPlatformSolutions/symphony-api-client-java</url>
-    </scm>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jjwt.version>0.9.1</jjwt.version>
+
+        <!-- Dependencies versions (alphabetical order) -->
+        <apiguardian-api.version>1.1.0</apiguardian-api.version>
+        <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-codec.version>1.14</commons-codec.version>
         <commons-io.version>2.6</commons-io.version>
-        <commons-beanutils.version>1.9.4</commons-beanutils.version>
+        <jackson.version>2.11.0</jackson.version>
         <jersey.version>2.30</jersey.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <jjwt.version>0.9.1</jjwt.version>
         <lombok.version>1.18.10</lombok.version>
+        <messageml.version>0.9.51</messageml.version>
+        <resilience4j-retry.version>1.4.0</resilience4j-retry.version>
+        <jsr305.version>3.0.2</jsr305.version>
+        <slf4j.version>1.7.30</slf4j.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-retry</artifactId>
+            <version>${resilience4j-retry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${jsr305.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apiguardian</groupId>
+            <artifactId>apiguardian-api</artifactId>
+            <version>${apiguardian-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-apache-connector</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.symphonyoss.symphony</groupId>
+            <artifactId>messageml</artifactId>
+            <version>${messageml.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>${commons-beanutils.version}</version>
+        </dependency>
+        <dependency>
+            <!-- TODO /!\ TO BE REMOVED /!\ -->
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <!-- TODO /!\ TO BE REMOVED /!\ -->
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+            <version>0.7.1</version>
+        </dependency>
+
+        <!-- Testing dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.26.3</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
 
     <build>
         <plugins>
@@ -145,114 +258,6 @@
         </plugins>
     </build>
 
-    <dependencies>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.10.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-multipart</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.connectors</groupId>
-            <artifactId>jersey-apache-connector</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.inject</groupId>
-            <artifactId>jersey-hk2</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.symphonyoss.symphony</groupId>
-            <artifactId>messageml</artifactId>
-            <version>0.9.47</version>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
-            <version>${jjwt.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>${commons-codec.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>${commons-beanutils.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.bitbucket.b_c</groupId>
-            <artifactId>jose4j</artifactId>
-            <version>0.7.0</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
-            <version>2.25.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>javax.activation-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-    </dependencies>
-
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -293,4 +298,27 @@
             </build>
         </profile>
     </profiles>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Symphony Platform Solutions</name>
+            <email>platformsolutions@symphony.com</email>
+            <organization>Symphony Communication Services</organization>
+            <organizationUrl>https://symphony.com/</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git</connection>
+        <developerConnection>scm:git:ssh://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git</developerConnection>
+        <url>https://github.com/SymphonyPlatformSolutions/symphony-api-client-java</url>
+    </scm>
+
 </project>

--- a/src/lombok.config
+++ b/src/lombok.config
@@ -1,0 +1,1 @@
+lombok.log.fieldName=logger

--- a/src/main/java/authentication/ISymAuth.java
+++ b/src/main/java/authentication/ISymAuth.java
@@ -3,12 +3,16 @@ package authentication;
 import exceptions.AuthenticationException;
 
 public interface ISymAuth {
+
     void authenticate() throws AuthenticationException;
     void sessionAuthenticate() throws AuthenticationException;
     void kmAuthenticate() throws AuthenticationException;
+
     String getSessionToken();
-    void setSessionToken(String sessionToken);
+    @Deprecated void setSessionToken(String sessionToken);
+
     String getKmToken();
-    void setKmToken(String kmToken);
+    @Deprecated void setKmToken(String kmToken);
+
     void logout();
 }

--- a/src/main/java/authentication/SymBotRSAAuth.java
+++ b/src/main/java/authentication/SymBotRSAAuth.java
@@ -79,8 +79,8 @@ public class SymBotRSAAuth extends APIClient implements ISymAuth {
             .maxAttempts(this.config.getRetry().getMaxAttempts())
             .intervalFunction(IntervalFunction.ofExponentialBackoff(
                 this.config.getRetry().getInitialIntervalMillis(),
-                this.config.getRetry().getMultiplier())
-            )
+                this.config.getRetry().getMultiplier()
+            ))
             .build();
 
         final RetryRegistry registry = RetryRegistry.of(config);

--- a/src/main/java/authentication/SymBotRSAAuth.java
+++ b/src/main/java/authentication/SymBotRSAAuth.java
@@ -1,54 +1,56 @@
 package authentication;
 
-import clients.ISymClient;
+import static internal.jersey.JerseyHelper.isNotSuccess;
+import static internal.jersey.JerseyHelper.isSuccess;
+
 import clients.symphony.api.APIClient;
 import clients.symphony.api.constants.CommonConstants;
 import configuration.SymConfig;
 import exceptions.AuthenticationException;
-import exceptions.SymClientException;
-import java.io.*;
-import java.security.GeneralSecurityException;
+import internal.FileHelper;
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.retry.RetryRegistry;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import model.Token;
+import org.glassfish.jersey.client.ClientConfig;
+import utils.HttpClientBuilderHelper;
+import utils.JwtHelper;
+
+import java.io.IOException;
 import java.security.PrivateKey;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.*;
+import java.util.concurrent.TimeoutException;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import model.Token;
-import org.glassfish.jersey.client.ClientConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import utils.HttpClientBuilderHelper;
-import utils.JwtHelper;
+import javax.xml.ws.WebServiceException;
 
+@Slf4j
 public class SymBotRSAAuth extends APIClient implements ISymAuth {
-    private final Logger logger = LoggerFactory.getLogger(SymBotRSAAuth.class);
-    private String sessionToken = null;
-    private String kmToken = null;
-    private SymConfig config;
-    private Client sessionAuthClient;
-    private Client kmAuthClient;
+
+    private final SymConfig config;
+    private final Client sessionAuthClient;
+    private final Client kmAuthClient;
+
+    private String sessionToken;
+    private String kmToken;
     private String jwt;
-    private long lastAuthTime = 0;
-    private int authRetries = 0;
 
     public SymBotRSAAuth(SymConfig config) {
-        this.config = config;
-        ClientBuilder clientBuilder = HttpClientBuilderHelper.getHttpClientBuilderWithTruststore(config);
-        Client client = clientBuilder.build();
-
-        this.sessionAuthClient = client;
-        this.kmAuthClient = client;
-
-        ClientConfig clientConfig = HttpClientBuilderHelper.getPodClientConfig(config);
-        ClientConfig kmClientConfig = HttpClientBuilderHelper.getKMClientConfig(config);
-
-        this.sessionAuthClient = clientBuilder.withConfig(clientConfig).build();
-        this.kmAuthClient = clientBuilder.withConfig(kmClientConfig).build();
+        this(
+            config,
+            HttpClientBuilderHelper.getPodClientConfig(config),
+            HttpClientBuilderHelper.getKMClientConfig(config)
+        );
     }
 
     public SymBotRSAAuth(SymConfig config, ClientConfig sessionAuthClientConfig, ClientConfig kmAuthClientConfig) {
@@ -67,157 +69,53 @@ public class SymBotRSAAuth extends APIClient implements ISymAuth {
     }
 
     @Override
+    @SneakyThrows
     public void authenticate() throws AuthenticationException {
-        PrivateKey privateKey = null;
-        try {
-            privateKey = JwtHelper.parseRSAPrivateKey(this.getRSAPrivateKeyFile(this.config));
-        } catch (IOException | GeneralSecurityException e) {
-            logger.error("Error trying to parse RSA private key", e);
-        }
-        if (lastAuthTime == 0 || System.currentTimeMillis() - lastAuthTime > AuthEndpointConstants.WAIT_TIME) {
-            logger.info("Last auth time was {}", lastAuthTime);
-            logger.info("Now is {}", System.currentTimeMillis());
-            jwt = JwtHelper.createSignedJwt(config.getBotUsername(), AuthEndpointConstants.JWT_EXPIRY_MS, privateKey);
 
-            ExecutorService executor = Executors.newFixedThreadPool(2);
-            Future<AuthenticationException> sessionAuthFuture = executor.submit(() -> {
-                try {
-                    sessionAuthenticate();
-                    return null;
-                } catch (AuthenticationException e) {
-                    return e;
-                }
-            });
-            Future<AuthenticationException> kmAuthFuture = executor.submit(() -> {
-                try {
-                    kmAuthenticate();
-                    return null;
-                } catch (AuthenticationException e) {
-                    return e;
-                }
-            });
-            executor.shutdown();
+        this.jwt = JwtHelper.createSignedJwt(this.config.getBotUsername(), AuthEndpointConstants.JWT_EXPIRY_MS, this.loadPrivateKey());
 
-            try {
-                int connectionTimeout = config.getConnectionTimeout();
-                if (connectionTimeout == 0) {
-                    connectionTimeout = 35000;
-                }
-                executor.awaitTermination(connectionTimeout, TimeUnit.MILLISECONDS);
-                executor.shutdownNow();
-                if (!executor.isTerminated()) {
-                    throw new AuthenticationException(new Exception("Timeout"));
-                }
-            } catch (InterruptedException e) {
-                throw new RuntimeException("Termination Interrupted");
-            }
+        logger.debug("RSA authentication with retry : {}", this.config.getRetry());
+        final RetryConfig config = RetryConfig.custom()
+            .maxAttempts(this.config.getRetry().getMaxAttempts())
+            .intervalFunction(IntervalFunction.ofExponentialBackoff(
+                this.config.getRetry().getInitialIntervalMillis(),
+                this.config.getRetry().getMultiplier())
+            )
+            .build();
 
-            try {
-                if (sessionAuthFuture.get() != null) {
-                    throw sessionAuthFuture.get();
-                }
-                if (kmAuthFuture.get() != null) {
-                    throw kmAuthFuture.get();
-                }
-            } catch (InterruptedException | ExecutionException e) {
-                logger.error("Interrupted Exception");
-            }
+        final RetryRegistry registry = RetryRegistry.of(config);
 
-            lastAuthTime = System.currentTimeMillis();
-        } else {
-            try {
-                logger.info("Re-authenticated too fast. Wait 30 seconds to try again.");
-                TimeUnit.SECONDS.sleep(AuthEndpointConstants.TIMEOUT);
-                authenticate();
-            } catch (InterruptedException e) {
-                logger.error("Error with authentication", e);
-            }
-        }
-    }
+        registry.retry("Session auth").executeCheckedSupplier(() -> {
+            this.sessionAuthenticate();
+            return null;
+        });
 
-    protected InputStream getRSAPrivateKeyFile(final SymConfig config) throws FileNotFoundException {
-        final String dirPath = config.getBotPrivateKeyPath();
-        final String keyName = config.getBotPrivateKeyName();
-        final String path = dirPath + (dirPath.endsWith(File.separator) ? "" : File.separator) + keyName;
-        if (path.startsWith("classpath:")) {
-            return this.getClass().getResourceAsStream(path.replace("classpath:", ""));
-        }
-        return new FileInputStream(path);
+        registry.retry("KeyManager auth").executeCheckedSupplier(() -> {
+            this.kmAuthenticate();
+            return null;
+        });
     }
 
     @Override
     public void sessionAuthenticate() throws AuthenticationException {
-        Map<String, String> token = new HashMap<>();
-        token.put("token", jwt);
-
-        Invocation.Builder builder = this.sessionAuthClient
-            .target(config.getPodUrl())
-            .path(AuthEndpointConstants.SESSION_AUTH_PATH_RSA)
-            .request(MediaType.APPLICATION_JSON);
-
-        try (Response response = builder.post(Entity.entity(token, MediaType.APPLICATION_JSON))) {
-            if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
-                try {
-                    handleError(response, null);
-                } catch (Exception e) {
-                    logger.error("Unexpected error, retry authentication in 30 seconds");
-                }
-                try {
-                    TimeUnit.SECONDS.sleep(AuthEndpointConstants.TIMEOUT);
-                } catch (InterruptedException e) {
-                    logger.error("Error with authentication", e);
-                }
-                if (authRetries++ > AuthEndpointConstants.MAX_AUTH_RETRY) {
-                    logger.error("Max retries reached. Giving up on auth.");
-                    return;
-                }
-                sessionAuthenticate();
-            } else {
-                sessionToken = response.readEntity(Token.class).getToken();
-            }
-        } catch (Exception e) {
-            throw new AuthenticationException(e);
-        }
-    }
-
-    @Override
-    protected void handleError(Response response, ISymClient botClient) throws SymClientException {
-        super.handleError(response, botClient);
+        logger.debug("Starting session authentication...");
+        this.sessionToken = this.doRsaAuth(
+            this.sessionAuthClient,
+            this.config.getPodUrl(),
+            AuthEndpointConstants.SESSION_AUTH_PATH_RSA,
+            this.jwt
+        );
     }
 
     @Override
     public void kmAuthenticate() throws AuthenticationException {
-        Map<String, String> token = new HashMap<>();
-        token.put("token", jwt);
-
-        Invocation.Builder builder = this.kmAuthClient
-            .target(config.getKeyAuthUrl())
-            .path(AuthEndpointConstants.KEY_AUTH_PATH_RSA)
-            .request(MediaType.APPLICATION_JSON);
-
-        try (Response response = builder.post(Entity.entity(token, MediaType.APPLICATION_JSON))) {
-            if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
-                try {
-                    handleError(response, null);
-                } catch (Exception e) {
-                    logger.error("Unexpected error, retry authentication in 30 seconds");
-                }
-                try {
-                    TimeUnit.SECONDS.sleep(AuthEndpointConstants.TIMEOUT);
-                } catch (InterruptedException e) {
-                    logger.error("Error with authentication", e);
-                }
-                if (authRetries++ > AuthEndpointConstants.MAX_AUTH_RETRY) {
-                    logger.error("Max retries reached. Giving up on auth.");
-                    return;
-                }
-                kmAuthenticate();
-            } else {
-                kmToken = response.readEntity(Token.class).getToken();
-            }
-        } catch (Exception e) {
-            throw new AuthenticationException(e);
-        }
+        logger.debug("Starting KM authentication...");
+        this.kmToken = this.doRsaAuth(
+            this.kmAuthClient,
+            this.config.getKeyAuthUrl(),
+            AuthEndpointConstants.KEY_AUTH_PATH_RSA,
+            this.jwt
+        );
     }
 
     @Override
@@ -242,22 +140,27 @@ public class SymBotRSAAuth extends APIClient implements ISymAuth {
 
     @Override
     public void logout() {
-        logger.info("Logging out");
-        Client client = ClientBuilder.newClient();
-        String target = CommonConstants.HTTPS_PREFIX + config.getSessionAuthHost() + ":" + config.getSessionAuthPort();
-        Invocation.Builder builder = client.target(target)
-            .path(AuthEndpointConstants.LOGOUT_PATH)
-            .request(MediaType.APPLICATION_JSON)
-            .header("sessionToken", getSessionToken());
+        logger.warn("Logout is not needed for RSA authentication.");
+    }
 
-        try (Response response = builder.post(null)) {
-            if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
-                try {
-                    handleError(response, null);
-                } catch (Exception e) {
-                    logger.error("Unexpected error, retry logout in 30 seconds", e);
-                }
+    public String doRsaAuth(Client client, String target, String path, String jwt) throws AuthenticationException {
+
+        final Token payload = new Token();
+        payload.setToken(jwt);
+
+        final Invocation.Builder builder = client.target(target).path(path).request(MediaType.APPLICATION_JSON);
+
+        try (final Response response = builder.post(Entity.entity(payload, MediaType.APPLICATION_JSON))) {
+            if (isNotSuccess(response)) {
+                throw new AuthenticationException(response.readEntity(String.class));
+            } else {
+                return response.readEntity(Token.class).getToken();
             }
         }
+    }
+
+    @SneakyThrows
+    private PrivateKey loadPrivateKey() {
+        return JwtHelper.parseRSAPrivateKey(FileHelper.readFile(this.config.getBotPrivateKeyPath() + this.config.getBotPrivateKeyName()));
     }
 }

--- a/src/main/java/clients/SymBotClient.java
+++ b/src/main/java/clients/SymBotClient.java
@@ -82,7 +82,11 @@ public final class SymBotClient implements ISymClient {
         try {
             botAuth.authenticate();
         } catch (AuthenticationException e) {
-            throw e.getRootException();
+            if(e.hasRootException()) {
+                throw e.getRootException();
+            } else {
+                throw e;
+            }
         }
         return new SymBotClient(config, botAuth);
     }

--- a/src/main/java/clients/symphony/api/HealthcheckClient.java
+++ b/src/main/java/clients/symphony/api/HealthcheckClient.java
@@ -20,7 +20,7 @@ public class HealthcheckClient extends APIClient {
     }
 
     public HealthcheckResponse performHealthCheck() {
-        boolean showFirehoseErrors = botClient.getConfig().getShowFirehoseErrors();
+        boolean showFirehoseErrors = botClient.getConfig().isShowFirehoseErrors();
         if (showFirehoseErrors) {
             HashMap<String, Object> parameters = new HashMap<>();
             parameters.put(QueryParameterNames.SHOW_FIREHOSE_ERRORS.getName(), Boolean.TRUE);

--- a/src/main/java/configuration/RetryConfiguration.java
+++ b/src/main/java/configuration/RetryConfiguration.java
@@ -1,0 +1,23 @@
+package configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.apiguardian.api.API;
+
+/**
+ * Sub-configuration class for Retry parametrization. Experimental, the contract might change in the future.
+ */
+@ToString
+@Getter @Setter
+@API(status = API.Status.EXPERIMENTAL)
+public class RetryConfiguration {
+
+  public static final int DEFAULT_MAX_ATTEMPTS = 10;
+  public static final long DEFAULT_INITIAL_INTERVAL_MILLIS = 500L;
+  public static final double DEFAULT_MULTIPLIER = 1.5;
+
+  private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+  private long initialIntervalMillis = DEFAULT_INITIAL_INTERVAL_MILLIS;
+  private double multiplier = DEFAULT_MULTIPLIER;
+}

--- a/src/main/java/configuration/SymConfig.java
+++ b/src/main/java/configuration/SymConfig.java
@@ -8,361 +8,85 @@ import lombok.Setter;
 import java.util.ArrayList;
 import java.util.Objects;
 
+@Getter @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SymConfig {
+
+    private static final int DEFAULT_CONNECTION_TIMEOUT = 35000;
+    private static final int DEFAULT_READ_TIMEOUT = 60000;
+
+    // ---------------------------------------------------------------------------------------------------------------//
+    // NETWORK
+    //
     private String sessionAuthHost;
     private int sessionAuthPort;
+
     private String keyAuthHost;
     private int keyAuthPort;
-    private String podHost;
-    private int podPort;
-    private String agentHost;
-    private int agentPort;
-    private String botCertPath;
-    private String botCertName;
-    private String botCertPassword;
-    private String botEmailAddress;
-    private String appCertPath;
-    private String appCertName;
-    private String appCertPassword;
-    private String proxyURL;
-    private String proxyUsername;
-    private String proxyPassword;
-    private String podProxyURL;
-    private String podProxyUsername;
-    private String podProxyPassword;
     private String keyManagerProxyURL;
     private String keyManagerProxyUsername;
     private String keyManagerProxyPassword;
-    private int authTokenRefreshPeriod;
-    private String truststorePath;
-    private String truststorePassword;
+
+    private String podHost;
+    private int podPort;
+    private String podProxyURL;
+    private String podProxyUsername;
+    private String podProxyPassword;
+
+    private String agentHost;
+    private int agentPort;
+    private String agentProxyURL;
+    private String agentProxyUsername;
+    private String agentProxyPassword;
+
+    private String proxyURL;
+    private String proxyUsername;
+    private String proxyPassword;
+
+    private int connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
+    private int readTimeout = DEFAULT_READ_TIMEOUT;
+
+    // ---------------------------------------------------------------------------------------------------------------//
+    // AUTHENTICATION
+    //
     private String botUsername;
+    private String botEmailAddress;
+    // rsa
     private String botPrivateKeyPath;
     private String botPrivateKeyName;
+    // cert
+    private String botCertPath;
+    private String botCertName;
+    private String botCertPassword;
+
+    private String appId;
+    // rsa
     private String appPrivateKeyPath;
     private String appPrivateKeyName;
-    private String appId;
+    // cert
+    private String appCertPath;
+    private String appCertName;
+    private String appCertPassword;
+
+    // ---------------------------------------------------------------------------------------------------------------//
+    // SSL
+    //
+    private String truststorePath;
+    private String truststorePassword;
+
+    // ---------------------------------------------------------------------------------------------------------------//
+    // DATAFEED
     private int datafeedEventsThreadpoolSize;
     private int datafeedEventsErrorTimeout;
     private Boolean reuseDatafeedID;
+
+    // ---------------------------------------------------------------------------------------------------------------//
+    // MISC
+    //
     private String authenticationFilterUrlPattern;
     private boolean showFirehoseErrors;
-    private int connectionTimeout;
     private ArrayList<String> supportedUriSchemes = new ArrayList<>();
-    @Getter @Setter private RetryConfiguration retry = new RetryConfiguration();
-
-    public String getSessionAuthHost() {
-        return sessionAuthHost;
-    }
-
-    public void setSessionAuthHost(String sessionAuthHost) {
-        this.sessionAuthHost = sessionAuthHost;
-    }
-
-    public int getSessionAuthPort() {
-        return sessionAuthPort;
-    }
-
-    public void setSessionAuthPort(int sessionAuthPort) {
-        this.sessionAuthPort = sessionAuthPort;
-    }
-
-    public String getKeyAuthHost() {
-        return keyAuthHost;
-    }
-
-    public void setKeyAuthHost(String keyAuthHost) {
-        this.keyAuthHost = keyAuthHost;
-    }
-
-    public int getKeyAuthPort() {
-        return keyAuthPort;
-    }
-
-    public void setKeyAuthPort(int keyAuthPort) {
-        this.keyAuthPort = keyAuthPort;
-    }
-
-    public String getPodHost() {
-        return podHost;
-    }
-
-    public void setPodHost(String podHost) {
-        this.podHost = podHost;
-    }
-
-    public int getPodPort() {
-        return podPort;
-    }
-
-    public void setPodPort(int podPort) {
-        this.podPort = podPort;
-    }
-
-    public String getAgentHost() {
-        return agentHost;
-    }
-
-    public void setAgentHost(String agentHost) {
-        this.agentHost = agentHost;
-    }
-
-    public int getAgentPort() {
-        return agentPort;
-    }
-
-    public void setAgentPort(int agentPort) {
-        this.agentPort = agentPort;
-    }
-
-    public String getBotCertPath() {
-        return botCertPath;
-    }
-
-    public void setBotCertPath(String botCertPath) {
-        this.botCertPath = botCertPath;
-    }
-
-    public String getBotCertName() {
-        return botCertName;
-    }
-
-    public void setBotCertName(String botCertName) {
-        this.botCertName = botCertName;
-    }
-
-    public String getBotCertPassword() {
-        return botCertPassword;
-    }
-
-    public void setBotCertPassword(String botCertPassword) {
-        this.botCertPassword = botCertPassword;
-    }
-
-    public String getBotEmailAddress() {
-        return botEmailAddress;
-    }
-
-    public void setBotEmailAddress(String botEmailAddress) {
-        this.botEmailAddress = botEmailAddress;
-    }
-
-    public String getAppCertPath() {
-        return appCertPath;
-    }
-
-    public void setAppCertPath(String appCertPath) {
-        this.appCertPath = appCertPath;
-    }
-
-    public String getAppCertName() {
-        return appCertName;
-    }
-
-    public void setAppCertName(String appCertName) {
-        this.appCertName = appCertName;
-    }
-
-    public String getAppCertPassword() {
-        return appCertPassword;
-    }
-
-    public void setAppCertPassword(String appCertPassword) {
-        this.appCertPassword = appCertPassword;
-    }
-
-    public String getProxyURL() {
-        return Objects.toString(proxyURL, "").trim();
-    }
-
-    public void setProxyURL(String proxyURL) {
-        this.proxyURL = proxyURL;
-    }
-
-    public String getProxyUsername() {
-        return Objects.toString(proxyUsername, "").trim();
-    }
-
-    public void setProxyUsername(String proxyUsername) {
-        this.proxyUsername = proxyUsername;
-    }
-
-    public String getProxyPassword() {
-        return Objects.toString(proxyPassword, "").trim();
-    }
-
-    public void setProxyPassword(String proxyPassword) {
-        this.proxyPassword = proxyPassword;
-    }
-
-    public String getPodProxyURL() {
-        return Objects.toString(podProxyURL, "").trim();
-    }
-
-    public void setPodProxyURL(String podProxyURL) {
-        this.podProxyURL = podProxyURL;
-    }
-
-    public String getPodProxyUsername() {
-        return Objects.toString(podProxyUsername, "").trim();
-    }
-
-    public void setPodProxyUsername(String podProxyUsername) {
-        this.podProxyUsername = podProxyUsername;
-    }
-
-    public String getPodProxyPassword() {
-        return Objects.toString(podProxyPassword, "").trim();
-    }
-
-    public void setPodProxyPassword(String podProxyPassword) {
-        this.podProxyPassword = podProxyPassword;
-    }
-
-    public String getKeyManagerProxyURL() {
-        return Objects.toString(keyManagerProxyURL, "").trim();
-    }
-
-    public void setKeyManagerProxyURL(String keyManagerProxyURL) {
-        this.keyManagerProxyURL = keyManagerProxyURL;
-    }
-
-    public String getKeyManagerProxyUsername() {
-        return keyManagerProxyUsername;
-    }
-
-    public void setKeyManagerProxyUsername(String keyManagerProxyUsername) {
-        this.keyManagerProxyUsername = keyManagerProxyUsername;
-    }
-
-    public String getKeyManagerProxyPassword() {
-        return keyManagerProxyPassword;
-    }
-
-    public void setKeyManagerProxyPassword(String keyManagerProxyPassword) {
-        this.keyManagerProxyPassword = keyManagerProxyPassword;
-    }
-
-    public int getAuthTokenRefreshPeriod() {
-        return authTokenRefreshPeriod;
-    }
-
-    public void setAuthTokenRefreshPeriod(int authTokenRefreshPeriod) {
-        this.authTokenRefreshPeriod = authTokenRefreshPeriod;
-    }
-
-    public String getTruststorePath() {
-        return truststorePath;
-    }
-
-    public void setTruststorePath(String truststorePath) {
-        this.truststorePath = truststorePath;
-    }
-
-    public String getTruststorePassword() {
-        return truststorePassword;
-    }
-
-    public void setTruststorePassword(String truststorePassword) {
-        this.truststorePassword = truststorePassword;
-    }
-
-    public String getBotUsername() {
-        return botUsername;
-    }
-
-    public void setBotUsername(String botUsername) {
-        this.botUsername = botUsername;
-    }
-
-    public String getBotPrivateKeyPath() {
-        return botPrivateKeyPath;
-    }
-
-    public void setBotPrivateKeyPath(String botPrivateKeyPath) {
-        this.botPrivateKeyPath = botPrivateKeyPath;
-    }
-
-    public String getBotPrivateKeyName() {
-        return botPrivateKeyName;
-    }
-
-    public void setBotPrivateKeyName(String botPrivateKeyName) {
-        this.botPrivateKeyName = botPrivateKeyName;
-    }
-
-    public String getAppPrivateKeyPath() {
-        return appPrivateKeyPath;
-    }
-
-    public void setAppPrivateKeyPath(String appPrivateKeyPath) {
-        this.appPrivateKeyPath = appPrivateKeyPath;
-    }
-
-    public String getAppPrivateKeyName() {
-        return appPrivateKeyName;
-    }
-
-    public void setAppPrivateKeyName(String appPrivateKeyName) {
-        this.appPrivateKeyName = appPrivateKeyName;
-    }
-
-    public String getAppId() {
-        return appId;
-    }
-
-    public void setAppId(String appId) {
-        this.appId = appId;
-    }
-
-    public int getDatafeedEventsThreadpoolSize() {
-        return datafeedEventsThreadpoolSize;
-    }
-
-    public void setDatafeedEventsThreadpoolSize(int datafeedEventsThreadpoolSize) {
-        this.datafeedEventsThreadpoolSize = datafeedEventsThreadpoolSize;
-    }
-
-    public int getDatafeedEventsErrorTimeout() {
-        return datafeedEventsErrorTimeout;
-    }
-
-    public void setDatafeedEventsErrorTimeout(int datafeedEventsErrorTimeout) {
-        this.datafeedEventsErrorTimeout = datafeedEventsErrorTimeout;
-    }
-
-    public Boolean getReuseDatafeedID() {
-        return reuseDatafeedID;
-    }
-
-    public void setReuseDatafeedID(boolean reuseDatafeedID) {
-        this.reuseDatafeedID = reuseDatafeedID;
-    }
-
-    public String getAuthenticationFilterUrlPattern() {
-        return authenticationFilterUrlPattern;
-    }
-
-    public void setAuthenticationFilterUrlPattern(String authenticationFilterUrlPattern) {
-        this.authenticationFilterUrlPattern = authenticationFilterUrlPattern;
-    }
-
-    public boolean getShowFirehoseErrors() {
-        return showFirehoseErrors;
-    }
-
-    public void setShowFirehoseErrors(boolean showFirehoseErrors) {
-        this.showFirehoseErrors = showFirehoseErrors;
-    }
-
-    public int getConnectionTimeout() {
-        return connectionTimeout;
-    }
-
-    public void setConnectionTimeout(int connectionTimeout) {
-        this.connectionTimeout = connectionTimeout;
-    }
+    private RetryConfiguration retry = new RetryConfiguration();
 
     public String getAgentUrl() {
         String port = (this.getAgentPort() == 443) ? "" : ":" + this.getAgentPort();
@@ -370,21 +94,17 @@ public class SymConfig {
     }
 
     public String getPodUrl() {
-        String port = (podPort == 443) ? "" : ":" + podPort;
-        return CommonConstants.HTTPS_PREFIX + podHost + port;
+        String port = (this.getPodPort() == 443) ? "" : ":" + this.getPodPort();
+        return CommonConstants.HTTPS_PREFIX + this.getPodHost() + port;
     }
 
     public String getKeyAuthUrl() {
-        String port = (keyAuthPort == 443) ? "" : ":" + keyAuthPort;
-        return CommonConstants.HTTPS_PREFIX + keyAuthHost + port;
+        String port = (this.getKeyAuthPort() == 443) ? "" : ":" + this.getKeyAuthPort();
+        return CommonConstants.HTTPS_PREFIX + this.getKeyAuthHost() + port;
     }
 
     public String getSessionAuthUrl() {
-        String port = (sessionAuthPort == 443) ? "" : ":" + sessionAuthPort;
-        return CommonConstants.HTTPS_PREFIX + sessionAuthHost + port;
-    }
-    
-    public ArrayList<String> getSupportedUriSchemes() {
-        return supportedUriSchemes;
+        String port = (this.getSessionAuthPort() == 443) ? "" : ":" + this.getSessionAuthPort();
+        return CommonConstants.HTTPS_PREFIX + this.getSessionAuthHost() + port;
     }
 }

--- a/src/main/java/configuration/SymConfig.java
+++ b/src/main/java/configuration/SymConfig.java
@@ -12,8 +12,8 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SymConfig {
 
-    private static final int DEFAULT_CONNECTION_TIMEOUT = 35000;
-    private static final int DEFAULT_READ_TIMEOUT = 60000;
+    private static final int DEFAULT_CONNECTION_TIMEOUT = 10_000;
+    private static final int DEFAULT_READ_TIMEOUT = 35_000;
 
     // ---------------------------------------------------------------------------------------------------------------//
     // NETWORK

--- a/src/main/java/configuration/SymConfig.java
+++ b/src/main/java/configuration/SymConfig.java
@@ -2,6 +2,8 @@ package configuration;
 
 import clients.symphony.api.constants.CommonConstants;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.Objects;
@@ -48,6 +50,7 @@ public class SymConfig {
     private boolean showFirehoseErrors;
     private int connectionTimeout;
     private ArrayList<String> supportedUriSchemes = new ArrayList<>();
+    @Getter @Setter private RetryConfiguration retry = new RetryConfiguration();
 
     public String getSessionAuthHost() {
         return sessionAuthHost;

--- a/src/main/java/configuration/SymLoadBalancedConfig.java
+++ b/src/main/java/configuration/SymLoadBalancedConfig.java
@@ -40,7 +40,7 @@ public class SymLoadBalancedConfig extends SymConfig {
             case random:
                 if (currentAgentIndex == -1 || !isSticky) {
                     rotateAgent();
-                    log.info("Returning random agent index #{}: {}", currentAgentIndex, agentServers.get(currentAgentIndex));
+                    logger.info("Returning random agent index #{}: {}", currentAgentIndex, agentServers.get(currentAgentIndex));
                 }
                 return agentServers.get(currentAgentIndex);
 
@@ -49,7 +49,7 @@ public class SymLoadBalancedConfig extends SymConfig {
                     currentAgentIndex++;
                 }
                 String roundRobinAgentHost = agentServers.get(currentAgentIndex);
-                log.info("Returning round-robin agent index #{}: {}", currentAgentIndex, roundRobinAgentHost);
+                logger.info("Returning round-robin agent index #{}: {}", currentAgentIndex, roundRobinAgentHost);
                 if (!isSticky) {
                     rotateAgent();
                 }
@@ -57,10 +57,10 @@ public class SymLoadBalancedConfig extends SymConfig {
 
             case external:
                 if (actualAgentHost == null || !isSticky) {
-                    log.info("Retrieving actual agent hostname..");
+                    logger.info("Retrieving actual agent hostname..");
                     rotateAgent();
                 }
-                log.info("Actual agent host: {}", actualAgentHost);
+                logger.info("Actual agent host: {}", actualAgentHost);
                 return actualAgentHost;
 
             default:
@@ -88,7 +88,7 @@ public class SymLoadBalancedConfig extends SymConfig {
                 break;
             default:
         }
-        log.info("Agent rotated to: {}", newAgent);
+        logger.info("Agent rotated to: {}", newAgent);
     }
 
     /**
@@ -105,11 +105,11 @@ public class SymLoadBalancedConfig extends SymConfig {
             .get();
 
         if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
-            log.error("Unable to get actual Agent hostname, cause : {}", response);
+            logger.error("Unable to get actual Agent hostname, cause : {}", response);
             return null;
         } else {
             final String agentServerFqdn = response.readEntity(AgentInfo.class).getServerFqdn();
-            log.debug("Agent FQDN={}", agentServerFqdn);
+            logger.debug("Agent FQDN={}", agentServerFqdn);
             return agentServerFqdn;
         }
     }
@@ -118,7 +118,7 @@ public class SymLoadBalancedConfig extends SymConfig {
         try {
             BeanUtils.copyProperties(this, config);
         } catch (IllegalAccessException | InvocationTargetException e) {
-            log.error("Unable to copy properties from " + config + " to this.", e);
+            logger.error("Unable to copy properties from " + config + " to this.", e);
         }
     }
 }

--- a/src/main/java/exceptions/AuthenticationException.java
+++ b/src/main/java/exceptions/AuthenticationException.java
@@ -1,18 +1,22 @@
 package exceptions;
 
 public class AuthenticationException extends Exception {
-    private Exception rootException;
+
+    public AuthenticationException(String message) {
+        super(message);
+    }
 
     public AuthenticationException(Exception rootException) {
         super(rootException);
-        this.rootException = rootException;
     }
 
+    @Deprecated
     public Exception getRootException() {
-        return rootException;
+        return (Exception) this.getCause();
     }
 
-    public void setRootException(Exception rootException) {
-        this.rootException = rootException;
+    @Deprecated
+    public boolean hasRootException() {
+        return this.getRootException() != null;
     }
 }

--- a/src/main/java/internal/FileHelper.java
+++ b/src/main/java/internal/FileHelper.java
@@ -1,0 +1,46 @@
+package internal;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.apiguardian.api.API;
+import utils.HttpClientBuilderHelper;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Helper class for reading files from either classpath or system path. Internal usage only.
+ */
+@Slf4j
+@API(status = API.Status.INTERNAL)
+public class FileHelper {
+
+  /**
+   * Loads file content (as byte[]) from either system or classpath location.
+   *
+   * @param path Absolute file path or classpath location
+   * @return content of the file
+   */
+  @SneakyThrows
+  public static byte[] readFile(@Nonnull final String path) {
+
+    byte[] content;
+
+    if(new File(path).exists()) {
+      content = IOUtils.toByteArray(new FileInputStream(path));
+      logger.debug("File loaded from system path : {}", path);
+    }
+    else if (HttpClientBuilderHelper.class.getResource(path) != null) {
+      content = IOUtils.toByteArray(HttpClientBuilderHelper.class.getResourceAsStream(path.replace("classpath:", "")));
+      logger.debug("File loaded from classpath location : {}", path);
+    } else {
+      throw new FileNotFoundException("Unable to load custom truststore from path : " + path);
+    }
+
+    return content;
+  }
+}

--- a/src/main/java/internal/FileHelper.java
+++ b/src/main/java/internal/FileHelper.java
@@ -9,6 +9,7 @@ import org.apiguardian.api.API;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.nio.file.Paths;
 
 import javax.annotation.Nonnull;
 
@@ -43,6 +44,10 @@ public class FileHelper {
     }
 
     return content;
+  }
+
+  public static String path(String first, String... more) {
+    return Paths.get(first, more).toString();
   }
 
   private static String classpath(String path) {

--- a/src/main/java/internal/FileHelper.java
+++ b/src/main/java/internal/FileHelper.java
@@ -1,10 +1,10 @@
 package internal;
 
+import static org.apache.commons.io.IOUtils.toByteArray;
+
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.IOUtils;
 import org.apiguardian.api.API;
-import utils.HttpClientBuilderHelper;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,17 +30,26 @@ public class FileHelper {
 
     byte[] content;
 
-    if(new File(path).exists()) {
-      content = IOUtils.toByteArray(new FileInputStream(path));
+    if(!isClasspath(path) && new File(path).exists()) {
+      content = toByteArray(new FileInputStream(path));
       logger.debug("File loaded from system path : {}", path);
     }
-    else if (HttpClientBuilderHelper.class.getResource(path) != null) {
-      content = IOUtils.toByteArray(HttpClientBuilderHelper.class.getResourceAsStream(path.replace("classpath:", "")));
+    else if (FileHelper.class.getResource(classpath(path)) != null) {
+      content = toByteArray(FileHelper.class.getResourceAsStream(classpath(path)));
       logger.debug("File loaded from classpath location : {}", path);
-    } else {
-      throw new FileNotFoundException("Unable to load custom truststore from path : " + path);
+    }
+    else {
+      throw new FileNotFoundException("Unable to load file from path : " + path);
     }
 
     return content;
+  }
+
+  private static String classpath(String path) {
+    return path.replace("classpath:", "");
+  }
+
+  private static boolean isClasspath(String path) {
+    return path.startsWith("classpath:");
   }
 }

--- a/src/main/java/internal/jersey/JerseyHelper.java
+++ b/src/main/java/internal/jersey/JerseyHelper.java
@@ -29,4 +29,14 @@ public class JerseyHelper {
   public static boolean isSuccess(Response response) {
     return response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL;
   }
+
+  /**
+   * Read Jersey {@link javax.ws.rs.client.Client} response and map it to a {@link Class}.
+   * @param response The Jersey {@link javax.ws.rs.client.Client} response.
+   * @param clz Type of the mapping class.
+   * @return mapped response.
+   */
+  public static <T> T read(final Response response, final Class<T> clz) {
+    return response.readEntity(clz);
+  }
 }

--- a/src/main/java/internal/jersey/JerseyHelper.java
+++ b/src/main/java/internal/jersey/JerseyHelper.java
@@ -1,0 +1,32 @@
+package internal.jersey;
+
+import org.apiguardian.api.API;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Helper class that facilitate recurrent Jersey {@link javax.ws.rs.client.Client} operations. Internal usage only.
+ */
+@API(status = API.Status.INTERNAL)
+public class JerseyHelper {
+
+  /**
+   * Checks if {@link javax.ws.rs.client.Client} response is not successful.
+   *
+   * @param response Jersey {@link javax.ws.rs.client.Client} response.
+   * @return true if response is not successful, false otherwise.
+   */
+  public static boolean isNotSuccess(Response response) {
+    return !isSuccess(response);
+  }
+
+  /**
+   * Checks if {@link javax.ws.rs.client.Client} response is successful.
+   *
+   * @param response Jersey {@link javax.ws.rs.client.Client} response.
+   * @return true if response is successful, false otherwise.
+   */
+  public static boolean isSuccess(Response response) {
+    return response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL;
+  }
+}

--- a/src/main/java/internal/jersey/NoCacheFeature.java
+++ b/src/main/java/internal/jersey/NoCacheFeature.java
@@ -1,4 +1,6 @@
-package utils.jersey;
+package internal.jersey;
+
+import org.apiguardian.api.API;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
@@ -11,6 +13,7 @@ import javax.ws.rs.core.HttpHeaders;
  * @author Thibault Pensec
  * @since 24/02/2020
  */
+@API(status = API.Status.INTERNAL)
 public class NoCacheFeature implements ClientRequestFilter {
 
     @Override

--- a/src/main/java/utils/JwtHelper.java
+++ b/src/main/java/utils/JwtHelper.java
@@ -60,6 +60,11 @@ public class JwtHelper {
         return parseRSAPrivateKey(IOUtils.toString(pemPrivateKeyFile, Charset.defaultCharset()));
     }
 
+    public static PrivateKey parseRSAPrivateKey(final byte[] content)
+        throws IOException, GeneralSecurityException {
+        return parseRSAPrivateKey(IOUtils.toString(content, "utf-8"));
+    }
+
     /**
      * Create a RSA Private Ket from a PEM String. It supports PKCS#1 and PKCS#8 string formats
      */

--- a/src/test/java/internal/FileHelperTest.java
+++ b/src/test/java/internal/FileHelperTest.java
@@ -1,0 +1,32 @@
+package internal;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+public class FileHelperTest {
+
+  @Test
+  public void should_read_file_from_classpath() {
+    assertNotNull(FileHelper.readFile("/avatar.png"));
+    assertNotNull(FileHelper.readFile("classpath:/avatar.png"));
+  }
+
+  @Test
+  public void should_read_file_from_system() throws IOException {
+    final Path file = Files.createTempFile(UUID.randomUUID().toString(), ".txt");
+    assertNotNull(FileHelper.readFile(file.toAbsolutePath().toString()));
+    Files.delete(file);
+  }
+
+  @Test(expected = FileNotFoundException.class)
+  public void fail_to_read_file() {
+    FileHelper.readFile(UUID.randomUUID().toString() + ".abc");
+  }
+}

--- a/src/test/java/it/authentication/SymBotRSAAuthTest.java
+++ b/src/test/java/it/authentication/SymBotRSAAuthTest.java
@@ -6,38 +6,58 @@ import exceptions.AuthenticationException;
 import it.commons.ServerTest;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+
+import org.junit.Before;
 import org.junit.Test;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static it.commons.BotTest.stubPost;
 import static org.junit.Assert.*;
 
 public class SymBotRSAAuthTest extends ServerTest {
+
+    private final SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(config);
+
+    @Before
+    public void setup() {
+        // stub KM auth response
+        stubPost(
+            AuthEndpointConstants.KEY_AUTH_PATH_RSA,
+            "{ \"token\": \"0100e4feOiJSUzUxMiJ97oqGf729d1866f\", \"name\": \"sessionToken\" }"
+        );
+    }
+
     @Test
-    public void authenticateSuccess() {
-        stubFor(post(urlEqualTo(AuthEndpointConstants.SESSION_AUTH_PATH_RSA))
-            .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
-                .withBody("{ \"token\": \"eyJhbGciOiJSUzUxMiJ97oqG1Kd28l1FpQ\", \"name\": \"sessionToken\" }")));
+    public void should_authenticate_with_success() throws AuthenticationException {
 
-        stubFor(post(urlEqualTo(AuthEndpointConstants.KEY_AUTH_PATH_RSA))
-            .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
-                .withBody("{ \"token\": \"0100e4feOiJSUzUxMiJ97oqGf729d1866f\", \"name\": \"keyManagerToken\" }")));
+        // session auth returns 200
+        stubPost(
+            AuthEndpointConstants.SESSION_AUTH_PATH_RSA,
+            "{ \"token\": \"eyJhbGciOiJSUzUxMiJ97oqG1Kd28l1FpQ\", \"name\": \"sessionToken\" }"
+        );
 
-        SymBotRSAAuth symBotRSAAuth = new SymBotRSAAuth(config);
+        this.symBotRSAAuth.authenticate();
+        assertNotNull(this.symBotRSAAuth.getSessionToken());
+        assertEquals("eyJhbGciOiJSUzUxMiJ97oqG1Kd28l1FpQ", this.symBotRSAAuth.getSessionToken());
+        assertNotNull(this.symBotRSAAuth.getKmToken());
+        assertEquals("0100e4feOiJSUzUxMiJ97oqGf729d1866f", this.symBotRSAAuth.getKmToken());
+    }
+
+    @Test
+    public void should_fail_to_authenticate_session() {
+
+        final String responsePayload = "{ \"error\": \"Service unavailable\" }";
+
+        // session auth returns 503
+        stubPost(
+            AuthEndpointConstants.SESSION_AUTH_PATH_RSA,
+            responsePayload,
+            503
+        );
 
         try {
-            symBotRSAAuth.authenticate();
-
-            assertNotNull(symBotRSAAuth.getSessionToken());
-            assertEquals("eyJhbGciOiJSUzUxMiJ97oqG1Kd28l1FpQ", symBotRSAAuth.getSessionToken());
-            assertNotNull(symBotRSAAuth.getKmToken());
-            assertEquals("0100e4feOiJSUzUxMiJ97oqGf729d1866f", symBotRSAAuth.getKmToken());
-        } catch (AuthenticationException e) {
-            fail();
+            this.symBotRSAAuth.authenticate();
+        } catch (AuthenticationException ex) {
+            assertEquals(responsePayload, ex.getMessage());
         }
     }
 }

--- a/src/test/java/it/commons/BotTest.java
+++ b/src/test/java/it/commons/BotTest.java
@@ -65,11 +65,15 @@ public class BotTest extends ServerTest {
         );
     }
 
-    protected static StubMapping stubPost(String url, String returnedJsonResponse) {
+    public static StubMapping stubPost(String url, String returnedJsonResponse) {
+        return stubPost(url,returnedJsonResponse, 200);
+    }
+
+    public static StubMapping stubPost(String url, String returnedJsonResponse, int status) {
         return stubFor(post(urlEqualTo(url))
             .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
             .willReturn(aResponse()
-                .withStatus(200)
+                .withStatus(status)
                 .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
                 .withBody(returnedJsonResponse))
         );

--- a/src/test/resources/bot-config.json
+++ b/src/test/resources/bot-config.json
@@ -14,7 +14,14 @@
   "botPrivateKeyName": "testprivatekey.pkcs8",
   "botUsername": "testbot",
   "authTokenRefreshPeriod": "30",
+  "connectionTimeout": 1000,
+
   "truststorePath": "src/test/resources/testkeystore.jks",
   "truststorePassword": "123456",
-  "connectionTimeout": 1000
+
+  "retry": {
+    "maxAttempts": 2,
+    "initialIntervalMillis": 200,
+    "multiplier": 1.5
+  }
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=DEBUG, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
A customer faced some random troubles with custom truststore configuration. I discovered that this problem was caused by the multi-threaded calls when authenticating a service account with RSA. 

This PR completely refactor the way that RSA authentication is performed by the SDK. I also introduced `resilience4j` as an experimental library for retries. It is also possible to configure the exponential backoff through `config.json` : 
```json
{
    "retry": {
        "maxAttempts": 10,
        "initialIntervalMillis": 500,
        "multiplier": 1.5
    }
}
```