### PR TITLE
SDK-99: make tests SymConfigLoaderTest compatible with windows

### DIFF
--- a/src/test/java/it/configuration/SymConfigLoaderTest.java
+++ b/src/test/java/it/configuration/SymConfigLoaderTest.java
@@ -1,5 +1,7 @@
 package it.configuration;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import configuration.SymConfig;
 import configuration.SymConfigLoader;
 import it.commons.BaseTest;
@@ -7,11 +9,17 @@ import it.commons.BaseTest;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class SymConfigLoaderTest {
+
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
   @Test
   public void loadConfig() {
     InputStream configFileStream = BaseTest.class.getResourceAsStream("/bot-config.json");
@@ -22,29 +30,34 @@ public class SymConfigLoaderTest {
   }
 
   @Test
-  public void nullDatafeedIdFilePathShouldReturnCurrentFolder() {
-    assertInputProducesDatafeedIdPath("{}", "." + File.separator);
+  public void nullDatafeedIdFilePathShouldReturnCurrentFolder() throws JsonProcessingException {
+    assertInputProducesDatafeedIdPath(null, "." + File.separator);
   }
 
   @Test
-  public void emptyDatafeedIdFilePathShouldReturnCurrentFolder() {
-    assertInputProducesDatafeedIdPath("{ \"datafeedIdFilePath\": \"\"}", "." + File.separator);
+  public void emptyDatafeedIdFilePathShouldReturnCurrentFolder() throws JsonProcessingException {
+    assertInputProducesDatafeedIdPath("", "." + File.separator);
   }
 
   @Test
-  public void nonEmptyDatafeedIdFilePathShouldAppendSeparator() {
+  public void nonEmptyDatafeedIdFilePathShouldAppendSeparator() throws JsonProcessingException {
     String folder = "folder";
-    assertInputProducesDatafeedIdPath("{ \"datafeedIdFilePath\": \"" + folder + "\"}", folder + File.separator);
+    assertInputProducesDatafeedIdPath(folder, folder + File.separator);
   }
 
   @Test
-  public void nonEmptyDatafeedIdFilePathWithSeparatorShouldReturnTheSame() {
+  public void nonEmptyDatafeedIdFilePathWithSeparatorShouldReturnTheSame() throws JsonProcessingException {
     String folder = "folder" + File.separator;
-    assertInputProducesDatafeedIdPath("{ \"datafeedIdFilePath\": \"" + folder + "\"}", folder);
+    assertInputProducesDatafeedIdPath(folder, folder);
   }
 
-  private void assertInputProducesDatafeedIdPath(String configFileContent, String expected) {
-    InputStream configStream = new ByteArrayInputStream(configFileContent.getBytes());
+  private void assertInputProducesDatafeedIdPath(String inputFolder, String expected) throws JsonProcessingException {
+    Map<String, Object> params = new HashMap<>();
+    params.put("datafeedIdFilePath", inputFolder);
+
+    String payload = OBJECT_MAPPER.writeValueAsString(params);
+
+    InputStream configStream = new ByteArrayInputStream(payload.getBytes());
     SymConfig config = SymConfigLoader.load(configStream);
 
     assertNotNull(config);


### PR DESCRIPTION
This is to have file separator '\' on Windows being escaped properly in unit tests