### PR TITLE
APP-3103: Add @JsonIgnore to the OutboundMessage#setContentAttachment(ContentAttachment)

### DIFF
--- a/symphony-bdk-legacy/symphony-api-client-java/src/main/java/model/OutboundMessage.java
+++ b/symphony-bdk-legacy/symphony-api-client-java/src/main/java/model/OutboundMessage.java
@@ -1,5 +1,6 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.File;
 import java.util.ArrayList;
@@ -100,6 +101,7 @@ public class OutboundMessage {
         this.contentAttachment = contentAttachment;
     }
 
+    @JsonIgnore
     public void setContentAttachment(ContentAttachment... contentAttachment) {
         this.contentAttachment = Arrays.asList(contentAttachment);
     }


### PR DESCRIPTION
### Ticket
[APP-3103](https://perzoinc.atlassian.net/browse/APP-3103)

### Description
There are two setters setContentAttachment in OutboundMessage which can lead to
ambigous reference error while deserializing with Jackson. Associated
OutboundMessage#setContentAttachment(ContentAttachment) with @JsonIgnore to
prevent Jackson use this setter to deserialize

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title and in the corresponding section
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
