### PR TITLE
add option to enable/disable datafeed polling

### DIFF
--- a/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/main/java/com/symphony/bdk/bot/sdk/symphony/DatafeedClientImpl.java
+++ b/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/main/java/com/symphony/bdk/bot/sdk/symphony/DatafeedClientImpl.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.bot.sdk.symphony;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import clients.SymBotClient;
 import listeners.ElementsListener;
 import listeners.IMListener;

--- a/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/main/java/com/symphony/bdk/bot/sdk/symphony/DatafeedClientImpl.java
+++ b/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/main/java/com/symphony/bdk/bot/sdk/symphony/DatafeedClientImpl.java
@@ -10,6 +10,7 @@ import listeners.RoomListener;
 import listeners.ConnectionListener;
 
 @Service
+@ConditionalOnProperty(value = "datafeed.polling.disabled", havingValue="false", matchIfMissing=true)
 public class DatafeedClientImpl implements DatafeedClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(DatafeedClientImpl.class);
 


### PR DESCRIPTION
### Ticket
[APP-3199](https://perzoinc.atlassian.net/browse/APP-3199)

### Description
Add a way to enable/disable datafeed polling in legacy BDK

### Dependencies
N/A

### Checklist
- [ ] Referenced a ticket in the PR title and in the corresponding section
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
