### PR TITLE
APP-3106: Publish BOM when releasing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,30 +5,26 @@ ext.symphonyRepoUrl = project.properties['symphonyRepoUrl'] ?: 'https://oss.sona
 ext.symphonyRepoUser = project.properties['symphonyRepoUser'] ?: 'Symphony artifactory user'
 ext.symphonyRepoPassword = project.properties['symphonyRepoPassword'] ?: 'Symphony artifactory password'
 
-ext.pomDefinition = { p ->
-    { it ->
-        name = p.name
-        description = p.description
+ext.pomDefinition = {
+    url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
+    licenses {
+        license {
+            name = 'MIT License'
+            url = 'http://www.opensource.org/licenses/mit-license.php'
+        }
+    }
+    developers {
+        developer {
+            name = 'Symphony Platform Solutions'
+            email = 'platformsolutions@symphony.com'
+            organization = 'Symphony Communication Services'
+            organizationUrl = 'https://symphony.com/'
+        }
+    }
+    scm {
+        connection = 'scm:git:git://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
+        developerConnection = 'scm:git:ssh://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
         url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
-        licenses {
-            license {
-                name = 'MIT License'
-                url = 'http://www.opensource.org/licenses/mit-license.php'
-            }
-        }
-        developers {
-            developer {
-                name = 'Symphony Platform Solutions'
-                email = 'platformsolutions@symphony.com'
-                organization = 'Symphony Communication Services'
-                organizationUrl = 'https://symphony.com/'
-            }
-        }
-        scm {
-            connection = 'scm:git:git://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
-            developerConnection = 'scm:git:ssh://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
-            url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
-        }
     }
 }
 
@@ -76,7 +72,15 @@ configure(subprojects.findAll { it.name != 'symphony-bdk-bom' }) {
         publications {
             maven(MavenPublication) {
                 from(components.java)
-                pom(rootProject.ext.pomDefinition(project))
+                pom(rootProject.ext.pomDefinition)
+                pom.withXml {
+                    // otherwise project description is evaluated too early
+                    asNode().children().first().plus {
+                        setResolveStrategy(Closure.DELEGATE_FIRST)
+                        'name' project.name
+                        'description' project.description
+                    }
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,36 @@
 ext.projectVersion = project.properties['projectVersion'] ?: '1.4.0-SNAPSHOT'
 ext.isReleaseVersion = !ext.projectVersion.endsWith('SNAPSHOT')
 
-ext.symphonyRepoUrl = project.properties['symphonyRepoUrl'] ?: 'Symphony repository URL'
+ext.symphonyRepoUrl = project.properties['symphonyRepoUrl'] ?: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
 ext.symphonyRepoUser = project.properties['symphonyRepoUser'] ?: 'Symphony artifactory user'
 ext.symphonyRepoPassword = project.properties['symphonyRepoPassword'] ?: 'Symphony artifactory password'
+
+ext.pomDefinition = { p ->
+    { it ->
+        name = p.name
+        description = p.description
+        url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
+        licenses {
+            license {
+                name = 'MIT License'
+                url = 'http://www.opensource.org/licenses/mit-license.php'
+            }
+        }
+        developers {
+            developer {
+                name = 'Symphony Platform Solutions'
+                email = 'platformsolutions@symphony.com'
+                organization = 'Symphony Communication Services'
+                organizationUrl = 'https://symphony.com/'
+            }
+        }
+        scm {
+            connection = 'scm:git:git://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
+            developerConnection = 'scm:git:ssh://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
+            url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
+        }
+    }
+}
 
 allprojects {
     group = 'com.symphony.platformsolutions'
@@ -17,7 +44,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0'
     }
 }
@@ -30,6 +56,11 @@ subprojects {
 
 tasks.withType(Sign) {
     onlyIf { ext.isReleaseVersion }
+}
+
+nexusStaging {
+    username = rootProject.ext.symphonyRepoUser
+    password = rootProject.ext.symphonyRepoPassword
 }
 
 configure(subprojects.findAll { it.name != 'symphony-bdk-bom' }) {
@@ -45,6 +76,7 @@ configure(subprojects.findAll { it.name != 'symphony-bdk-bom' }) {
         publications {
             maven(MavenPublication) {
                 from(components.java)
+                pom(rootProject.ext.pomDefinition(project))
             }
         }
     }
@@ -89,9 +121,9 @@ configure(subprojects.findAll { it.name != 'symphony-bdk-bom' }) {
     }
 }
 
+// do not publish example modules
 configure(subprojects.findAll { !it.name.contains('example') }) {
     apply plugin: 'maven-publish'
-    apply plugin: 'com.bmuschko.nexus'
 
     publishing {
         repositories {
@@ -103,41 +135,5 @@ configure(subprojects.findAll { !it.name.contains('example') }) {
                 url rootProject.ext.symphonyRepoUrl
             }
         }
-    }
-
-    modifyPom {
-        project {
-            name = project.name
-            description = project.description
-            url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
-            licenses {
-                license {
-                    name = 'MIT License'
-                    url = 'http://www.opensource.org/licenses/mit-license.php'
-                }
-            }
-            developers {
-                developer {
-                    name = 'Symphony Platform Solutions'
-                    email = 'platformsolutions@symphony.com'
-                    organization = 'Symphony Communication Services'
-                    organizationUrl = 'https://symphony.com/'
-                }
-            }
-            scm {
-                connection = 'scm:git:git://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
-                developerConnection = 'scm:git:ssh://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
-                url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
-            }
-        }
-    }
-
-    extraArchive {
-        sources = false
-        javadoc = false
-    }
-
-    nexus {
-        sign = isReleaseVersion
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-ext.projectVersion = project.properties['projectVersion'] ?: '1.4.0-SNAPSHOT'
+ext.projectVersion = '1.4.0-SNAPSHOT'
 ext.isReleaseVersion = !ext.projectVersion.endsWith('SNAPSHOT')
 
 ext.symphonyRepoUrl = project.properties['symphonyRepoUrl'] ?: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
@@ -99,7 +99,6 @@ configure(subprojects.findAll { it.name != 'symphony-bdk-bom' }) {
     javadoc {
         options.encoding = 'UTF-8'
         options.addStringOption('Xdoclint:none', '-quiet')
-        options.encoding = 'UTF-8'
     }
 
     java {

--- a/jenkins/Jenkinsfile-release
+++ b/jenkins/Jenkinsfile-release
@@ -11,21 +11,17 @@ node {
                 "GIT_ORG=$PARAM_REPO_OWNER",
                 "GIT_REPO=symphony-api-client-java"
         ]) {
-            def isVersionOverriden = env.PARAM_RELEASE_VERSION?.trim()
-            def releaseParamVersion = isVersionOverriden ? '-PprojectVersion=$PARAM_RELEASE_VERSION ' : ''
-
             stage('Git Checkout') {
                 gitCheckout()
             }
 
             stage('Build BDK 2.0 project') {
-                sh './gradlew ' + releaseParamVersion
+                sh './gradlew'
             }
 
             stage('Deploy BDK2.0 on Nexus and Maven Central') {
                 sh './gradlew -PsymphonyRepoUser=symphony-platform-solutions -PsymphonyRepoPassword=$PASSPHRASE ' +
                         '-Psigning.keyId=3C09C6D3 -Psigning.secretKeyRingFile=$KEYRING_FILE -Psigning.password=$PASSPHRASE ' +
-                        releaseParamVersion +
                         'publish closeAndReleaseRepository'
             }
         }

--- a/jenkins/Jenkinsfile-release
+++ b/jenkins/Jenkinsfile-release
@@ -23,10 +23,10 @@ node {
             }
 
             stage('Deploy BDK2.0 on Nexus and Maven Central') {
-                sh './gradlew -PnexusUsername=symphony-platform-solutions -PnexusPassword=$PASSPHRASE ' +
+                sh './gradlew -PsymphonyRepoUser=symphony-platform-solutions -PsymphonyRepoPassword=$PASSPHRASE ' +
                         '-Psigning.keyId=3C09C6D3 -Psigning.secretKeyRingFile=$KEYRING_FILE -Psigning.password=$PASSPHRASE ' +
                         releaseParamVersion +
-                        'uploadArchives closeAndReleaseRepository'
+                        'publish closeAndReleaseRepository'
             }
         }
     }

--- a/jenkins/Jenkinsfile-release-legacy
+++ b/jenkins/Jenkinsfile-release-legacy
@@ -24,10 +24,10 @@ node {
                 }
 
                 stage('Deploy legacy BDK on Nexus and Maven Central') {
-                    sh './gradlew -PnexusUsername=symphony-platform-solutions -PnexusPassword=$PASSPHRASE ' +
+                    sh './gradlew -PsymphonyRepoUser=symphony-platform-solutions -PsymphonyRepoPassword=$PASSPHRASE ' +
                             '-Psigning.keyId=3C09C6D3 -Psigning.secretKeyRingFile=$KEYRING_FILE -Psigning.password=$PASSPHRASE ' +
                             releaseParamVersion +
-                            'uploadArchives closeAndReleaseRepository'
+                            'publish closeAndReleaseRepository'
                 }
             }
         }

--- a/jenkins/Jenkinsfile-release-legacy
+++ b/jenkins/Jenkinsfile-release-legacy
@@ -11,22 +11,18 @@ node {
                 "GIT_ORG=$PARAM_REPO_OWNER",
                 "GIT_REPO=symphony-api-client-java"
         ]) {
-            def isVersionOverriden = env.PARAM_RELEASE_VERSION?.trim()
-            def releaseParamVersion = isVersionOverriden ? '-PprojectVersion=$PARAM_RELEASE_VERSION ' : ''
-
             stage('Git Checkout') {
                 gitCheckout()
             }
 
             dir("symphony-bdk-legacy") {
                 stage('Build legacy BDK project') {
-                    sh './gradlew ' + releaseParamVersion
+                    sh './gradlew'
                 }
 
                 stage('Deploy legacy BDK on Nexus and Maven Central') {
                     sh './gradlew -PsymphonyRepoUser=symphony-platform-solutions -PsymphonyRepoPassword=$PASSPHRASE ' +
                             '-Psigning.keyId=3C09C6D3 -Psigning.secretKeyRingFile=$KEYRING_FILE -Psigning.password=$PASSPHRASE ' +
-                            releaseParamVersion +
                             'publish closeAndReleaseRepository'
                 }
             }

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -80,7 +80,11 @@ publishing {
     publications {
         bom(MavenPublication) {
             from components.javaPlatform
-            pom(rootProject.ext.pomDefinition(project))
+            pom(rootProject.ext.pomDefinition)
+            pom {
+                name = project.name
+                description = project.description
+            }
         }
     }
 }

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java-platform'
-    id 'maven-publish'
 }
 
 description = 'Symphony Java BDK Bom (Bill Of Materials)'
@@ -79,13 +78,14 @@ dependencies {
 
 publishing {
     publications {
-        symphonyBdk(MavenPublication) {
+        bom(MavenPublication) {
             from components.javaPlatform
+            pom(rootProject.ext.pomDefinition(project))
         }
     }
 }
 
 signing {
     required { rootProject.isReleaseVersion }
-    sign publishing.publications.symphonyBdk
+    sign publishing.publications.bom
 }

--- a/symphony-bdk-legacy/build.gradle
+++ b/symphony-bdk-legacy/build.gradle
@@ -1,6 +1,6 @@
 description = 'Symphony Java BDK Legacy Module'
 
-ext.projectVersion = project.properties['projectVersion'] ?: '1.3.0-SNAPSHOT'
+ext.projectVersion = '1.3.0-SNAPSHOT'
 ext.isReleaseVersion = !ext.projectVersion.endsWith('SNAPSHOT')
 
 ext.symphonyRepoUrl = project.properties['symphonyRepoUrl'] ?: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'

--- a/symphony-bdk-legacy/build.gradle
+++ b/symphony-bdk-legacy/build.gradle
@@ -3,6 +3,37 @@ description = 'Symphony Java BDK Legacy Module'
 ext.projectVersion = project.properties['projectVersion'] ?: '1.3.0-SNAPSHOT'
 ext.isReleaseVersion = !ext.projectVersion.endsWith('SNAPSHOT')
 
+ext.symphonyRepoUrl = project.properties['symphonyRepoUrl'] ?: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+ext.symphonyRepoUser = project.properties['symphonyRepoUser'] ?: 'Symphony artifactory user'
+ext.symphonyRepoPassword = project.properties['symphonyRepoPassword'] ?: 'Symphony artifactory password'
+
+ext.pomDefinition = { p ->
+    { it ->
+        name = p.name
+        description = p.description
+        url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
+        licenses {
+            license {
+                name = 'MIT License'
+                url = 'http://www.opensource.org/licenses/mit-license.php'
+            }
+        }
+        developers {
+            developer {
+                name = 'Symphony Platform Solutions'
+                email = 'platformsolutions@symphony.com'
+                organization = 'Symphony Communication Services'
+                organizationUrl = 'https://symphony.com/'
+            }
+        }
+        scm {
+            connection = 'scm:git:git://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
+            developerConnection = 'scm:git:ssh://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
+            url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
+        }
+    }
+}
+
 allprojects {
     group = 'com.symphony.platformsolutions'
     version = projectVersion
@@ -15,19 +46,22 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0'
     }
 }
 
 apply plugin: 'io.codearte.nexus-staging'
 
+nexusStaging {
+    username = rootProject.ext.symphonyRepoUser
+    password = rootProject.ext.symphonyRepoPassword
+}
+
 subprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'
     apply plugin: 'signing'
     apply plugin: 'maven-publish'
-    apply plugin: 'com.bmuschko.nexus'
 
     repositories {
         mavenCentral()
@@ -111,45 +145,11 @@ subprojects {
         publications {
             maven(MavenPublication) {
                 from(components.java)
+                pom(rootProject.ext.pomDefinition(project))
             }
         }
     }
 
-    modifyPom {
-        project {
-            name = project.name
-            description = project.description
-            url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
-            licenses {
-                license {
-                    name = 'MIT License'
-                    url = 'http://www.opensource.org/licenses/mit-license.php'
-                }
-            }
-            developers {
-                developer {
-                    name = 'Symphony Platform Solutions'
-                    email = 'platformsolutions@symphony.com'
-                    organization = 'Symphony Communication Services'
-                    organizationUrl = 'https://symphony.com/'
-                }
-            }
-            scm {
-                connection = 'scm:git:git://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
-                developerConnection = 'scm:git:ssh://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
-                url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
-            }
-        }
-    }
-
-    extraArchive {
-        sources = false
-        javadoc = false
-    }
-
-    nexus {
-        sign = isReleaseVersion
-    }
 }
 
 tasks.withType(Sign) {

--- a/symphony-bdk-legacy/build.gradle
+++ b/symphony-bdk-legacy/build.gradle
@@ -7,30 +7,26 @@ ext.symphonyRepoUrl = project.properties['symphonyRepoUrl'] ?: 'https://oss.sona
 ext.symphonyRepoUser = project.properties['symphonyRepoUser'] ?: 'Symphony artifactory user'
 ext.symphonyRepoPassword = project.properties['symphonyRepoPassword'] ?: 'Symphony artifactory password'
 
-ext.pomDefinition = { p ->
-    { it ->
-        name = p.name
-        description = p.description
+ext.pomDefinition = {
+    url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
+    licenses {
+        license {
+            name = 'MIT License'
+            url = 'http://www.opensource.org/licenses/mit-license.php'
+        }
+    }
+    developers {
+        developer {
+            name = 'Symphony Platform Solutions'
+            email = 'platformsolutions@symphony.com'
+            organization = 'Symphony Communication Services'
+            organizationUrl = 'https://symphony.com/'
+        }
+    }
+    scm {
+        connection = 'scm:git:git://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
+        developerConnection = 'scm:git:ssh://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
         url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
-        licenses {
-            license {
-                name = 'MIT License'
-                url = 'http://www.opensource.org/licenses/mit-license.php'
-            }
-        }
-        developers {
-            developer {
-                name = 'Symphony Platform Solutions'
-                email = 'platformsolutions@symphony.com'
-                organization = 'Symphony Communication Services'
-                organizationUrl = 'https://symphony.com/'
-            }
-        }
-        scm {
-            connection = 'scm:git:git://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
-            developerConnection = 'scm:git:ssh://github.com/SymphonyPlatformSolutions/symphony-api-client-java.git'
-            url = 'https://github.com/SymphonyPlatformSolutions/symphony-api-client-java'
-        }
     }
 }
 
@@ -145,11 +141,18 @@ subprojects {
         publications {
             maven(MavenPublication) {
                 from(components.java)
-                pom(rootProject.ext.pomDefinition(project))
+                pom(rootProject.ext.pomDefinition)
+                pom.withXml {
+                    // otherwise project description is evaluated too early
+                    asNode().children().first().plus {
+                        setResolveStrategy(Closure.DELEGATE_FIRST)
+                        'name' project.name
+                        'description' project.description
+                    }
+                }
             }
         }
     }
-
 }
 
 tasks.withType(Sign) {


### PR DESCRIPTION
**Port on the master branch from 1.3rc**

The nexus plugin we were using was not supporting BOM files. We ended up
using the maven-publish plugin (and kept the nexus staging plugin to
close and release the staging repository).

By default the repository URL is the Nexus staging one.

The POM definition is shared at top level with a closure.

Also applied this to legacy project.

### Ticket
[APP-3106](https://perzoinc.atlassian.net/browse/APP-3106)

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Updated the documentation in [docs folder](../docs) -> in the wiki