### PR TITLE
SDK-90: Handle null content-type 401 error response

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Wanna know more about this ?
+# https://help.github.com/en/articles/about-code-owners
+
+*       @SymphonyPlatformSolutions/symphony-sdk

--- a/src/main/java/clients/symphony/api/APIClient.java
+++ b/src/main/java/clients/symphony/api/APIClient.java
@@ -14,6 +14,17 @@ public abstract class APIClient {
     private final Logger logger = LoggerFactory.getLogger(APIClient.class);
     private static final ObjectMapper mapper = new ObjectMapper();
 
+    private ClientError readClientError(Response response) {
+        String errorString = response.readEntity(String.class);
+        try {
+            return mapper.readValue(errorString, ClientError.class);
+        } catch (JsonProcessingException e) {
+            ClientError error = new ClientError();
+            error.setMessage(errorString);
+            return error;
+        }
+    }
+
     protected void handleError(Response response, ISymClient botClient) throws SymClientException {
         if (response.getStatusInfo().getFamily() == Family.SERVER_ERROR) {
             logger.error("REST error: error code {} reason {}",
@@ -22,16 +33,9 @@ public abstract class APIClient {
             );
             throw new ServerErrorException(response.getStatusInfo().getReasonPhrase());
         } else {
-            String errorString = response.readEntity(String.class);
-            ClientError error;
-            try {
-                error = mapper.readValue(errorString, ClientError.class);
-            } catch (JsonProcessingException e) {
-                throw new APIClientErrorException(e.getMessage());
-            }
-
+            ClientError error = this.readClientError(response);
             if (response.getStatus() == BAD_REQUEST.getStatusCode()) {
-                logger.error("Client error occurred: {}", error);
+                logger.error("Client error occurred: {}", error.getMessage());
                 throw new APIClientErrorException(error.getMessage());
             } else if (response.getStatus() == UNAUTHORIZED.getStatusCode()) {
                 logger.error("User unauthorized, refreshing tokens");

--- a/src/main/java/clients/symphony/api/APIClient.java
+++ b/src/main/java/clients/symphony/api/APIClient.java
@@ -19,6 +19,7 @@ public abstract class APIClient {
         try {
             return mapper.readValue(errorString, ClientError.class);
         } catch (JsonProcessingException e) {
+            logger.error("Error response is not in json format: {}", errorString);
             ClientError error = new ClientError();
             error.setMessage(errorString);
             return error;

--- a/src/main/java/clients/symphony/api/APIClient.java
+++ b/src/main/java/clients/symphony/api/APIClient.java
@@ -12,6 +12,7 @@ import static javax.ws.rs.core.Response.Status.*;
 
 public abstract class APIClient {
     private final Logger logger = LoggerFactory.getLogger(APIClient.class);
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     protected void handleError(Response response, ISymClient botClient) throws SymClientException {
         if (response.getStatusInfo().getFamily() == Family.SERVER_ERROR) {
@@ -22,7 +23,6 @@ public abstract class APIClient {
             throw new ServerErrorException(response.getStatusInfo().getReasonPhrase());
         } else {
             String errorString = response.readEntity(String.class);
-            ObjectMapper mapper = new ObjectMapper();
             ClientError error;
             try {
                 error = mapper.readValue(errorString, ClientError.class);

--- a/src/main/java/clients/symphony/api/APIClient.java
+++ b/src/main/java/clients/symphony/api/APIClient.java
@@ -1,6 +1,8 @@
 package clients.symphony.api;
 
 import clients.ISymClient;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import exceptions.*;
 import javax.ws.rs.core.Response;
 import model.ClientError;
@@ -19,7 +21,15 @@ public abstract class APIClient {
             );
             throw new ServerErrorException(response.getStatusInfo().getReasonPhrase());
         } else {
-            ClientError error = response.readEntity(ClientError.class);
+            String errorString = response.readEntity(String.class);
+            ObjectMapper mapper = new ObjectMapper();
+            ClientError error;
+            try {
+                error = mapper.readValue(errorString, ClientError.class);
+            } catch (JsonProcessingException e) {
+                throw new APIClientErrorException(e.getMessage());
+            }
+
             if (response.getStatus() == BAD_REQUEST.getStatusCode()) {
                 logger.error("Client error occurred: {}", error);
                 throw new APIClientErrorException(error.getMessage());

--- a/src/test/java/it/clients/symphony/api/StreamsClientTest.java
+++ b/src/test/java/it/clients/symphony/api/StreamsClientTest.java
@@ -4,10 +4,8 @@ import authentication.AuthEndpointConstants;
 import clients.symphony.api.StreamsClient;
 import clients.symphony.api.constants.PodConstants;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
-import exceptions.AuthenticationException;
 import exceptions.SymClientException;
 import it.commons.BotTest;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -19,13 +17,11 @@ import javax.ws.rs.core.NoContentException;
 import model.*;
 import org.junit.Before;
 import org.junit.Test;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.Assert.*;
 
 public class StreamsClientTest extends BotTest {
   private StreamsClient streamsClient;
-
 
   @Before
   public void initClient() {
@@ -545,7 +541,7 @@ public class StreamsClientTest extends BotTest {
   }
 
   @Test(expected = SymClientException.class)
-  public void getListUserStreamsUnauthorized() throws AuthenticationException {
+  public void getListUserStreamsUnauthorized() {
     stubFor(post(urlEqualTo(PodConstants.LISTUSERSTREAMS + "?skip=0&limit=50"))
             .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
             .willReturn(aResponse()

--- a/src/test/java/it/clients/symphony/api/StreamsClientTest.java
+++ b/src/test/java/it/clients/symphony/api/StreamsClientTest.java
@@ -1,9 +1,14 @@
 package it.clients.symphony.api;
 
+import authentication.AuthEndpointConstants;
 import clients.symphony.api.StreamsClient;
 import clients.symphony.api.constants.PodConstants;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import exceptions.AuthenticationException;
+import exceptions.SymClientException;
 import it.commons.BotTest;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,11 +19,13 @@ import javax.ws.rs.core.NoContentException;
 import model.*;
 import org.junit.Before;
 import org.junit.Test;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.Assert.*;
 
 public class StreamsClientTest extends BotTest {
   private StreamsClient streamsClient;
+
 
   @Before
   public void initClient() {
@@ -486,6 +493,74 @@ public class StreamsClientTest extends BotTest {
 
     assertNotNull(streamsList);
     assertEquals(1, streamsList.size());
+  }
+
+  @Test
+  public void getListUserStreamsUnAuthorizedSuccessRetry() {
+    stubFor(post(urlEqualTo(PodConstants.LISTUSERSTREAMS + "?skip=0&limit=50"))
+            .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
+            .inScenario("Get List User Streams")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willReturn(aResponse()
+                    .withStatus(401)
+                    .withBody("{\r\n" +
+                            "   \"message\":  \"Can't retrieve session from ID 688787d8ff144c502c7\"\r\n" +
+                            "}"))
+            .willSetStateTo("Failed first time"));
+    stubPost(
+            AuthEndpointConstants.KEY_AUTH_PATH_RSA,
+            "{ \"token\": \"0100e4feOiJSUzUxMiJ97oqGf729d1866f\", \"name\": \"sessionToken\" }"
+    );
+    stubPost(
+            AuthEndpointConstants.SESSION_AUTH_PATH_RSA,
+            "{ \"token\": \"eyJhbGciOiJSUzUxMiJ97oqG1Kd28l1FpQ\", \"name\": \"sessionToken\" }"
+    );
+    stubFor(post(urlEqualTo(PodConstants.LISTUSERSTREAMS + "?skip=0&limit=50"))
+            .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
+            .inScenario("Get List User Streams")
+            .whenScenarioStateIs("Failed first time")
+            .willReturn(aResponse()
+                    .withStatus(200)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("[\n" +
+                            "  {\n" +
+                            "    \"id\": \"iWyZBIOdQQzQj0tKOLRivX___qu6YeyZdA\",\n" +
+                            "    \"crossPod\": false,\n" +
+                            "    \"active\": true,\n" +
+                            "    \"streamType\": {\n" +
+                            "      \"type\": \"POST\"\n" +
+                            "    },\n" +
+                            "    \"streamAttributes\": {\n" +
+                            "      \"members\": [\n" +
+                            "        7215545078229\n" +
+                            "      ]\n" +
+                            "    }\n" +
+                            "  }\n" +
+                            "]")));
+
+    List<String> streamTypes = Arrays.asList("IM", "POST");
+    List<StreamListItem> streams =  streamsClient.getUserStreams(streamTypes, true);
+    assertEquals(streams.size(), 1);
+    assertEquals(streams.get(0).getId(), "iWyZBIOdQQzQj0tKOLRivX___qu6YeyZdA");
+  }
+
+  @Test(expected = SymClientException.class)
+  public void getListUserStreamsUnauthorized() throws AuthenticationException {
+    stubFor(post(urlEqualTo(PodConstants.LISTUSERSTREAMS + "?skip=0&limit=50"))
+            .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON))
+            .willReturn(aResponse()
+                    .withStatus(401)
+                    .withBody("{\r\n" +
+                            "   \"message\":  \"Can't retrieve session from ID 688787d8ff144c502c7f5cffaafe2cc588d86079f9de88304c26b0cb99ce91c6\"\r\n" +
+                            "}")));
+
+    stubPost(
+            AuthEndpointConstants.SESSION_AUTH_PATH_RSA,
+            "{ \"error\": \"Service unavailable\" }",
+            503
+    );
+    List<String> streamTypes = Arrays.asList("IM", "POST");
+    streamsClient.getUserStreams(streamTypes, true);
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
The issue in ticket SDK-90 comes from the 401 error returned with no content-type in headers.
`ClientError error = response.readEntity(ClientError.class);`
So, instead using Json parser to `readEntity` as `ClientError` object, we will content of response as a String then parse it with Jackson.
```
String errorString = response.readEntity(String.class);
ObjectMapper mapper = new ObjectMapper();
ClientError error;
try {
       error = mapper.readValue(errorString, ClientError.class);
} catch (JsonProcessingException e) {
       throw new APIClientErrorException(e.getMessage());
}
```