### PR TITLE
APP-2898: Fix exception handling when reading a faulty datafeed

### DIFF
--- a/symphony-bdk-legacy/symphony-api-client-java/src/main/java/clients/symphony/api/DatafeedClientV2.java
+++ b/symphony-bdk-legacy/symphony-api-client-java/src/main/java/clients/symphony/api/DatafeedClientV2.java
@@ -95,7 +95,7 @@ final class DatafeedClientV2 extends APIClient implements IDatafeedClient {
                 return null;
             } else {
                 DatafeedV2EventList datafeedEventList = response.readEntity(DatafeedV2EventList.class);
-                logger.info("Read datafeed events from datafeed {} ...", datafeedId);
+                logger.debug("Read datafeed events from datafeed {} ...", datafeedId);
                 this.ackId = datafeedEventList.getAckId();
                 return datafeedEventList.getEvents();
             }

--- a/symphony-bdk-legacy/symphony-api-client-java/src/main/java/services/DatafeedEventsServiceV2.java
+++ b/symphony-bdk-legacy/symphony-api-client-java/src/main/java/services/DatafeedEventsServiceV2.java
@@ -51,6 +51,8 @@ class DatafeedEventsServiceV2 extends AbstractDatafeedEventsService {
             do {
                 try {
                     readEventsFromDatafeed();
+                } catch (APIClientErrorException e) {
+                    logger.debug("Something went wrong rather than faulty datafeed", e);
                 } catch (Exception e) {
                     logger.error("Something went wrong while reading datafeed", e);
                     logger.info("Sleeping for {} seconds before retrying..", botClient.getConfig().getDatafeedEventsErrorTimeout());

--- a/symphony-bdk-legacy/symphony-api-client-java/src/main/java/services/DatafeedEventsServiceV2.java
+++ b/symphony-bdk-legacy/symphony-api-client-java/src/main/java/services/DatafeedEventsServiceV2.java
@@ -80,7 +80,7 @@ class DatafeedEventsServiceV2 extends AbstractDatafeedEventsService {
                 }
             } catch (APIClientErrorException e) {
                 //Datafeed was stale
-                logger.debug("Something went wrong with this datafeed: {}", datafeedId);
+                logger.debug("Something went wrong with this datafeed: {}", datafeedId, e);
                 logger.info(e.getMessage());
                 datafeedClient.deleteDatafeed(datafeedId);
                 break;

--- a/symphony-bdk-legacy/symphony-api-client-java/src/main/java/services/DatafeedEventsServiceV2.java
+++ b/symphony-bdk-legacy/symphony-api-client-java/src/main/java/services/DatafeedEventsServiceV2.java
@@ -51,9 +51,6 @@ class DatafeedEventsServiceV2 extends AbstractDatafeedEventsService {
             do {
                 try {
                     readEventsFromDatafeed();
-                } catch (APIClientErrorException e) {
-                    //Datafeed was stale
-                    logger.info(e.getMessage());
                 } catch (Exception e) {
                     logger.error("Something went wrong while reading datafeed", e);
                     logger.info("Sleeping for {} seconds before retrying..", botClient.getConfig().getDatafeedEventsErrorTimeout());
@@ -74,10 +71,19 @@ class DatafeedEventsServiceV2 extends AbstractDatafeedEventsService {
             datafeedId = datafeedIds.get(0).getId();
         }
         //Read datafeed in loop
+        logger.info("Start reading datafeed events from datafeed {}", datafeedId);
         do {
-            List<DatafeedEvent> events = datafeedClient.readDatafeed(datafeedId, datafeedClient.getAckId());
-            if (events != null && !events.isEmpty()) {
-                handleEvents(events);
+            try {
+                List<DatafeedEvent> events = datafeedClient.readDatafeed(datafeedId, datafeedClient.getAckId());
+                if (events != null && !events.isEmpty()) {
+                    handleEvents(events);
+                }
+            } catch (APIClientErrorException e) {
+                //Datafeed was stale
+                logger.debug("Something went wrong with this datafeed: {}", datafeedId);
+                logger.info(e.getMessage());
+                datafeedClient.deleteDatafeed(datafeedId);
+                break;
             }
 
         } while (started.get());

--- a/symphony-bdk-legacy/symphony-api-client-java/src/test/java/services/DatafeedEventsServiceTest.java
+++ b/symphony-bdk-legacy/symphony-api-client-java/src/test/java/services/DatafeedEventsServiceTest.java
@@ -103,6 +103,7 @@ public class DatafeedEventsServiceTest {
 
         verify(datafeedClient, times(2)).listDatafeedId();
         verify(datafeedClient, times(1)).createDatafeed();
+        verify(datafeedClient, times(1)).deleteDatafeed("123");
         verify(datafeedClient, times(1)).readDatafeed("123", "ack_id_string");
         verify(datafeedClient, atLeast(1)).readDatafeed("1234", "ack_id_string");
         verify(sleeper, times(0)).sleep(anyInt());


### PR DESCRIPTION
Once reading a datafeed throws an APIClientException, it means that
the datafeed is faulty. Before, this datafeed is automatically removed
after being read but now it's not removed anymore. Therefore, the
faulty datafeed should be deleted manually after the exception is thrown.