### PR TITLE
APP-2999: CICD release in symphony repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,12 +39,8 @@ jobs:
 
       # run tests!
       - run:
-          name: Verify BDK 2.0
-          command: mvn verify -P2.0
-
-      - run:
-          name: Verify legacy projects
-          command: mvn verify -Plegacy
+          name: Verify
+          command: mvn verify
 
       - run:
           name: Save test results

--- a/jenkins/Jenkinsfile-release
+++ b/jenkins/Jenkinsfile-release
@@ -40,10 +40,10 @@ node {
         
             sh 'find . -type f -regex ".*/target/symphony-api-client-java-.*.jar" -exec gpg --batch --passphrase $PASSPHRASE -ab {} \\;'
             sh 'ls -la ./symphony-bdk-legacy/symphony-api-client-java/target'
-            sh 'mvn --batch-mode --settings ../../jenkins/config-release/settings-release.xml -P release,symphony-repo ' +
+            sh 'mvn --batch-mode --settings ../../jenkins/config-release/settings-release.xml -P release,$PARAM_REPO_ID ' +
                     '-Dgpg.passphrase=$PASSPHRASE ' +
-                    '-Drepo.id=symphony-repo -Drepo.username=symphony-platform-solutions -Drepo.password=$PASSPHRASE ' +
-                    '-Dsym.releases.url=$PARAM_RELEASES_URL -Dsym.snapshots.url=$PARAM_SNAPSHOTS_URL ' +
+                    '-Drepo.id=$PARAM_REPO_ID -Drepo.username=symphony-platform-solutions -Drepo.password=$PASSPHRASE ' +
+                    '-Dsym.repo.url=$PARAM_SYM_REPO_URL ' +
                     'clean deploy'
         }
       }

--- a/jenkins/Jenkinsfile-release
+++ b/jenkins/Jenkinsfile-release
@@ -8,11 +8,6 @@ cicdUtils = new SymphonyCICDUtils()
 
 
 node {
-
-    // default org and branch
-    def org = env.PARAM_REPO_OWNER ?: 'SymphonyPlatformSolutions'
-    def branch = env.PARAM_BUILD_BRANCH ?: 'master'
-
     withCredentials([
         file(credentialsId: 'JAVA_SDK_GPG_KEY', variable: 'KEY'), 
         string(credentialsId: 'JAVA_SDK_GPG_PASSPHRASE', variable: 'PASSPHRASE')
@@ -45,11 +40,11 @@ node {
         
             sh 'find . -type f -regex ".*/target/symphony-api-client-java-.*.jar" -exec gpg --batch --passphrase $PASSPHRASE -ab {} \\;'
             sh 'ls -la ./symphony-bdk-legacy/symphony-api-client-java/target'
-            sh '''
-                cd ./symphony-bdk-legacy/symphony-api-client-java
-                pwd
-                mvn --batch-mode --settings ../../jenkins/config-release/settings-release.xml -Dgpg.passphrase=$PASSPHRASE -Drepo.id=ossrh -Drepo.username=symphony-platform-solutions -Drepo.password=$PASSPHRASE clean deploy
-            '''
+            sh 'mvn --batch-mode --settings ../../jenkins/config-release/settings-release.xml -P release,symphony-repo ' +
+                    '-Dgpg.passphrase=$PASSPHRASE ' +
+                    '-Drepo.id=symphony-repo -Drepo.username=symphony-platform-solutions -Drepo.password=$PASSPHRASE ' +
+                    '-Dsym.releases.url=$PARAM_RELEASES_URL -Dsym.snapshots.url=$PARAM_SNAPSHOTS_URL ' +
+                    'clean deploy'
         }
       }
     }

--- a/jenkins/config-release/settings-release.xml
+++ b/jenkins/config-release/settings-release.xml
@@ -20,12 +20,12 @@
                 <repository>
                     <id>symphony-repo</id>
                     <name>Symphony Releases</name>
-                    <url>${sym.releases.url}</url>
+                    <url>${sym.repo.url}/libs-release-local</url>
                 </repository>
                 <snapshotRepository>
                     <id>symphony-repo</id>
                     <name>Symphony Snapshots</name>
-                    <url>${sym.snapshots.url}</url>
+                    <url>${sym.repo.url}/libs-snapshot-local</url>
                 </snapshotRepository>
             </distributionManagement>
         </profile>

--- a/jenkins/config-release/settings-release.xml
+++ b/jenkins/config-release/settings-release.xml
@@ -8,4 +8,26 @@
             <password>${repo.password}</password>
         </server>
     </servers>
+
+    <profiles>
+        <profile>
+            <id>symphony-repo</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+
+            <distributionManagement>
+                <repository>
+                    <id>symphony-repo</id>
+                    <name>Symphony Releases</name>
+                    <url>${sym.releases.url}</url>
+                </repository>
+                <snapshotRepository>
+                    <id>symphony-repo</id>
+                    <name>Symphony Snapshots</name>
+                    <url>${sym.snapshots.url}</url>
+                </snapshotRepository>
+            </distributionManagement>
+        </profile>
+    </profiles>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,15 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
+            <modules>
+                <module>symphony-bdk-bom</module>
+                <module>symphony-bdk-core</module>
+                <module>symphony-bdk-core-invokers</module>
+                <module>symphony-bdk-examples</module>
+                <module>symphony-bdk-spring</module>
+                <module>symphony-bdk-template</module>
+                <module>symphony-bdk-legacy</module>
+            </modules>
             <build>
                 <plugins>
                     <plugin>
@@ -205,7 +214,28 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
 
+        <profile>
+            <id>ossrh</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.7</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
             <distributionManagement>
                 <snapshotRepository>
                     <id>ossrh</id>
@@ -216,7 +246,6 @@
                     <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
                 </repository>
             </distributionManagement>
-
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,16 @@
         <url>https://github.com/SymphonyPlatformSolutions/symphony-api-client-java</url>
     </scm>
 
+    <modules>
+        <module>symphony-bdk-legacy</module>
+        <module>symphony-bdk-bom</module>
+        <module>symphony-bdk-core</module>
+        <module>symphony-bdk-core-invokers</module>
+        <module>symphony-bdk-spring</module>
+        <module>symphony-bdk-template</module>
+        <module>symphony-bdk-examples</module>
+    </modules>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -131,45 +141,18 @@
     </build>
 
     <profiles>
-
-        <profile>
-            <id>legacy</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>symphony-bdk-legacy</module>
-            </modules>
-        </profile>
-
-        <profile>
-            <id>2.0</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <modules>
-                <module>symphony-bdk-bom</module>
-                <module>symphony-bdk-core</module>
-                <module>symphony-bdk-core-invokers</module>
-                <module>symphony-bdk-examples</module>
-                <module>symphony-bdk-spring</module>
-                <module>symphony-bdk-template</module>
-            </modules>
-        </profile>
-
         <profile>
             <id>release</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
             <modules>
+                <module>symphony-bdk-legacy</module>
                 <module>symphony-bdk-bom</module>
                 <module>symphony-bdk-core</module>
                 <module>symphony-bdk-core-invokers</module>
-                <module>symphony-bdk-examples</module>
                 <module>symphony-bdk-spring</module>
                 <module>symphony-bdk-template</module>
-                <module>symphony-bdk-legacy</module>
             </modules>
             <build>
                 <plugins>


### PR DESCRIPTION
Idea is to keep to remove 2.0 and legacy profiles and to have a new release profile containing legacy + 2.0 - 2.0 examples.
`-pl !symphony-bdk-examples` does not works as intended by us as it does not exclude sub-modules (or we have to list examples modules + all examples submodules).

Alternatives using `skipNexusStagingDeployMojo` documented [here](https://help.sonatype.com/repomanager2/staging-releases/configuring-your-project-for-deployment) seems cumbersome as only the configuration of the latest module in the mvn reactor is taken into account. For multi-modules project, it seems it is everything or nothing

```xml
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-deploy-plugin</artifactId>
    <version>2.7</version>
    <configuration>
        <skip>true</skip>
    </configuration>
  </plugin>
```
does not work as nexus plugin is used.

For releasing: we will deploy releases manually on ossrh from release branches and deploy snapshots automatically on symphony repo from master branch.