### PR TITLE
Add Configuration features for BDK 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           key: v1-dependencies-{{ checksum "pom.xml" }}
 
       # run tests!
-      - run: mvn checkstyle:check integration-test
+      - run: mvn checkstyle:check integration-test -P2.0
 
       - run:
           name: Save test results

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <commons-io.version>2.6</commons-io.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <lombok.version>1.18.12</lombok.version>
+        <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
         <migbase64.version>2.2</migbase64.version>
         <slf4j.version>1.7.30</slf4j.version>
 
@@ -266,6 +267,14 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/symphony-bdk-core/pom.xml
+++ b/symphony-bdk-core/pom.xml
@@ -17,6 +17,7 @@
 
         <!-- Alphabetical order -->
         <bcpkix-jdk15on.version>1.64</bcpkix-jdk15on.version>
+        <jackson.version>2.11.2</jackson.version>
         <jjwt.version>0.9.1</jjwt.version>
         <jsr305.version>3.0.2</jsr305.version>
         <swagger-annotations.version>1.6.0</swagger-annotations.version>
@@ -82,6 +83,18 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <version>${bcpkix-jdk15on.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 
         <!-- ******************************** -->
@@ -184,6 +197,69 @@
                         </goals>
                         <configuration>
                             <inputSpec>${codegen.spec.base}/login/login-api-public.yaml</inputSpec>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <configuration>
+                    <excludes>
+                        <!-- No need to cover exceptions and configs, mostly getters and setters -->
+                        <exclude>com/symphony/bdk/core/**/*Adapter.class</exclude>
+                        <exclude>com/symphony/bdk/core/**/*Type.class</exclude>
+                        <exclude>com/symphony/bdk/core/**/*Config.class</exclude>
+                        <exclude>com/symphony/bdk/core/**/*Exception.class</exclude>
+
+                        <!-- We don't cover generated code -->
+                        <exclude>com/symphony/bdk/gen/**/*</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>target/jacoco.exec</dataFile>
+                            <outputDirectory>target/jacoco-report</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>CLASS</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.9</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
                         </configuration>
                     </execution>
                 </executions>

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/BdkConfigLoader.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/BdkConfigLoader.java
@@ -1,0 +1,156 @@
+package com.symphony.bdk.core.config;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.symphony.bdk.core.config.legacy.model.LegacySymConfig;
+import com.symphony.bdk.core.config.model.BdkConfig;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+public class BdkConfigLoader {
+
+    private static final JsonMapper JSON_MAPPER = new JsonMapper();
+    private static final YAMLMapper YAML_MAPPER = new YAMLMapper();
+
+    /**
+     * Load BdkConfig from a file path
+     *
+     * @param configPath Path of the config file
+     *
+     * @return Symphony Bot Configuration
+     */
+    public static BdkConfig loadFromFile(String configPath) {
+        try {
+            return JSON_MAPPER.readValue(new File(configPath), BdkConfig.class);
+        } catch (IOException e) {
+            log.debug("Config is not in JSON format");
+        }
+
+        try {
+            return YAML_MAPPER.readValue(new File(configPath), BdkConfig.class);
+        } catch (IOException e) {
+            log.debug("Config is not in Yaml format");
+        }
+
+        log.error("Config is not in a valid format");
+        return null;
+    }
+
+    /**
+     * Load BdkConfig from an InputStream
+     *
+     * @param inputStream InputStream
+     *
+     * @return Symphony Bot Configuration
+     */
+    public static BdkConfig loadFromInputStream(InputStream inputStream) {
+        try {
+            return JSON_MAPPER.readValue(inputStream, BdkConfig.class);
+        } catch (IOException e) {
+            log.debug("Config is not in JSON format");
+        }
+
+        try {
+            return YAML_MAPPER.readValue(inputStream, BdkConfig.class);
+        } catch (IOException e) {
+            log.debug("Config is not in Yaml format");
+        }
+
+        log.error("Config is not in a valid format");
+        return null;
+    }
+
+    /**
+     * Load BdkConfig from a classpath
+     *
+     * @param configPath Classpath to config file
+     *
+     * @return Symphony Bot Configuration
+     */
+    public static BdkConfig loadFromClasspath(String configPath) {
+        if (!configPath.startsWith(File.separator)) {
+            configPath = File.separator + configPath;
+        }
+        String externalUrlPath = System.getProperty("user.dir") + configPath;
+
+        BdkConfig config;
+        if ((new File(externalUrlPath)).exists()) {
+            config = loadFromFile(externalUrlPath);
+        } else {
+            InputStream is = BdkConfigLoader.class.getResourceAsStream(configPath);
+            if (is == null) {
+                is = Thread.currentThread().getContextClassLoader().getResourceAsStream(configPath);
+            }
+            config = loadFromInputStream(is);
+        }
+
+        return config;
+    }
+
+    /**
+     * Load LegacySymConfig from a config file
+     *
+     * @param configPath Path to config file
+     *
+     * @return Symphony Bot Legacy Configuration
+     */
+    public static LegacySymConfig loadLegacyConfigFromFile(String configPath) {
+        try {
+            return JSON_MAPPER.readValue(new File(configPath), LegacySymConfig.class);
+        } catch (IOException e) {
+            log.debug("Config is not in JSON format");
+        }
+
+        log.error("Config is not in a valid format");
+        return null;
+    }
+
+    /**
+     * Load LegacySymConfig from an input stream
+     *
+     * @param inputStream InputStream
+     *
+     * @return Symphony Bot Legacy Configuration
+     */
+    public static LegacySymConfig loadLegacyConfigFromInputStream(InputStream inputStream) {
+        try {
+            return JSON_MAPPER.readValue(inputStream, LegacySymConfig.class);
+        } catch (IOException e) {
+            log.debug("Config is not in JSON format");
+        }
+
+        log.error("Config is not in a valid format");
+        return null;
+    }
+
+    /**
+     * Load LegacySymConfig from a classpath
+     *
+     * @param configPath Classpath to config file
+     *
+     * @return Symphony Bot Legacy Configuration
+     */
+    public static LegacySymConfig loadLegacyConfigFromClasspath(String configPath) {
+        if (!configPath.startsWith(File.separator)) {
+            configPath = File.separator + configPath;
+        }
+        String externalUrlPath = System.getProperty("user.dir") + configPath;
+
+        LegacySymConfig config;
+        if ((new File(externalUrlPath)).exists()) {
+            config = loadLegacyConfigFromFile(externalUrlPath);
+        } else {
+            InputStream is = BdkConfigLoader.class.getResourceAsStream(configPath);
+            if (is == null) {
+                is = Thread.currentThread().getContextClassLoader().getResourceAsStream(configPath);
+            }
+            config = loadLegacyConfigFromInputStream(is);
+        }
+
+        return config;
+    }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/BdkConfigParser.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/BdkConfigParser.java
@@ -1,9 +1,11 @@
 package com.symphony.bdk.core.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.symphony.bdk.core.exceptions.BdkConfigException;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -15,7 +17,9 @@ class BdkConfigParser {
     private static final ObjectMapper JSON_MAPPER = new JsonMapper();
     private static final ObjectMapper YAML_MAPPER = new YAMLMapper();
 
-    public static JsonNode parse(InputStream inputStream) {
+    public static JsonNode parse(InputStream inputStream) throws BdkConfigException {
+        JSON_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        YAML_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         try {
             return JSON_MAPPER.readTree(inputStream);
         } catch (IOException e) {
@@ -27,7 +31,6 @@ class BdkConfigParser {
         } catch (IOException e) {
             log.debug("Config file is not in YAML format");
         }
-        log.error("Config file is not in a valid format");
-        return null;
+        throw new BdkConfigException("Config file is not in a valid format");
     }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/BdkConfigParser.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/BdkConfigParser.java
@@ -1,0 +1,33 @@
+package com.symphony.bdk.core.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+class BdkConfigParser {
+
+    private static final ObjectMapper JSON_MAPPER = new JsonMapper();
+    private static final ObjectMapper YAML_MAPPER = new YAMLMapper();
+
+    public static JsonNode parse(InputStream inputStream) {
+        try {
+            return JSON_MAPPER.readTree(inputStream);
+        } catch (IOException e) {
+            log.debug("Config file is not in JSON format");
+        }
+
+        try {
+            return YAML_MAPPER.readTree(inputStream);
+        } catch (IOException e) {
+            log.debug("Config file is not in YAML format");
+        }
+        log.error("Config file is not in a valid format");
+        return null;
+    }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/LegacyConfigMapper.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/LegacyConfigMapper.java
@@ -1,0 +1,57 @@
+package com.symphony.bdk.core.config;
+
+import com.symphony.bdk.core.config.legacy.model.LegacySymConfig;
+import com.symphony.bdk.core.config.model.*;
+
+public class LegacyConfigMapper {
+
+    public static BdkConfig map(LegacySymConfig legacySymConfig) {
+        BdkClientConfig pod = new BdkClientConfig();
+        pod.setHost(legacySymConfig.getPodHost());
+        pod.setPort(legacySymConfig.getPodPort());
+        pod.setContext(legacySymConfig.getPodContextPath());
+
+        BdkClientConfig agent = new BdkClientConfig();
+        agent.setHost(legacySymConfig.getAgentHost());
+        agent.setPort(legacySymConfig.getAgentPort());
+        agent.setContext(legacySymConfig.getAgentContextPath());
+
+        BdkClientConfig keyManager = new BdkClientConfig();
+        keyManager.setHost(legacySymConfig.getKeyAuthHost());
+        keyManager.setPort(legacySymConfig.getKeyAuthPort());
+        keyManager.setContext(legacySymConfig.getKeyAuthContextPath());
+
+        BdkBotConfig bot = new BdkBotConfig();
+        bot.setUsername(legacySymConfig.getBotUsername());
+        if (legacySymConfig.getBotPrivateKeyPath() != null && legacySymConfig.getBotPrivateKeyName() != null) {
+            bot.setPrivateKeyPath(legacySymConfig.getBotPrivateKeyPath() + legacySymConfig.getBotPrivateKeyName());
+        }
+        if (legacySymConfig.getBotCertPath() != null && legacySymConfig.getAppCertName() != null) {
+            bot.setCertificatePath(legacySymConfig.getBotCertPath() + legacySymConfig.getBotCertName());
+        }
+        bot.setCertificatePassword(legacySymConfig.getBotCertPassword());
+
+        BdkExtAppConfig app = new BdkExtAppConfig();
+        app.setAppId(legacySymConfig.getAppId());
+        if (legacySymConfig.getAppPrivateKeyPath() != null && legacySymConfig.getAppPrivateKeyName() != null) {
+            app.setPrivateKeyPath(legacySymConfig.getAppPrivateKeyPath() + legacySymConfig.getAppPrivateKeyName());
+        }
+        if (legacySymConfig.getAppCertPath() != null && legacySymConfig.getAppCertName() != null) {
+            app.setCertificatePath(legacySymConfig.getAgentContextPath() + legacySymConfig.getAppCertName());
+        }
+        app.setCertificatePassword(legacySymConfig.getAppCertPassword());
+
+        BdkSslConfig ssl = new BdkSslConfig();
+        ssl.setTrustStorePath(legacySymConfig.getTruststorePath());
+        ssl.setTrustStorePassword(legacySymConfig.getTruststorePassword());
+
+        BdkConfig config = new BdkConfig();
+        config.setAgent(agent);
+        config.setPod(pod);
+        config.setKeyManager(keyManager);
+        config.setBot(bot);
+        config.setApp(app);
+        config.setSsl(ssl);
+        return config;
+    }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/legacy/model/LegacyRetryConfiguration.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/legacy/model/LegacyRetryConfiguration.java
@@ -10,8 +10,9 @@ import org.apiguardian.api.API;
  */
 @ToString
 @Getter @Setter
-@API(status = API.Status.EXPERIMENTAL)
-public class RetryConfiguration {
+@Deprecated
+@API(status = API.Status.DEPRECATED)
+public class LegacyRetryConfiguration {
 
     public static final int DEFAULT_MAX_ATTEMPTS = 10;
     public static final long DEFAULT_INITIAL_INTERVAL_MILLIS = 500L;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/legacy/model/LegacySymConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/legacy/model/LegacySymConfig.java
@@ -1,0 +1,154 @@
+package com.symphony.bdk.core.config.legacy.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.File;
+import java.util.ArrayList;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LegacySymConfig {
+
+    private static final int DEFAULT_CONNECTION_TIMEOUT = 10_000;
+    private static final int DEFAULT_READ_TIMEOUT = 35_000;
+    private static final String DEFAULT_SCHEME = "https";
+
+    // ---------------------------------------------------------------------------------------------------------------//
+    // NETWORK
+    //
+    private String scheme = DEFAULT_SCHEME;
+    private String sessionAuthHost;
+    private int sessionAuthPort;
+    private String sessionAuthContextPath;
+
+    private String keyAuthHost;
+    private int keyAuthPort;
+    private String keyAuthContextPath;
+    private String keyManagerProxyURL;
+    private String keyManagerProxyUsername;
+    private String keyManagerProxyPassword;
+
+    private String podHost;
+    private int podPort;
+    private String podContextPath;
+    private String podProxyURL;
+    private String podProxyUsername;
+    private String podProxyPassword;
+
+    private String agentHost;
+    private int agentPort;
+    private String agentContextPath;
+    private String agentProxyURL;
+    private String agentProxyUsername;
+    private String agentProxyPassword;
+
+    private String proxyURL;
+    private String proxyUsername;
+    private String proxyPassword;
+
+
+
+    private int connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
+    private int readTimeout = DEFAULT_READ_TIMEOUT;
+
+    // ---------------------------------------------------------------------------------------------------------------//
+    // AUTHENTICATION
+    //
+    private String botUsername;
+    private String botEmailAddress;
+    // rsa
+    private String botPrivateKeyPath;
+    private String botPrivateKeyName;
+    // cert
+    private String botCertPath;
+    private String botCertName;
+    private String botCertPassword;
+
+    private String appId;
+    // rsa
+    private String appPrivateKeyPath;
+    private String appPrivateKeyName;
+    // cert
+    private String appCertPath;
+    private String appCertName;
+    private String appCertPassword;
+
+    // ---------------------------------------------------------------------------------------------------------------//
+    // SSL
+    //
+    private String truststorePath;
+    private String truststorePassword;
+
+    // ---------------------------------------------------------------------------------------------------------------//
+    // DATAFEED
+    private String datafeedVersion;
+    private int datafeedEventsThreadpoolSize;
+    private int datafeedEventsErrorTimeout;
+    private Boolean reuseDatafeedID;
+    private String datafeedIdFilePath;
+
+    // ---------------------------------------------------------------------------------------------------------------//
+    // MISC
+    //
+    private String authenticationFilterUrlPattern;
+    private boolean showFirehoseErrors;
+    private ArrayList<String> supportedUriSchemes = new ArrayList<>();
+    private RetryConfiguration retry = new RetryConfiguration();
+
+    public String getAgentUrl() {
+        String port = (this.getAgentPort() == 443) ? "" : ":" + this.getAgentPort();
+        String contextPath = formatContextPath(this.getAgentContextPath());
+        return this.getScheme() + "://" + this.getAgentHost() + port + contextPath;
+    }
+
+    public String getPodUrl() {
+        String port = (this.getPodPort() == 443) ? "" : ":" + this.getPodPort();
+        String contextPath = formatContextPath(this.getPodContextPath());
+        return this.getScheme() + "://" + this.getPodHost() + port + contextPath;
+    }
+
+    public String getKeyAuthUrl() {
+        String port = (this.getKeyAuthPort() == 443) ? "" : ":" + this.getKeyAuthPort();
+        String contextPath = formatContextPath(this.getKeyAuthContextPath());
+        return this.getScheme() + "://" + this.getKeyAuthHost() + port + contextPath;
+    }
+
+    public String getSessionAuthUrl() {
+        String port = (this.getSessionAuthPort() == 443) ? "" : ":" + this.getSessionAuthPort();
+        String contextPath = formatContextPath(this.getSessionAuthContextPath());
+        return this.getScheme() + "://" + this.getSessionAuthHost() + port + contextPath;
+    }
+
+    public String getDatafeedIdFilePath() {
+        if (datafeedIdFilePath == null || datafeedIdFilePath.isEmpty()) {
+            return "." + File.separator;
+        }
+        if (!datafeedIdFilePath.endsWith(File.separator)) {
+            return datafeedIdFilePath + File.separator;
+        }
+        return datafeedIdFilePath;
+    }
+
+    private String formatContextPath(String contextPath) {
+        String formattedPath = (contextPath == null) ? "" : contextPath;
+        if (!formattedPath.equals("") && formattedPath.charAt(0) != '/') {
+            formattedPath =  "/" + formattedPath;
+        }
+        if (!formattedPath.equals("") && formattedPath.endsWith("/")) {
+            formattedPath = formattedPath.substring(0, formattedPath.length() - 1);
+        }
+        return formattedPath;
+    }
+
+    public int getDatafeedEventsThreadpoolSize() {
+        return this.datafeedEventsThreadpoolSize > 0 ? this.datafeedEventsThreadpoolSize : 5;
+    }
+
+    public int getDatafeedEventsErrorTimeout() {
+        return this.datafeedEventsErrorTimeout > 0 ? this.datafeedEventsErrorTimeout : 30;
+    }
+
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/legacy/model/LegacySymConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/legacy/model/LegacySymConfig.java
@@ -16,6 +16,8 @@ public class LegacySymConfig {
     private static final int DEFAULT_READ_TIMEOUT = 35_000;
     private static final String DEFAULT_SCHEME = "https";
 
+    private String _version = "1.0";
+
     // ---------------------------------------------------------------------------------------------------------------//
     // NETWORK
     //
@@ -96,7 +98,7 @@ public class LegacySymConfig {
     private String authenticationFilterUrlPattern;
     private boolean showFirehoseErrors;
     private ArrayList<String> supportedUriSchemes = new ArrayList<>();
-    private RetryConfiguration retry = new RetryConfiguration();
+    private LegacyRetryConfiguration retry = new LegacyRetryConfiguration();
 
     public String getAgentUrl() {
         String port = (this.getAgentPort() == 443) ? "" : ":" + this.getAgentPort();

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/legacy/model/RetryConfiguration.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/legacy/model/RetryConfiguration.java
@@ -1,0 +1,23 @@
+package com.symphony.bdk.core.config.legacy.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.apiguardian.api.API;
+
+/**
+ * Sub-configuration class for Retry parametrization. Experimental, the contract might change in the future.
+ */
+@ToString
+@Getter @Setter
+@API(status = API.Status.EXPERIMENTAL)
+public class RetryConfiguration {
+
+    public static final int DEFAULT_MAX_ATTEMPTS = 10;
+    public static final long DEFAULT_INITIAL_INTERVAL_MILLIS = 500L;
+    public static final double DEFAULT_MULTIPLIER = 1.5;
+
+    private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+    private long initialIntervalMillis = DEFAULT_INITIAL_INTERVAL_MILLIS;
+    private double multiplier = DEFAULT_MULTIPLIER;
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkBotConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkBotConfig.java
@@ -12,5 +12,5 @@ public class BdkBotConfig {
     private String username;
     private String privateKeyPath;
     private String certificatePath;
-    private String getCertificatePassword;
+    private String certificatePassword;
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkBotConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkBotConfig.java
@@ -1,0 +1,16 @@
+package com.symphony.bdk.core.config.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BdkBotConfig {
+
+    private String username;
+    private String privateKeyPath;
+    private String certificatePath;
+    private String getCertificatePassword;
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkBotConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkBotConfig.java
@@ -1,12 +1,10 @@
 package com.symphony.bdk.core.config.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BdkBotConfig {
 
     private String username;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkClientConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkClientConfig.java
@@ -1,0 +1,33 @@
+package com.symphony.bdk.core.config.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BdkClientConfig {
+
+    private static final String DEFAULT_SCHEME = "https";
+    private static final int DEFAULT_HTTPS_PORT = 443;
+
+    private String scheme = DEFAULT_SCHEME;
+    private String url;
+    private int port;
+    private String context = "";
+
+    public String getBasePath() {
+        return this.scheme + "://" + this.url + ":" + this.port;
+    }
+
+    public String getContext() {
+        if (!context.equals("") && context.charAt(0) != '/') {
+            context =  "/" + context;
+        }
+        if (!context.equals("") && context.endsWith("/")) {
+            context = context.substring(0, context.length() - 1);
+        }
+        return context;
+    }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkClientConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkClientConfig.java
@@ -13,12 +13,12 @@ public class BdkClientConfig {
     private static final int DEFAULT_HTTPS_PORT = 443;
 
     private String scheme = DEFAULT_SCHEME;
-    private String url;
+    private String host;
     private int port;
     private String context = "";
 
     public String getBasePath() {
-        return this.scheme + "://" + this.url + ":" + this.port;
+        return this.scheme + "://" + this.host + ":" + this.port + this.getContext();
     }
 
     public String getContext() {

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkClientConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkClientConfig.java
@@ -1,12 +1,10 @@
 package com.symphony.bdk.core.config.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BdkClientConfig {
 
     private static final String DEFAULT_SCHEME = "https";

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkConfig.java
@@ -1,0 +1,19 @@
+package com.symphony.bdk.core.config.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BdkConfig {
+
+    private BdkClientConfig agent = new BdkClientConfig();
+    private BdkClientConfig pod = new BdkClientConfig();
+    private BdkClientConfig keyManager = new BdkClientConfig();
+
+    private BdkBotConfig bot = new BdkBotConfig();
+    private BdkExtAppConfig app = new BdkExtAppConfig();
+    private BdkSSLConfig ssl = new BdkSSLConfig();
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkConfig.java
@@ -1,13 +1,10 @@
 package com.symphony.bdk.core.config.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.symphony.bdk.core.config.legacy.model.LegacySymConfig;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BdkConfig {
 
     private String _version = "2.0";
@@ -20,53 +17,4 @@ public class BdkConfig {
     private BdkExtAppConfig app = new BdkExtAppConfig();
     private BdkSslConfig ssl = new BdkSslConfig();
 
-    public static BdkConfig fromLegacyConfig(LegacySymConfig legacySymConfig) {
-        BdkClientConfig pod = new BdkClientConfig();
-        pod.setHost(legacySymConfig.getPodHost());
-        pod.setPort(legacySymConfig.getPodPort());
-        pod.setContext(legacySymConfig.getPodContextPath());
-
-        BdkClientConfig agent = new BdkClientConfig();
-        agent.setHost(legacySymConfig.getAgentHost());
-        agent.setPort(legacySymConfig.getAgentPort());
-        agent.setContext(legacySymConfig.getAgentContextPath());
-
-        BdkClientConfig keyManager = new BdkClientConfig();
-        keyManager.setHost(legacySymConfig.getKeyAuthHost());
-        keyManager.setPort(legacySymConfig.getKeyAuthPort());
-        keyManager.setContext(legacySymConfig.getKeyAuthContextPath());
-
-        BdkBotConfig bot = new BdkBotConfig();
-        bot.setUsername(legacySymConfig.getBotUsername());
-        if (legacySymConfig.getBotPrivateKeyPath() != null && legacySymConfig.getBotPrivateKeyName() != null) {
-            bot.setPrivateKeyPath(legacySymConfig.getBotPrivateKeyPath() + legacySymConfig.getBotPrivateKeyName());
-        }
-        if (legacySymConfig.getBotCertPath() != null && legacySymConfig.getAppCertName() != null) {
-            bot.setCertificatePath(legacySymConfig.getBotCertPath() + legacySymConfig.getBotCertName());
-        }
-        bot.setCertificatePassword(legacySymConfig.getBotCertPassword());
-
-        BdkExtAppConfig app = new BdkExtAppConfig();
-        app.setAppId(legacySymConfig.getAppId());
-        if (legacySymConfig.getAppPrivateKeyPath() != null && legacySymConfig.getAppPrivateKeyName() != null) {
-            app.setPrivateKeyPath(legacySymConfig.getAppPrivateKeyPath() + legacySymConfig.getAppPrivateKeyName());
-        }
-        if (legacySymConfig.getAppCertPath() != null && legacySymConfig.getAppCertName() != null) {
-            app.setCertificatePath(legacySymConfig.getAgentContextPath() + legacySymConfig.getAppCertName());
-        }
-        app.setCertificatePassword(legacySymConfig.getAppCertPassword());
-
-        BdkSslConfig ssl = new BdkSslConfig();
-        ssl.setTruststorePath(legacySymConfig.getTruststorePath());
-        ssl.setTruststorePassword(legacySymConfig.getTruststorePassword());
-
-        BdkConfig config = new BdkConfig();
-        config.setAgent(agent);
-        config.setPod(pod);
-        config.setKeyManager(keyManager);
-        config.setBot(bot);
-        config.setApp(app);
-        config.setSsl(ssl);
-        return config;
-    }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkConfig.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.core.config.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.symphony.bdk.core.config.legacy.model.LegacySymConfig;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,11 +10,63 @@ import lombok.Setter;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BdkConfig {
 
+    private String _version = "2.0";
+
     private BdkClientConfig agent = new BdkClientConfig();
     private BdkClientConfig pod = new BdkClientConfig();
     private BdkClientConfig keyManager = new BdkClientConfig();
 
     private BdkBotConfig bot = new BdkBotConfig();
     private BdkExtAppConfig app = new BdkExtAppConfig();
-    private BdkSSLConfig ssl = new BdkSSLConfig();
+    private BdkSslConfig ssl = new BdkSslConfig();
+
+    public static BdkConfig fromLegacyConfig(LegacySymConfig legacySymConfig) {
+        BdkClientConfig pod = new BdkClientConfig();
+        pod.setHost(legacySymConfig.getPodHost());
+        pod.setPort(legacySymConfig.getPodPort());
+        pod.setContext(legacySymConfig.getPodContextPath());
+
+        BdkClientConfig agent = new BdkClientConfig();
+        agent.setHost(legacySymConfig.getAgentHost());
+        agent.setPort(legacySymConfig.getAgentPort());
+        agent.setContext(legacySymConfig.getAgentContextPath());
+
+        BdkClientConfig keyManager = new BdkClientConfig();
+        keyManager.setHost(legacySymConfig.getKeyAuthHost());
+        keyManager.setPort(legacySymConfig.getKeyAuthPort());
+        keyManager.setContext(legacySymConfig.getKeyAuthContextPath());
+
+        BdkBotConfig bot = new BdkBotConfig();
+        bot.setUsername(legacySymConfig.getBotUsername());
+        if (legacySymConfig.getBotPrivateKeyPath() != null && legacySymConfig.getBotPrivateKeyName() != null) {
+            bot.setPrivateKeyPath(legacySymConfig.getBotPrivateKeyPath() + legacySymConfig.getBotPrivateKeyName());
+        }
+        if (legacySymConfig.getBotCertPath() != null && legacySymConfig.getAppCertName() != null) {
+            bot.setCertificatePath(legacySymConfig.getBotCertPath() + legacySymConfig.getBotCertName());
+        }
+        bot.setCertificatePassword(legacySymConfig.getBotCertPassword());
+
+        BdkExtAppConfig app = new BdkExtAppConfig();
+        app.setAppId(legacySymConfig.getAppId());
+        if (legacySymConfig.getAppPrivateKeyPath() != null && legacySymConfig.getAppPrivateKeyName() != null) {
+            app.setPrivateKeyPath(legacySymConfig.getAppPrivateKeyPath() + legacySymConfig.getAppPrivateKeyName());
+        }
+        if (legacySymConfig.getAppCertPath() != null && legacySymConfig.getAppCertName() != null) {
+            app.setCertificatePath(legacySymConfig.getAgentContextPath() + legacySymConfig.getAppCertName());
+        }
+        app.setCertificatePassword(legacySymConfig.getAppCertPassword());
+
+        BdkSslConfig ssl = new BdkSslConfig();
+        ssl.setTruststorePath(legacySymConfig.getTruststorePath());
+        ssl.setTruststorePassword(legacySymConfig.getTruststorePassword());
+
+        BdkConfig config = new BdkConfig();
+        config.setAgent(agent);
+        config.setPod(pod);
+        config.setKeyManager(keyManager);
+        config.setBot(bot);
+        config.setApp(app);
+        config.setSsl(ssl);
+        return config;
+    }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkExtAppConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkExtAppConfig.java
@@ -1,12 +1,10 @@
 package com.symphony.bdk.core.config.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BdkExtAppConfig {
 
     private String appId;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkExtAppConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkExtAppConfig.java
@@ -1,0 +1,16 @@
+package com.symphony.bdk.core.config.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BdkExtAppConfig {
+
+    private String appId;
+    private String privateKeyPath;
+    private String certificatePath;
+    private String certificatePassword;
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkSSLConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkSSLConfig.java
@@ -1,0 +1,14 @@
+package com.symphony.bdk.core.config.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BdkSSLConfig {
+
+    private String truststorePath;
+    private String truststorePassword;
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkSslConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkSslConfig.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class BdkSSLConfig {
+public class BdkSslConfig {
 
     private String truststorePath;
     private String truststorePassword;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkSslConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkSslConfig.java
@@ -1,14 +1,12 @@
 package com.symphony.bdk.core.config.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BdkSslConfig {
 
-    private String truststorePath;
-    private String truststorePassword;
+    private String trustStorePath;
+    private String trustStorePassword;
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/exceptions/BdkConfigException.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/exceptions/BdkConfigException.java
@@ -1,0 +1,8 @@
+package com.symphony.bdk.core.exceptions;
+
+public class BdkConfigException extends Exception{
+
+    public BdkConfigException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Define new structure for Configuration in 2.0 in BdkConfig.java.

Both of yaml and json formats are supported in 2.0, so Yaml parser
is added for parsing Yaml config

LegacyConfig model for supporting the legacy version of configuration.

Configuration is loaded by BdkConfigLoader in three ways:
- From path of config file: BdkConfigLoader#loadFromFile
- From inputstream: BdkConfigLoader#loadFromInputStream
- From classpath: BdkConfigLoader#loadFromClasspath

Set minimum code coverage score: 0.9