### PR TITLE
APP-3120 Handlebars does not automatically append .hbs extension to template name

### DIFF
--- a/symphony-bdk-template/symphony-bdk-template-handlebars/src/main/java/com/symphony/bdk/template/handlebars/HandlebarsEngine.java
+++ b/symphony-bdk-template/symphony-bdk-template-handlebars/src/main/java/com/symphony/bdk/template/handlebars/HandlebarsEngine.java
@@ -5,6 +5,7 @@ import com.symphony.bdk.template.api.TemplateEngine;
 import com.symphony.bdk.template.api.TemplateException;
 
 import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
 import com.github.jknack.handlebars.io.FileTemplateLoader;
 import com.github.jknack.handlebars.io.TemplateLoader;
 import org.apache.commons.io.FilenameUtils;
@@ -23,7 +24,7 @@ import java.io.IOException;
 public class HandlebarsEngine implements TemplateEngine {
 
   /** Handlebars for classpath loading. Ok for thread-safety. */
-  private static final Handlebars HANDLEBARS = new Handlebars();
+  private static final Handlebars HANDLEBARS = createHandlebars(new ClassPathTemplateLoader());
 
   /**
    * {@inheritDoc}
@@ -33,8 +34,7 @@ public class HandlebarsEngine implements TemplateEngine {
     final String basedir = FilenameUtils.getFullPathNoEndSeparator(templatePath);
     final String file = FilenameUtils.getName(templatePath);
     // for thread-safety, we need to create a specific Handlebars object
-    final TemplateLoader templateLoader = new FileTemplateLoader(basedir);
-    final Handlebars handlebars = new Handlebars(templateLoader);
+    final Handlebars handlebars = createHandlebars(new FileTemplateLoader(basedir));
     try {
       return new HandlebarsTemplate(handlebars.compile(file));
     } catch (IOException e) {
@@ -52,5 +52,15 @@ public class HandlebarsEngine implements TemplateEngine {
     } catch (IOException e) {
       throw new TemplateException("Unable to compile Handlebars template from classpath location: " + templatePath, e);
     }
+  }
+
+  /**
+   * Creates a new {@link Handlebars} object with suffix set to "" to make this {@link TemplateEngine} implementation
+   * consistent with other ones (e.g. developers have to specify the template resource extension).
+   */
+  private static Handlebars createHandlebars(final TemplateLoader templateLoader) {
+    final Handlebars handlebars = new Handlebars(templateLoader);
+    handlebars.getLoader().setSuffix("");
+    return handlebars;
   }
 }

--- a/symphony-bdk-template/symphony-bdk-template-handlebars/src/test/java/com/symphony/bdk/template/handlebars/HandlebarsEngineTest.java
+++ b/symphony-bdk-template/symphony-bdk-template-handlebars/src/test/java/com/symphony/bdk/template/handlebars/HandlebarsEngineTest.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.template.handlebars;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.symphony.bdk.template.api.Template;
 
@@ -25,9 +26,16 @@ class HandlebarsEngineTest {
 
   @Test
   void should_load_template_from_classpath() {
-    final Template template = this.engine.newTemplateFromClasspath("/test");
+    final Template template = this.engine.newTemplateFromClasspath("/test.hbs");
     final String content = template.process(Collections.singletonMap("message", "hello"));
     assertEquals(EXPECTED_TEST_HBS, content);
+  }
+
+  @Test
+  void should_load_complex_template_from_classpath() {
+    final Template template = this.engine.newTemplateFromClasspath("/home.hbs");
+    final String home = template.process(null);
+    assertTrue(home.contains("Powered by Handlebars.java")); // which is contained in base.hbs
   }
 
   @Test
@@ -36,8 +44,22 @@ class HandlebarsEngineTest {
     final Path templatePath = tempDir.resolve("test.hbs");
     Files.copy(this.getClass().getResourceAsStream("/test.hbs"), templatePath);
 
-    final Template template = this.engine.newTemplateFromFile(tempDir.resolve("test").toAbsolutePath().toString());
+    final Template template = this.engine.newTemplateFromFile(tempDir.resolve("test.hbs").toAbsolutePath().toString());
     final String content = template.process(Collections.singletonMap("message", "hello"));
     assertEquals(EXPECTED_TEST_HBS, content);
+  }
+
+  @Test
+  void should_load_complex_template_from_file(@TempDir Path tempDir) throws Exception {
+
+    // copy /base.hbs and /home.hbs from classpath to tempDir
+    Path templatePath = tempDir.resolve("home.hbs");
+    Files.copy(this.getClass().getResourceAsStream("/home.hbs"), templatePath);
+    templatePath = tempDir.resolve("base.hbs");
+    Files.copy(this.getClass().getResourceAsStream("/base.hbs"), templatePath);
+
+    final Template template = this.engine.newTemplateFromFile(tempDir.resolve("home.hbs").toAbsolutePath().toString());
+    final String home = template.process(null);
+    assertTrue(home.contains("Powered by Handlebars.java")); // which is contained in base.hbs
   }
 }

--- a/symphony-bdk-template/symphony-bdk-template-handlebars/src/test/resources/base.hbs
+++ b/symphony-bdk-template/symphony-bdk-template-handlebars/src/test/resources/base.hbs
@@ -1,0 +1,10 @@
+{{#block "header"}}
+    <h1>Title</h1>
+{{/block}}
+
+{{#block "content"}}
+{{/block}}
+
+{{#block "footer" }}
+    <span>Powered by Handlebars.java</span>
+{{/block}}

--- a/symphony-bdk-template/symphony-bdk-template-handlebars/src/test/resources/home.hbs
+++ b/symphony-bdk-template/symphony-bdk-template-handlebars/src/test/resources/home.hbs
@@ -1,0 +1,5 @@
+{{#partial "content" }}
+    <p>Home page</p>
+{{/partial}}
+
+{{> base.hbs}}


### PR DESCRIPTION
### Ticket
[APP-3120](https://perzoinc.atlassian.net/browse/APP-3120)

### Description
By default, Handlebars automatically appends `.hbs` extension to template names. This behaviour is not consistent with with existing Freemarker implementation.  

### Dependencies
N/A

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
