### PR TITLE
SDK-80 Changing caching strategy of SymOBOClient

### DIFF
--- a/src/main/java/clients/SymOBOClient.java
+++ b/src/main/java/clients/SymOBOClient.java
@@ -5,7 +5,6 @@ import clients.symphony.api.*;
 import configuration.SymConfig;
 import javax.ws.rs.client.Client;
 import org.glassfish.jersey.client.ClientConfig;
-import sun.jvm.hotspot.debugger.cdbg.Sym;
 import utils.HttpClientBuilderHelper;
 
 import java.util.HashMap;

--- a/src/main/java/clients/SymOBOClient.java
+++ b/src/main/java/clients/SymOBOClient.java
@@ -5,10 +5,14 @@ import clients.symphony.api.*;
 import configuration.SymConfig;
 import javax.ws.rs.client.Client;
 import org.glassfish.jersey.client.ClientConfig;
+import sun.jvm.hotspot.debugger.cdbg.Sym;
 import utils.HttpClientBuilderHelper;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public final class SymOBOClient implements ISymClient {
-    private static SymOBOClient oboClient;
+    private static final Map<ISymAuth, SymOBOClient> cachedOBOClients = new HashMap<>();
     private SymConfig config;
     private ISymAuth symAuth;
     private MessagesClient messagesClient;
@@ -21,25 +25,7 @@ public final class SymOBOClient implements ISymClient {
     private Client agentClient;
 
     public static SymOBOClient initOBOClient(SymConfig config, ISymAuth auth) {
-        if (oboClient == null) {
-            oboClient = new SymOBOClient(config, auth);
-            return oboClient;
-        }
-        return oboClient;
-    }
-
-    private SymOBOClient(SymConfig config,
-                         ISymAuth symAuth,
-                         ClientConfig podClientConfig,
-                         ClientConfig agentClientConfig) {
-        this.config = config;
-        this.symAuth = symAuth;
-        this.podClient = HttpClientBuilderHelper
-                .getHttpClientBuilderWithTruststore(config)
-                .withConfig(podClientConfig).build();
-        this.agentClient = HttpClientBuilderHelper
-                .getHttpClientBuilderWithTruststore(config)
-                .withConfig(agentClientConfig).build();
+        return cachedOBOClients.computeIfAbsent(auth, newAuth -> new SymOBOClient(config, newAuth));
     }
 
     public SymOBOClient(SymConfig config, ISymAuth symAuth) {

--- a/src/main/java/utils/HttpClientBuilderHelper.java
+++ b/src/main/java/utils/HttpClientBuilderHelper.java
@@ -6,6 +6,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.util.Enumeration;
 import javax.ws.rs.client.ClientBuilder;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
@@ -130,7 +131,13 @@ public class HttpClientBuilderHelper {
         try (InputStream trustStoreIS = loadInputStream(config.getTruststorePath())) {
             tks.load(trustStoreIS, config.getTruststorePassword().toCharArray());
             clientBuilder.trustStore(tks);
-        } catch (CertificateException | NoSuchAlgorithmException | IOException e) {
+            Enumeration<String> aliases = tks.aliases();
+            while (aliases.hasMoreElements()) {
+                String alias = aliases.nextElement();
+                logger.debug("Truststore entry's alias: " + alias);
+            }
+            logger.debug(tks.toString());
+        } catch (CertificateException | NoSuchAlgorithmException | IOException | KeyStoreException e) {
             logger.error("Error loading truststore", e);
         }
     }

--- a/src/test/java/it/clients/SymBotOBOClientTest.java
+++ b/src/test/java/it/clients/SymBotOBOClientTest.java
@@ -1,15 +1,36 @@
 package it.clients;
 
 import authentication.SymBotRSAAuth;
+import authentication.SymOBOUserRSAAuth;
 import clients.SymOBOClient;
 import it.commons.BaseTest;
 import org.junit.Test;
-import static org.junit.Assert.assertNotNull;
+
+import static org.junit.Assert.*;
 
 public class SymBotOBOClientTest extends BaseTest {
   @Test
   public void initOBOClientSuccess() {
     SymOBOClient symOBOClient = SymOBOClient.initOBOClient(config, new SymBotRSAAuth(config));
     assertNotNull(symOBOClient);
+  }
+
+  @Test
+  public void initOBOClientWithSameUserAuth() {
+    SymOBOUserRSAAuth userAuth = new SymOBOUserRSAAuth(config, null,"username", null);
+    SymOBOClient symOBOClient1 = SymOBOClient.initOBOClient(config, userAuth);
+    SymOBOClient symOBOClient2 = SymOBOClient.initOBOClient(config, userAuth);
+    assertEquals(symOBOClient1, symOBOClient2);
+  }
+
+  @Test
+  public void initOBOClientWithDiffUserAuth() {
+    SymOBOUserRSAAuth userAuth = new SymOBOUserRSAAuth(config, null, "username-1", null);
+    SymOBOClient symOBOClient1 = SymOBOClient.initOBOClient(config, userAuth);
+    SymOBOClient symOBOClient2 = SymOBOClient.initOBOClient(config,
+            new SymOBOUserRSAAuth(config, null, "username-2", null));
+    SymOBOClient symOBOClient3 = SymOBOClient.initOBOClient(config, userAuth);
+    assertNotEquals(symOBOClient1, symOBOClient2);
+    assertEquals(symOBOClient1, symOBOClient3);
   }
 }


### PR DESCRIPTION
With the legacy caching strategy using Singleton pattern, we cannot instantiate different SymOBOClient with different passed user auth.
My solution is, instead of using Singleton, I will use Flyweight pattern to init SymOBOClient by using a HashMap to store all instantiated SymOBOClient referred by keys which are the passed user auth.