### PR TITLE
CES-1719: Added the images field to Attachment

### DIFF
--- a/symphony-bdk-legacy/symphony-api-client-java/src/main/java/model/Attachment.java
+++ b/symphony-bdk-legacy/symphony-api-client-java/src/main/java/model/Attachment.java
@@ -2,6 +2,8 @@ package model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.util.List;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Attachment {
 
@@ -9,6 +11,7 @@ public class Attachment {
     private String name;
     private Long size;
     private ImageInfo image;
+    private List<ImageInfo> images;
 
     public String getId() {
         return id;
@@ -40,5 +43,13 @@ public class Attachment {
 
     public void setImage(ImageInfo image) {
         this.image = image;
+    }
+
+    public List<ImageInfo> getImages() {
+        return images;
+    }
+
+    public void setImages(List<ImageInfo> images) {
+        this.images = images;
     }
 }


### PR DESCRIPTION
## Description
- [Jira Ticket](https://perzoinc.atlassian.net/browse/CES-1719)

## Implementation
- We want to make use of the thumbnail of the image attachment.
- We can see that the agent is already sending that inside the attachment object in the `images` field.
- This field was missing in the `Attachment` class. So, we have added it.