### PR TITLE
APP-3187: Spring boot auto property expansion strategy for gradle project

### DIFF
--- a/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/build.gradle
+++ b/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/build.gradle
@@ -1,4 +1,13 @@
+plugins {
+    id 'java'
+}
 description = '[legacy] Symphony BDK'
+
+processResources {
+    filesMatching("application-base.properties") {
+        expand(project.properties)
+    }
+}
 
 dependencies {
     implementation project(':symphony-api-client-java')

--- a/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/main/resources/application-base.properties
+++ b/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/main/resources/application-base.properties
@@ -22,7 +22,7 @@ management.endpoints.web.base-path=/monitor
 management.endpoints.web.exposure.include=health, info, prometheus
 management.endpoint.health.show-details=always
 management.health.defaults.enabled=false
-management.symphony-api-client-version=@symphony.apiclient.version@
+management.symphony-api-client-version=${projectVersion}
 
 restclient.timeout=35000
 


### PR DESCRIPTION
### Ticket
[APP-3187](https://perzoinc.atlassian.net/browse/APP-3187)

### Description
The legacy strategy for expanding property (`@symphony.apiclient.version@`) only works with
Maven project. Since we decided to use gradle instead, this expansion haven't worked anymore.
That's why we have to update the properties file with the gradle auto property expansion.
More details: https://docs.spring.io/spring-boot/docs/1.4.x/reference/html/howto-properties-and-configuration.html#howto-automatic-expansion-gradle

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
