### PR TITLE
Added new profile to exclude 2.0 examples when releasing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,20 @@
         </profile>
 
         <profile>
+            <id>2.0-no-example</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>symphony-bdk-bom</module>
+                <module>symphony-bdk-core</module>
+                <module>symphony-bdk-core-invokers</module>
+                <module>symphony-bdk-spring</module>
+                <module>symphony-bdk-template</module>
+            </modules>
+        </profile>
+
+        <profile>
             <id>release</id>
             <activation>
                 <activeByDefault>false</activeByDefault>


### PR DESCRIPTION
This is to exclude the examples module to be excluded when releasing BDK2.0 as we don't want to release them. When releasing BDK2.0, we will have to use both profiles `2.0-no-example` and `release`.

Alternatives using `skipNexusStagingDeployMojo` documented [here](https://help.sonatype.com/repomanager2/staging-releases/configuring-your-project-for-deploymentl) seems cumbersome as the latest module in the reactor must have this configured in order to work.

```xml
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-deploy-plugin</artifactId>
    <version>2.7</version>
    <configuration>
        <skip>true</skip>
    </configuration>
  </plugin>
```
does not work as nexus plugin is used.