### PR TITLE
Move DatafeedClient out of datafeeds package

### DIFF
--- a/src/main/java/clients/SymBotClient.java
+++ b/src/main/java/clients/SymBotClient.java
@@ -4,7 +4,7 @@ import authentication.ISymAuth;
 import authentication.SymBotAuth;
 import authentication.SymBotRSAAuth;
 import clients.symphony.api.*;
-import clients.symphony.api.datafeeds.DatafeedClient;
+import clients.symphony.api.DatafeedClient;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/clients/symphony/api/DatafeedClient.java
+++ b/src/main/java/clients/symphony/api/DatafeedClient.java
@@ -1,4 +1,4 @@
-package clients.symphony.api.datafeeds;
+package clients.symphony.api;
 
 import clients.SymBotClient;
 import clients.symphony.api.constants.DatafeedVersion;
@@ -6,8 +6,6 @@ import configuration.SymConfig;
 import exceptions.SymClientException;
 import model.DatafeedEvent;
 import model.datafeed.DatafeedV2;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 

--- a/src/main/java/clients/symphony/api/DatafeedClientV1.java
+++ b/src/main/java/clients/symphony/api/DatafeedClientV1.java
@@ -1,7 +1,6 @@
-package clients.symphony.api.datafeeds;
+package clients.symphony.api;
 
 import clients.SymBotClient;
-import clients.symphony.api.APIClient;
 import clients.symphony.api.constants.AgentConstants;
 import configuration.SymConfig;
 import configuration.SymLoadBalancedConfig;

--- a/src/main/java/clients/symphony/api/DatafeedClientV2.java
+++ b/src/main/java/clients/symphony/api/DatafeedClientV2.java
@@ -1,7 +1,6 @@
-package clients.symphony.api.datafeeds;
+package clients.symphony.api;
 
 import clients.SymBotClient;
-import clients.symphony.api.APIClient;
 import clients.symphony.api.constants.AgentConstants;
 import configuration.SymConfig;
 import exceptions.SymClientException;

--- a/src/main/java/clients/symphony/api/IDatafeedClient.java
+++ b/src/main/java/clients/symphony/api/IDatafeedClient.java
@@ -1,4 +1,4 @@
-package clients.symphony.api.datafeeds;
+package clients.symphony.api;
 
 import model.DatafeedEvent;
 import model.datafeed.DatafeedV2;

--- a/src/main/java/services/AbstractDatafeedEventsService.java
+++ b/src/main/java/services/AbstractDatafeedEventsService.java
@@ -1,7 +1,7 @@
 package services;
 
 import clients.SymBotClient;
-import clients.symphony.api.datafeeds.DatafeedClient;
+import clients.symphony.api.DatafeedClient;
 import listeners.*;
 import model.DatafeedEvent;
 import model.Initiator;

--- a/src/test/java/it/clients/symphony/api/DatafeedClientV1Test.java
+++ b/src/test/java/it/clients/symphony/api/DatafeedClientV1Test.java
@@ -3,7 +3,7 @@ package it.clients.symphony.api;
 import authentication.SymBotRSAAuth;
 import clients.SymBotClient;
 import clients.symphony.api.constants.PodConstants;
-import clients.symphony.api.datafeeds.DatafeedClient;
+import clients.symphony.api.DatafeedClient;
 import clients.symphony.api.constants.AgentConstants;
 import it.commons.BotTest;
 

--- a/src/test/java/it/clients/symphony/api/DatafeedClientV2Test.java
+++ b/src/test/java/it/clients/symphony/api/DatafeedClientV2Test.java
@@ -3,7 +3,7 @@ package it.clients.symphony.api;
 import authentication.SymBotRSAAuth;
 import clients.SymBotClient;
 import clients.symphony.api.constants.PodConstants;
-import clients.symphony.api.datafeeds.DatafeedClient;
+import clients.symphony.api.DatafeedClient;
 import clients.symphony.api.constants.AgentConstants;
 import it.commons.BotTest;
 import model.DatafeedEvent;

--- a/src/test/java/services/DatafeedEventsServiceTest.java
+++ b/src/test/java/services/DatafeedEventsServiceTest.java
@@ -1,7 +1,7 @@
 package services;
 
 import clients.SymBotClient;
-import clients.symphony.api.datafeeds.DatafeedClient;
+import clients.symphony.api.DatafeedClient;
 import configuration.SymConfig;
 import exceptions.APIClientErrorException;
 import model.datafeed.DatafeedV2;


### PR DESCRIPTION
Before, the DatafeedClient is under symphony.api package, so moving it
to datafeeds package might break the compatibility of project. That's
why it should be moved out of datafeed package, back to symphony.api.