### PR TITLE
SDK-81 Handle null authorization header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.21.0</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,11 @@
             <version>2.26.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.21.0</version>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/authentication/jwt/AuthenticationFilter.java
+++ b/src/main/java/authentication/jwt/AuthenticationFilter.java
@@ -52,15 +52,13 @@ public class AuthenticationFilter implements Filter {
         HttpServletResponse response = (HttpServletResponse) servletResponse;
 
         if (matchesFilteredPattern(request.getServletPath())) {
-            String jwt =
-                request.getHeader(AUTHORIZATION_HEADER)
-                    .substring(AUTHORIZATION_HEADER_BEARER_PREFIX.length());
-            if (jwt == null) {
+            String jwt = request.getHeader(AUTHORIZATION_HEADER);
+            if (jwt == null || jwt.length() < AUTHORIZATION_HEADER_BEARER_PREFIX.length()) {
                 response.setStatus(401);
                 response.getWriter().write(MISSING_JWT_MESSAGE);
                 return;
             }
-
+            jwt = jwt.substring(AUTHORIZATION_HEADER_BEARER_PREFIX.length());
             Jws<Claims> jws;
             try {
                 PublicKey rsaVerifier = rsaAuth.getPodPublicKey();

--- a/src/test/java/it/authentication/jwt/AuthenticationFilterTest.java
+++ b/src/test/java/it/authentication/jwt/AuthenticationFilterTest.java
@@ -1,0 +1,91 @@
+package it.authentication.jwt;
+
+import authentication.AuthEndpointConstants;
+import authentication.SymExtensionAppRSAAuth;
+import authentication.jwt.AuthenticationFilter;
+import it.commons.ServerTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuthenticationFilterTest extends ServerTest {
+
+    private static AuthenticationFilter authFilter;
+    private static final String MISSING_JWT_MESSAGE = "Missing JWT";
+    private static final String UNAUTHORIZED_JWT_MESSAGE = "Unauthorized JWT";
+
+    @Mock
+    private static HttpServletRequest mRequest;
+    @Mock
+    private static HttpServletResponse mResponse;
+    @Mock
+    private static FilterChain mFilterChain;
+    @Mock
+    private static PrintWriter mWriter;
+
+    @Before
+    public void setup() {
+        config.setAuthenticationFilterUrlPattern("");
+        stubFor(get(urlEqualTo(AuthEndpointConstants.POD_CERT_RSA_PATH))
+                .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                        .withBody("{\"certificate\":\"-----BEGIN CERTIFICATE-----\\nMIIEQDCCAyigAwIBAgIVAKmSDvvk3rea1n\\n-----END CERTIFICATE-----\\n\"}")));
+
+        stubFor(post(urlEqualTo(AuthEndpointConstants.SESSION_EXT_APP_AUTH_PATH_RSA))
+                .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                        .withBody("{ \"appId\" : \"APP_ID\", \"appToken\" : \"APP_TOKEN\", \"symphonyToken\" : \"SYMPHONY_TOKEN\", \"expireAt\" : 1539636528288 }")));
+
+        authFilter = new AuthenticationFilter(new SymExtensionAppRSAAuth(config), config);
+    }
+
+    @Test
+    public void missingAuthorizationTest() throws IOException, ServletException {
+        when(mRequest.getServletPath()).thenReturn("");
+        when(mResponse.getWriter()).thenReturn(mWriter);
+        authFilter.doFilter(mRequest, mResponse, mFilterChain);
+        verify(mResponse).setStatus(401);
+        verify(mWriter).write(MISSING_JWT_MESSAGE);
+    }
+
+    @Test
+    public void tooShortTokenTest() throws IOException, ServletException {
+        when(mRequest.getServletPath()).thenReturn("");
+        when(mRequest.getHeader("Authorization")).thenReturn("short");
+        when(mResponse.getWriter()).thenReturn(mWriter);
+        authFilter.doFilter(mRequest, mResponse, mFilterChain);
+        verify(mResponse).setStatus(401);
+        verify(mWriter).write(MISSING_JWT_MESSAGE);
+    }
+
+    @Test
+    public void unAuthorizedJwtTest() throws IOException, ServletException {
+        when(mRequest.getServletPath()).thenReturn("");
+        when(mRequest.getHeader("Authorization")).thenReturn("unauthorized-token");
+        when(mResponse.getWriter()).thenReturn(mWriter);
+        authFilter.doFilter(mRequest, mResponse, mFilterChain);
+        verify(mResponse).setStatus(401);
+        verify(mWriter).write(UNAUTHORIZED_JWT_MESSAGE);
+    }
+}

--- a/src/test/java/it/authentication/jwt/AuthenticationFilterTest.java
+++ b/src/test/java/it/authentication/jwt/AuthenticationFilterTest.java
@@ -3,7 +3,7 @@ package it.authentication.jwt;
 import authentication.AuthEndpointConstants;
 import authentication.SymExtensionAppRSAAuth;
 import authentication.jwt.AuthenticationFilter;
-import it.commons.ServerTest;
+import it.commons.BotTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,49 +14,33 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AuthenticationFilterTest extends ServerTest {
+public class AuthenticationFilterTest extends BotTest {
 
     private static AuthenticationFilter authFilter;
     private static final String MISSING_JWT_MESSAGE = "Missing JWT";
     private static final String UNAUTHORIZED_JWT_MESSAGE = "Unauthorized JWT";
 
     @Mock
-    private static HttpServletRequest mRequest;
+    private HttpServletRequest mRequest;
     @Mock
-    private static HttpServletResponse mResponse;
+    private HttpServletResponse mResponse;
     @Mock
-    private static FilterChain mFilterChain;
+    private FilterChain mFilterChain;
     @Mock
-    private static PrintWriter mWriter;
+    private PrintWriter mWriter;
 
     @Before
     public void setup() {
         config.setAuthenticationFilterUrlPattern("");
-        stubFor(get(urlEqualTo(AuthEndpointConstants.POD_CERT_RSA_PATH))
-                .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
-                        .withBody("{\"certificate\":\"-----BEGIN CERTIFICATE-----\\nMIIEQDCCAyigAwIBAgIVAKmSDvvk3rea1n\\n-----END CERTIFICATE-----\\n\"}")));
-
-        stubFor(post(urlEqualTo(AuthEndpointConstants.SESSION_EXT_APP_AUTH_PATH_RSA))
-                .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
-                        .withBody("{ \"appId\" : \"APP_ID\", \"appToken\" : \"APP_TOKEN\", \"symphonyToken\" : \"SYMPHONY_TOKEN\", \"expireAt\" : 1539636528288 }")));
-
+        stubGet(AuthEndpointConstants.POD_CERT_RSA_PATH, "{\"certificate\":\"-----BEGIN CERTIFICATE-----\\nMIIEQDCCAyigAwIBAgIVAKmSDvvk3rea1n\\n-----END CERTIFICATE-----\\n\"}");
+        stubPost(AuthEndpointConstants.SESSION_EXT_APP_AUTH_PATH_RSA, "{ \"appId\" : \"APP_ID\", \"appToken\" : \"APP_TOKEN\", \"symphonyToken\" : \"SYMPHONY_TOKEN\", \"expireAt\" : 1539636528288 }");
         authFilter = new AuthenticationFilter(new SymExtensionAppRSAAuth(config), config);
     }
 


### PR DESCRIPTION
- Check if authorization headers of request is null or not to avoid NullPointerException when doing a substring.
- Add unittest for AuthenticationFilter