### PR TITLE
APP-3000: Simplified configuration when the configuration of api client is the same

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,9 @@ developers configure their own bot.
 ## Configuration structure
 
 The BDK configuration now includes the following properties:
+- The BDK configuration can contain the global properties for `host`, `port`, `context` and `scheme`. 
+These global properties can be used by the client configuration by default or can be override if
+user specify the dedicated `host`, `port`, `context`, `scheme` inside the client configuration.
 - `pod` contains information like host, port, scheme, context, proxy... of the pod on which 
 the service account using by the bot is created.
 - `agent` contains information like host, port, scheme, context, proxy... of the agent which 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,58 @@ The configuration file after being read will be represented by `BdkConfig` class
 - The configuration for `app` is represented by `BdkExtAppConfig`.
 - The configuration for `ssl` is represented by `BdkSslConfig`.
 
+## BDK configuration example
+
+```yaml
+scheme: https
+host: localhost.symphony.com
+port: 8443
+
+pod:
+  host: devx1.symphony.com
+  port: 443
+
+agent:
+  context: agent
+
+keyManager:
+  host: sym-devx1-dev-chat-glb-1-ause1-all.symphony.com
+  port: 8444
+
+sessionAuth:
+  host: sym-devx1-dev-chat-glb-1-ause1-all.symphony.com
+  port: 8444
+
+bot:
+  username: bot-name
+  privateKeyPath: path/to/private-key.pem
+  certificatePath: /path/to/bot-certificate.p12
+  certificatePassword: changeit
+
+ssl:
+  trustStorePath: /path/to/all_symphony_certs_truststore
+  trustStorePassword: changeit
+
+app:
+  appId: app-id
+  privateKeyPath: path/to/private-key.pem
+
+datafeed:
+  version: v1
+  retry:
+    maxAttempts: 6
+    initialIntervalMillis: 2000
+    multiplier: 1.5
+    maxIntervalMillis: 10000
+
+retry:
+    maxAttempts: 6
+    initialIntervalMillis: 2000
+    multiplier: 1.5
+    maxIntervalMillis: 10000
+
+```
+
 ## Backward Compatibility with legacy configuration file  
 
 The legacy configuration using by the Java SDK v1 is also supported in BDK Configuration 2.0.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,18 +80,18 @@ host: localhost.symphony.com
 port: 8443
 
 pod:
-  host: devx1.symphony.com
+  host: dev.symphony.com
   port: 443
 
 agent:
   context: agent
 
 keyManager:
-  host: sym-devx1-dev-chat-glb-1-ause1-all.symphony.com
+  host: dev-key.symphony.com
   port: 8444
 
 sessionAuth:
-  host: sym-devx1-dev-chat-glb-1-ause1-all.symphony.com
+  host: dev-session.symphony.com
   port: 8444
 
 bot:
@@ -117,10 +117,10 @@ datafeed:
     maxIntervalMillis: 10000
 
 retry:
-    maxAttempts: 6
-    initialIntervalMillis: 2000
-    multiplier: 1.5
-    maxIntervalMillis: 10000
+  maxAttempts: 6
+  initialIntervalMillis: 2000
+  multiplier: 1.5
+  maxIntervalMillis: 10000
 
 ```
 

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/BdkConfigLoader.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/BdkConfigLoader.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.core.config;
 import com.symphony.bdk.core.config.exception.BdkConfigException;
 import com.symphony.bdk.core.config.legacy.LegacyConfigMapper;
 import com.symphony.bdk.core.config.legacy.model.LegacySymConfig;
+import com.symphony.bdk.core.config.model.BdkClientConfig;
 import com.symphony.bdk.core.config.model.BdkConfig;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -51,7 +52,8 @@ public class BdkConfigLoader {
             if (jsonNode != null) {
                 JSON_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
                 if (jsonNode.at("/botUsername").isMissingNode()) {
-                    return JSON_MAPPER.convertValue(jsonNode, BdkConfig.class);
+                    BdkConfig config = JSON_MAPPER.convertValue(jsonNode, BdkConfig.class);
+                    return setUpGlobalValueConfig(config);
                 } else {
                     LegacySymConfig legacySymConfig = JSON_MAPPER.convertValue(jsonNode, LegacySymConfig.class);
                     return LegacyConfigMapper.map(legacySymConfig);
@@ -74,5 +76,29 @@ public class BdkConfigLoader {
             return loadFromInputStream(inputStream);
         }
         throw new BdkConfigException("Config file is not found");
+    }
+
+    private static BdkConfig setUpGlobalValueConfig(BdkConfig config) {
+      config.setPod(setUpClientConfig(config, config.getPod()));
+      config.setAgent(setUpClientConfig(config, config.getAgent()));
+      config.setKeyManager(setUpClientConfig(config, config.getKeyManager()));
+      config.setSessionAuth(setUpClientConfig(config, config.getSessionAuth()));
+      return config;
+    }
+
+    private static BdkClientConfig setUpClientConfig(BdkConfig config, BdkClientConfig clientConfig) {
+      if (clientConfig.getHost() == null) {
+        clientConfig.setHost(config.getHost());
+      }
+      if (clientConfig.getPort() == null) {
+        clientConfig.setPort(config.getPort());
+      }
+      if (clientConfig.getScheme() == null) {
+        clientConfig.setScheme(config.getScheme());
+      }
+      if (clientConfig.getContext() == null) {
+        clientConfig.setContext(config.getContext());
+      }
+      return clientConfig;
     }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkClientConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkClientConfig.java
@@ -7,13 +7,10 @@ import lombok.Setter;
 @Setter
 public class BdkClientConfig {
 
-    private static final String DEFAULT_SCHEME = "https";
-    private static final int DEFAULT_HTTPS_PORT = 443;
-
-    private String scheme = DEFAULT_SCHEME;
-    private String host;
-    private Integer port = DEFAULT_HTTPS_PORT;
-    private String context = "";
+    private String scheme = null;
+    private String host = null;
+    private Integer port = null;
+    private String context = null;
 
     private String proxyUrl = null;
     private String proxyUsername = null;
@@ -25,10 +22,13 @@ public class BdkClientConfig {
 
 
     public String getBasePath() {
-        return this.scheme + "://" + this.host + this.getPortAsString() + this.getContext();
+        return this.scheme + "://" + this.host + this.getPortAsString() + this.getFormattedContext();
     }
 
-    public String getContext() {
+    public String getFormattedContext() {
+        if (this.context == null) {
+            return "";
+        }
         if (!this.context.equals("") && this.context.charAt(0) != '/') {
             this.context =  "/" + this.context;
         }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkConfig.java
@@ -7,7 +7,13 @@ import lombok.Setter;
 @Setter
 public class BdkConfig {
 
-    private String _version = "2.0";
+    private static final String DEFAULT_SCHEME = "https";
+    private static final int DEFAULT_HTTPS_PORT = 443;
+
+    private String scheme = DEFAULT_SCHEME;
+    private String host;
+    private Integer port = DEFAULT_HTTPS_PORT;
+    private String context = "";
 
     private BdkClientConfig agent = new BdkClientConfig();
     private BdkClientConfig pod = new BdkClientConfig();

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/client/ApiClientFactoryTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/client/ApiClientFactoryTest.java
@@ -1,13 +1,14 @@
 package com.symphony.bdk.core.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.symphony.bdk.core.api.invoker.ApiClient;
 import com.symphony.bdk.core.api.invoker.jersey2.ApiClientJersey2;
 import com.symphony.bdk.core.auth.exception.AuthInitializationException;
 import com.symphony.bdk.core.config.model.BdkConfig;
-import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for the {@link ApiClientFactory}.
@@ -136,9 +137,17 @@ class ApiClientFactoryTest {
     final BdkConfig config = new BdkConfig();
 
     config.getPod().setHost("pod-host");
+    config.getPod().setScheme("https");
+    config.getPod().setPort(443);
     config.getAgent().setHost("agent-host");
+    config.getAgent().setScheme("https");
+    config.getAgent().setPort(443);
     config.getKeyManager().setHost("km-host");
+    config.getKeyManager().setScheme("https");
+    config.getKeyManager().setPort(443);
     config.getSessionAuth().setHost("sa-host");
+    config.getSessionAuth().setScheme("https");
+    config.getSessionAuth().setPort(443);
 
     return config;
   }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigLoaderTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigLoaderTest.java
@@ -17,21 +17,21 @@ import java.nio.file.Path;
 public class BdkConfigLoaderTest {
 
     @Test
-    public void loadFromYamlInputStreamTest() throws BdkConfigException {
+    void loadFromYamlInputStreamTest() throws BdkConfigException {
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config.yaml");
         BdkConfig config = BdkConfigLoader.loadFromInputStream(inputStream);
         assertEquals(config.getBot().getUsername(), "tibot");
     }
 
     @Test
-    public void loadFromJsonInputStreamTest() throws BdkConfigException {
+    void loadFromJsonInputStreamTest() throws BdkConfigException {
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config.json");
         BdkConfig config = BdkConfigLoader.loadFromInputStream(inputStream);
         assertEquals(config.getBot().getUsername(), "tibot");
     }
 
     @Test
-    public void loadFromYamlFileTest(@TempDir Path tempDir) throws BdkConfigException, IOException {
+    void loadFromYamlFileTest(@TempDir Path tempDir) throws BdkConfigException, IOException {
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config.yaml");
         Path configPath = tempDir.resolve("config.yaml");
         Files.copy(inputStream, configPath);
@@ -40,7 +40,7 @@ public class BdkConfigLoaderTest {
     }
 
     @Test
-    public void loadFromJsonFileTest(@TempDir Path tempDir) throws BdkConfigException, IOException {
+    void loadFromJsonFileTest(@TempDir Path tempDir) throws BdkConfigException, IOException {
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config.json");
         Path configPath = tempDir.resolve("config.json");
         Files.copy(inputStream, configPath);
@@ -49,19 +49,19 @@ public class BdkConfigLoaderTest {
     }
 
     @Test
-    public void loadFromJsonClasspathTest() throws BdkConfigException {
+    void loadFromJsonClasspathTest() throws BdkConfigException {
         BdkConfig config = BdkConfigLoader.loadFromClasspath("/config/config.json");
         assertEquals(config.getBot().getUsername(), "tibot");
     }
 
     @Test
-    public void loadFromYamlClasspathTest() throws BdkConfigException {
+    void loadFromYamlClasspathTest() throws BdkConfigException {
         BdkConfig config = BdkConfigLoader.loadFromClasspath("/config/config.yaml");
         assertEquals(config.getBot().getUsername(), "tibot");
     }
 
     @Test
-    public void loadFromFileNotFoundTest() throws BdkConfigException {
+    void loadFromFileNotFoundTest() throws BdkConfigException {
         BdkConfigException exception = assertThrows(BdkConfigException.class, () -> {
             String configPath = "/wrong_path/config.yaml";
             BdkConfigLoader.loadFromFile(configPath);
@@ -70,7 +70,7 @@ public class BdkConfigLoaderTest {
     }
 
     @Test
-    public void loadLegacyFromInputStreamTest() throws BdkConfigException {
+    void loadLegacyFromInputStreamTest() throws BdkConfigException {
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/legacy_config.json");
         BdkConfig config = BdkConfigLoader.loadFromInputStream(inputStream);
         assertEquals(config.getBot().getUsername(), "tibot");
@@ -79,7 +79,7 @@ public class BdkConfigLoaderTest {
     }
 
     @Test
-    public void loadFromClasspathNotFoundTest() throws BdkConfigException {
+    void loadFromClasspathNotFoundTest() throws BdkConfigException {
         BdkConfigException exception = assertThrows(BdkConfigException.class, () -> {
             BdkConfigLoader.loadFromClasspath("/wrong_classpath/config.yaml");
         });
@@ -87,14 +87,29 @@ public class BdkConfigLoaderTest {
     }
 
     @Test
-    public void loadClientGlobalConfig() throws BdkConfigException {
+    void loadClientGlobalConfig() throws BdkConfigException {
         BdkConfig config = BdkConfigLoader.loadFromClasspath("/config/config_client_global.yaml");
-        assertEquals(config.getPod().getHost(), "devx1.symphony.com");
+
+        assertEquals(config.getPod().getScheme(), "https");
+        assertEquals(config.getPod().getHost(), "diff-pod.symphony.com");
         assertEquals(config.getPod().getPort(), 8443);
         assertEquals(config.getPod().getContext(), "context");
+
         assertEquals(config.getScheme(), "https");
+
+        assertEquals(config.getAgent().getScheme(), "https");
+        assertEquals(config.getAgent().getHost(), "devx1.symphony.com");
         assertEquals(config.getAgent().getPort(), 443);
         assertEquals(config.getAgent().getFormattedContext(), "/context");
+
+        assertEquals(config.getKeyManager().getScheme(), "https");
+        assertEquals(config.getKeyManager().getHost(), "devx1.symphony.com");
+        assertEquals(config.getKeyManager().getPort(), 8443);
         assertEquals(config.getKeyManager().getFormattedContext(), "/diff-context");
+
+        assertEquals(config.getSessionAuth().getScheme(), "http");
+        assertEquals(config.getSessionAuth().getHost(), "devx1.symphony.com");
+        assertEquals(config.getSessionAuth().getPort(), 8443);
+        assertEquals(config.getSessionAuth().getContext(), "context");
     }
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigLoaderTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigLoaderTest.java
@@ -1,7 +1,11 @@
 package com.symphony.bdk.core.config;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.symphony.bdk.core.config.exception.BdkConfigException;
 import com.symphony.bdk.core.config.model.BdkConfig;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -9,9 +13,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BdkConfigLoaderTest {
 
@@ -83,5 +84,17 @@ public class BdkConfigLoaderTest {
             BdkConfigLoader.loadFromClasspath("/wrong_classpath/config.yaml");
         });
         assertEquals(exception.getMessage(), "Config file is not found");
+    }
+
+    @Test
+    public void loadClientGlobalConfig() throws BdkConfigException {
+        BdkConfig config = BdkConfigLoader.loadFromClasspath("/config/config_client_global.yaml");
+        assertEquals(config.getPod().getHost(), "devx1.symphony.com");
+        assertEquals(config.getPod().getPort(), 8443);
+        assertEquals(config.getPod().getContext(), "context");
+        assertEquals(config.getScheme(), "https");
+        assertEquals(config.getAgent().getPort(), 443);
+        assertEquals(config.getAgent().getFormattedContext(), "/context");
+        assertEquals(config.getKeyManager().getFormattedContext(), "/diff-context");
     }
 }

--- a/symphony-bdk-core/src/test/resources/config/config_client_global.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config_client_global.yaml
@@ -3,6 +3,7 @@ context: context
 port: 8443
 
 pod:
+  host: diff-pod.symphony.com
   port: 8443
 
 agent:
@@ -12,6 +13,9 @@ agent:
 keyManager:
   host: devx1.symphony.com
   context: diff-context
+
+sessionAuth:
+  scheme: http
 
 bot:
   username: tibot

--- a/symphony-bdk-core/src/test/resources/config/config_client_global.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config_client_global.yaml
@@ -1,0 +1,22 @@
+host: devx1.symphony.com
+context: context
+port: 8443
+
+pod:
+  port: 8443
+
+agent:
+  host: devx1.symphony.com
+  port: 443
+
+keyManager:
+  host: devx1.symphony.com
+  context: diff-context
+
+bot:
+  username: tibot
+  privateKeyPath: /Users/local/conf/agent/privatekey.pem
+
+app:
+  appId: tibapp
+  privateKeyPath: /Users/local/conf/agent/privatekey.pem

--- a/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/DatafeedExampleMain.java
+++ b/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/DatafeedExampleMain.java
@@ -19,7 +19,7 @@ public class DatafeedExampleMain {
     public static void main(String[] args) throws ApiException, BdkConfigException, AuthInitializationException, AuthUnauthorizedException {
 
         // load configuration from classpath
-        final BdkConfig config = BdkConfigLoader.loadFromClasspath("/config.yaml");
+        final BdkConfig config = BdkConfigLoader.loadFromClasspath("/enhanced_config.yaml");
 
         SymphonyBdk bdk = new SymphonyBdk(config);
         log.info("DatafeedV1: Start");

--- a/symphony-bdk-examples/bdk-core-examples/src/main/resources/enhanced_config.yaml
+++ b/symphony-bdk-examples/bdk-core-examples/src/main/resources/enhanced_config.yaml
@@ -1,0 +1,28 @@
+
+host: devx1.symphony.com
+port: 8443
+
+pod:
+  port: 443
+
+agent:
+  port: 443
+
+keyManager:
+  port: 443
+
+bot:
+  username: fxbot-hong
+  privateKeyPath: /Users/hong.le/dev/fxBot/rsa/rsa-private-fxBot.pem
+
+app:
+  appId: app-hong
+  privateKeyPath: /Users/hong.le/dev/fxBot/rsa/app_privatekey.pem
+
+datafeed:
+  version: v1
+  retry:
+    maxAttempts: 6
+    initialIntervalMillis: 2000
+    multiplier: 1.5
+    maxIntervalMillis: 10000


### PR DESCRIPTION
- 4 properties added to BdkConfig to specify the global configurations for host,
port, scheme and context. These properties can be used if they are not configured
in the api client configuration.

- Version of configuration file is also removed because it seems useless.

- Unittest updated

- Documentation updated