### PR TITLE
SDK-136 Removed @Ignore annotation from SymExtensionAppAuthTest

### DIFF
--- a/symphony-bdk-legacy/symphony-api-client-java/src/test/java/authentication/SymExtensionAppAuthTest.java
+++ b/symphony-bdk-legacy/symphony-api-client-java/src/test/java/authentication/SymExtensionAppAuthTest.java
@@ -1,15 +1,13 @@
 package authentication;
 
-import it.commons.BotTest;
-import model.AppAuthResponse;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@Ignore
+import it.commons.BotTest;
+import model.AppAuthResponse;
+import org.junit.Before;
+import org.junit.Test;
+
 public class SymExtensionAppAuthTest extends BotTest {
     private SymExtensionAppAuth symExtensionAppAuth;
 


### PR DESCRIPTION
The `@Ignore` annotation has been removed from class `SymExtensionAppAuthTest` and tests are now passing. 