### PR TITLE
Activate code coverage check on BDK 2.0 and legacy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,22 +38,41 @@ jobs:
           key: v1-dependencies-{{ checksum "pom.xml" }}
 
       # run tests!
-      - run: mvn checkstyle:check integration-test -P2.0
+      - run:
+          name: Check BDK 2.0
+          command: mvn checkstyle:check verify -P2.0
+
+      - run:
+          name: Check legacy
+          command: mvn checkstyle:check verify -Plegacy
 
       - run:
           name: Save test results
           command: |
             mkdir -p ~/test-results/junit/
             find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
-            mkdir -p ~/code-coverage/jacoco/
-            find . -type f -regex ".*/target/jacoco.exec" -exec cp {} ~/code-coverage/jacoco/ \;
-            find . -type d -regex ".*/target/jacoco-report" -exec cp -r {} ~/code-coverage/jacoco/ \;
           when: always
+
+      - run:
+          name: Save code coverage BDK 2.0
+          command: |
+            mkdir -p ~/code-coverage/jacoco/symphony-bdk-core/
+            find . -type f -regex ".*/symphony-bdk-core/target/jacoco.exec" -exec cp {} ~/code-coverage/jacoco/symphony-bdk-core/ \;
+            find . -type d -regex ".*/symphony-bdk-core/target/jacoco-report" -exec cp -r {} ~/code-coverage/jacoco/symphony-bdk-core/ \;
+
+      - run:
+          name: Save code coverage Legacy SDK
+          command: |
+            mkdir -p ~/code-coverage/jacoco/symphony-api-client-java/
+            find . -type f -regex ".*/symphony-api-client-java/target/jacoco.exec" -exec cp {} ~/code-coverage/jacoco/symphony-api-client-java/ \;
+            find . -type d -regex ".*/symphony-api-client-java/target/jacoco-report" -exec cp -r {} ~/code-coverage/jacoco/symphony-api-client-java/ \;
 
       - store_test_results:
           path: ~/test-results
+
       - store_artifacts:
           path: ~/test-results/junit
+
       - store_artifacts:
           path: ~/code-coverage/jacoco
 

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.5</version>
+                    <version>${jacoco-maven-plugin.version}</version>
                     <executions>
                         <execution>
                             <goals>
@@ -195,6 +195,12 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>
@@ -267,14 +273,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/symphony-bdk-core/pom.xml
+++ b/symphony-bdk-core/pom.xml
@@ -214,35 +214,14 @@
                         <exclude>com/symphony/bdk/core/**/*Exception.class</exclude>
                         <exclude>com/symphony/bdk/core/**/model/*.class</exclude>
 
+                        <exclude>com/symphony/bdk/core/BdkCore.class</exclude>
+                        <exclude>com/symphony/bdk/core/auth/*</exclude>
+
                         <!-- We don't cover generated code -->
                         <exclude>com/symphony/bdk/gen/**/*</exclude>
                     </excludes>
                 </configuration>
                 <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>jacoco-report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>target/jacoco.exec</dataFile>
-                            <outputDirectory>target/jacoco-report</outputDirectory>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>jacoco-check</id>
                         <goals>

--- a/symphony-bdk-legacy/symphony-api-client-java/pom.xml
+++ b/symphony-bdk-legacy/symphony-api-client-java/pom.xml
@@ -160,4 +160,46 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <configuration>
+                    <excludes>
+                        <!-- No need to cover models, exceptions and configs, mostly getters and setters -->
+                        <exclude>**/*Adapter.class</exclude>
+                        <exclude>**/*Type.class</exclude>
+                        <exclude>**/*Config.class</exclude>
+                        <exclude>**/*Exception.class</exclude>
+                        <exclude>**/model/*.class</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.42</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
I activated code coverage checks on both of BDK 2.0 and Legacy SDK.
For BDK, I temporarily exclude two files: BdkCore.class and JwtHelper.class because there is now no unit test on these two files (the exclusion should be removed when the PR of @symphony-thibault is finished with the code coverage >90%)