### PR TITLE
APP-3142: Adding SignalService feature

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/OboServices.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/OboServices.java
@@ -6,6 +6,7 @@ import com.symphony.bdk.core.config.model.BdkConfig;
 import com.symphony.bdk.core.service.connection.OboConnectionService;
 import com.symphony.bdk.core.service.message.OboMessageService;
 import com.symphony.bdk.core.service.presence.OboPresenceService;
+import com.symphony.bdk.core.service.signal.OboSignalService;
 import com.symphony.bdk.core.service.stream.OboStreamService;
 import com.symphony.bdk.core.service.user.OboUserService;
 
@@ -22,6 +23,7 @@ public class OboServices {
   private final OboMessageService oboMessageService;
   private final OboPresenceService oboPresenceService;
   private final OboConnectionService oboConnectionService;
+  private final OboSignalService oboSignalService;
 
   public OboServices(BdkConfig config, AuthSession oboSession) {
     final ServiceFactory serviceFactory = new ServiceFactory(new ApiClientFactory(config), oboSession, config);
@@ -31,6 +33,7 @@ public class OboServices {
     oboMessageService = serviceFactory.getMessageService();
     oboPresenceService = serviceFactory.getPresenceService();
     oboConnectionService = serviceFactory.getConnectionService();
+    oboSignalService = serviceFactory.getSignalService();
   }
 
   /**
@@ -67,6 +70,16 @@ public class OboServices {
    */
   public OboConnectionService connections() {
     return oboConnectionService;
+  }
+
+  /**
+   * Get the {@link OboSignalService} using the provided OBO session in constructor.
+   * The returned signal service instance.
+   *
+   * @return an {@link OboSignalService} instance with the provided OBO session.
+   */
+  public OboSignalService signals() {
+    return oboSignalService;
   }
 
   /**

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/ServiceFactory.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/ServiceFactory.java
@@ -12,6 +12,7 @@ import com.symphony.bdk.core.service.datafeed.impl.DatafeedServiceV1;
 import com.symphony.bdk.core.service.datafeed.impl.DatafeedServiceV2;
 import com.symphony.bdk.core.service.message.MessageService;
 import com.symphony.bdk.core.service.presence.PresenceService;
+import com.symphony.bdk.core.service.signal.SignalService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
 import com.symphony.bdk.gen.api.AttachmentsApi;
@@ -26,6 +27,7 @@ import com.symphony.bdk.gen.api.PresenceApi;
 import com.symphony.bdk.gen.api.RoomMembershipApi;
 import com.symphony.bdk.gen.api.SessionApi;
 import com.symphony.bdk.gen.api.ShareApi;
+import com.symphony.bdk.gen.api.SignalsApi;
 import com.symphony.bdk.gen.api.StreamsApi;
 import com.symphony.bdk.gen.api.UserApi;
 import com.symphony.bdk.gen.api.UsersApi;
@@ -146,5 +148,14 @@ class ServiceFactory {
    */
   public ConnectionService getConnectionService() {
     return new ConnectionService(new ConnectionApi(this.podClient), this.authSession, this.retryBuilder);
+  }
+
+  /**
+   * Returns a fully initialized {@link SignalService}.
+   *
+   * @return a new {@link SignalService} instance.
+   */
+  public SignalService getSignalService() {
+    return new SignalService(new SignalsApi(this.agentClient), this.authSession, this.retryBuilder);
   }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/SymphonyBdk.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/SymphonyBdk.java
@@ -14,6 +14,7 @@ import com.symphony.bdk.core.service.connection.ConnectionService;
 import com.symphony.bdk.core.service.datafeed.DatafeedService;
 import com.symphony.bdk.core.service.message.MessageService;
 import com.symphony.bdk.core.service.presence.PresenceService;
+import com.symphony.bdk.core.service.signal.SignalService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
 import com.symphony.bdk.core.util.ServiceLookup;
@@ -48,6 +49,7 @@ public class SymphonyBdk {
   private final DatafeedService datafeedService;
   private final PresenceService presenceService;
   private final ConnectionService connectionService;
+  private final SignalService signalService;
 
   public SymphonyBdk(BdkConfig config) throws AuthInitializationException, AuthUnauthorizedException {
     this(config, new ApiClientFactory(config));
@@ -70,6 +72,7 @@ public class SymphonyBdk {
     this.streamService = serviceFactory.getStreamService();
     this.presenceService = serviceFactory.getPresenceService();
     this.connectionService = serviceFactory.getConnectionService();
+    this.signalService = serviceFactory.getSignalService();
     this.messageService = serviceFactory.getMessageService();
     this.datafeedService = serviceFactory.getDatafeedService();
 
@@ -144,6 +147,15 @@ public class SymphonyBdk {
    */
   public ConnectionService connections() {
     return this.connectionService;
+  }
+
+  /**
+   * Get the {@link SignalService} from a Bdk entry point.
+   *
+   * @return {@link SignalService} signal service instance.
+   */
+  public SignalService signals() {
+    return this.signalService;
   }
 
   /**

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/signal/OboSignalService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/signal/OboSignalService.java
@@ -1,0 +1,128 @@
+package com.symphony.bdk.core.service.signal;
+
+import com.symphony.bdk.gen.api.model.BaseSignal;
+import com.symphony.bdk.gen.api.model.ChannelSubscriber;
+import com.symphony.bdk.gen.api.model.ChannelSubscriptionResponse;
+import com.symphony.bdk.gen.api.model.Signal;
+
+import org.apiguardian.api.API;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Service interface exposing OBO-enabled endpoints to manage signals information.
+ */
+@API(status = API.Status.STABLE)
+public interface OboSignalService {
+
+  /**
+   * Lists signals on behalf of the user.
+   * {@link SignalService#listSignals(Integer, Integer)}
+   *
+   * @param skip  The number of signals to skip.
+   * @param limit Maximum number of signals to return. Default is 50, maximum value is 500.
+   * @return List of signals that the user has created and public signals to which they have subscribed.
+   * @see <a href="https://developers.symphony.com/restapi/reference#list-signals">List Signals</a>
+   */
+  List<Signal> listSignals(Integer skip, Integer limit);
+
+  /**
+   * Lists signals on behalf of the user.
+   * {@link SignalService#listSignalsStream(Integer, Integer)}
+   *
+   * @param chunkSize size of elements to retrieve in one call. Optional and defaults to 50.
+   * @param totalSize size of elements to retrieve in one call. Optional and defaults to 50.
+   * @return a {@link Stream} containing the signals.
+   * @see <a href="https://developers.symphony.com/restapi/reference#list-signals">List Signals</a>
+   */
+  Stream<Signal> listSignalsStream(Integer chunkSize, Integer totalSize);
+
+  /**
+   * Gets details about the specified signal.
+   * {@link SignalService#getSignal(String)}
+   *
+   * @param id The id of the signal.
+   * @return Details of the specified signal.
+   * @see <a href="https://developers.symphony.com/restapi/reference#get-signal">Get Signal</a>
+   */
+  Signal getSignal(String id);
+
+  /**
+   * Create a new signal.
+   * {@link SignalService#createSignal(BaseSignal)}
+   *
+   * @param signal  A signal object to be created.
+   * @return A new created signal object.
+   * @see <a href=https://developers.symphony.com/restapi/reference#create-signal">Create Signal</a>
+   */
+  Signal createSignal(BaseSignal signal);
+
+  /**
+   * Update an existing signal.
+   * {@link SignalService#updateSignal(String, BaseSignal)}
+   *
+   * @param id      The id of the signal to be updated.
+   * @param signal  The signal object to be updated.
+   * @return The updated signal.
+   * @see <a href="https://developers.symphony.com/restapi/reference#update-signal">Update Signal</a>
+   */
+  Signal updateSignal(String id, BaseSignal signal);
+
+  /**
+   * Delete an existing signal.
+   * {@link SignalService#deleteSignal(String)}
+   *
+   * @param id  The id of the signal to be deleted.
+   * @see <a href="https://developers.symphony.com/restapi/reference#delete-signal">Delete Signal</a>
+   */
+  void deleteSignal(String id);
+
+  /**
+   * Subscribe a list of users to a signal.
+   * {@link SignalService#subscribeSignal(String, Boolean, List)}
+   *
+   * @param id      The id of the signal to be subscribed.
+   * @param pushed  Prevents the user from unsubscribing from the Signal (only for bulk subscriptions).
+   *                Requires the canManageSignalSubscription entitlement.
+   * @param userIds List of user ids to subscribe to the signal
+   * @return The subscription information.
+   * @see <a href="https://developers.symphony.com/restapi/reference#subscribe-signal">Subscribe Signal</a>
+   */
+  ChannelSubscriptionResponse subscribeSignal(String id, Boolean pushed, List<Long> userIds);
+
+  /**
+   * Unsubscribe a list of users from a signal.
+   * {@link SignalService#unsubscribeSignal(String, List)}
+   *
+   * @param id      The id of the signal to be unsubscribed.
+   * @param userIds The list of user ids to unsubscribe from the signal.
+   * @return The unsubscription information.
+   * @see <a href="https://developers.symphony.com/restapi/reference#unsubscribe-signal">Unsubscribe Signal</a>
+   */
+  ChannelSubscriptionResponse unsubscribeSignal(String id, List<Long> userIds);
+
+  /**
+   * Get the subscribers for a specified signal.
+   * {@link SignalService#subscribers(String, Integer, Integer)}
+   *
+   * @param id      The id of the specified signal.
+   * @param skip    The number of results to skip.
+   * @param limit   The maximum number of subscribers to return. If no value is provided, 100 is the default.
+   * @return List of subscribers of the signal.
+   * @see <a href="https://developers.symphony.com/restapi/reference#subscribers">Subscribers</a>
+   */
+  List<ChannelSubscriber> subscribers(String id, Integer skip, Integer limit);
+
+  /**
+   * Get the subscribers for a specified signal.
+   * {@link SignalService#subscribersStream(String, Integer, Integer)}
+   *
+   * @param id        The id of the specified signal.
+   * @param chunkSize The size of elements to retrieve in one call. Optional and defaults to 100.
+   * @param totalSize The size of elements to retrieve in one call. Optional and defaults to 100.
+   * @return a {@link Stream} containing the subscribers.
+   * @see <a href="https://developers.symphony.com/restapi/reference#subscribers">Subscribers</a>
+   */
+  Stream<ChannelSubscriber> subscribersStream(String id, Integer chunkSize, Integer totalSize);
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/signal/OboSignalService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/signal/OboSignalService.java
@@ -10,6 +10,9 @@ import org.apiguardian.api.API;
 import java.util.List;
 import java.util.stream.Stream;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Service interface exposing OBO-enabled endpoints to manage signals information.
  */
@@ -25,18 +28,36 @@ public interface OboSignalService {
    * @return List of signals that the user has created and public signals to which they have subscribed.
    * @see <a href="https://developers.symphony.com/restapi/reference#list-signals">List Signals</a>
    */
-  List<Signal> listSignals(Integer skip, Integer limit);
+  List<Signal> listSignals(@Nullable Integer skip, @Nullable Integer limit);
 
   /**
-   * Lists signals on behalf of the user.
+   * Lists signals on behalf of the user with default limit equal 50.
+   * {@link SignalService#listSignals()}
+   *
+   * @return List of signals that the user has created and public signals to which they have subscribed.
+   * @see <a href="https://developers.symphony.com/restapi/reference#list-signals">List Signals</a>
+   */
+  List<Signal> listSignals();
+
+  /**
+   * Lists paginated stream of signals on behalf of the user.
    * {@link SignalService#listSignalsStream(Integer, Integer)}
    *
    * @param chunkSize size of elements to retrieve in one call. Optional and defaults to 50.
-   * @param totalSize size of elements to retrieve in one call. Optional and defaults to 50.
+   * @param totalSize Total maximum number of signals to return. Optional and defaults to 50.
    * @return a {@link Stream} containing the signals.
    * @see <a href="https://developers.symphony.com/restapi/reference#list-signals">List Signals</a>
    */
-  Stream<Signal> listSignalsStream(Integer chunkSize, Integer totalSize);
+  Stream<Signal> listSignalsStream(@Nullable Integer chunkSize, @Nullable Integer totalSize);
+
+  /**
+   * Lists paginated stream of signals on behalf of the user with the default chunkSize and totalSize equal 50.
+   * {@link SignalService#listSignalsStream()}
+   *
+   * @return a {@link Stream} containing the signals.
+   * @see <a href="https://developers.symphony.com/restapi/reference#list-signals">List Signals</a>
+   */
+  Stream<Signal> listSignalsStream();
 
   /**
    * Gets details about the specified signal.
@@ -46,7 +67,7 @@ public interface OboSignalService {
    * @return Details of the specified signal.
    * @see <a href="https://developers.symphony.com/restapi/reference#get-signal">Get Signal</a>
    */
-  Signal getSignal(String id);
+  Signal getSignal(@Nonnull String id);
 
   /**
    * Create a new signal.
@@ -56,7 +77,7 @@ public interface OboSignalService {
    * @return A new created signal object.
    * @see <a href="https://developers.symphony.com/restapi/reference#create-signal">Create Signal</a>
    */
-  Signal createSignal(BaseSignal signal);
+  Signal createSignal(@Nonnull BaseSignal signal);
 
   /**
    * Update an existing signal.
@@ -67,7 +88,7 @@ public interface OboSignalService {
    * @return The updated signal.
    * @see <a href="https://developers.symphony.com/restapi/reference#update-signal">Update Signal</a>
    */
-  Signal updateSignal(String id, BaseSignal signal);
+  Signal updateSignal(@Nonnull String id, @Nonnull BaseSignal signal);
 
   /**
    * Delete an existing signal.
@@ -76,7 +97,7 @@ public interface OboSignalService {
    * @param id  The id of the signal to be deleted.
    * @see <a href="https://developers.symphony.com/restapi/reference#delete-signal">Delete Signal</a>
    */
-  void deleteSignal(String id);
+  void deleteSignal(@Nonnull String id);
 
   /**
    * Subscribe a list of users to a signal.
@@ -89,7 +110,7 @@ public interface OboSignalService {
    * @return The subscription information.
    * @see <a href="https://developers.symphony.com/restapi/reference#subscribe-signal">Subscribe Signal</a>
    */
-  ChannelSubscriptionResponse subscribeSignal(String id, Boolean pushed, List<Long> userIds);
+  ChannelSubscriptionResponse subscribeSignal(@Nonnull String id, @Nullable Boolean pushed, @Nullable List<Long> userIds);
 
   /**
    * Unsubscribe a list of users from a signal.
@@ -100,7 +121,7 @@ public interface OboSignalService {
    * @return The unsubscription information.
    * @see <a href="https://developers.symphony.com/restapi/reference#unsubscribe-signal">Unsubscribe Signal</a>
    */
-  ChannelSubscriptionResponse unsubscribeSignal(String id, List<Long> userIds);
+  ChannelSubscriptionResponse unsubscribeSignal(@Nonnull String id, @Nullable List<Long> userIds);
 
   /**
    * Get the subscribers for a specified signal.
@@ -112,17 +133,37 @@ public interface OboSignalService {
    * @return List of subscribers of the signal.
    * @see <a href="https://developers.symphony.com/restapi/reference#subscribers">Subscribers</a>
    */
-  List<ChannelSubscriber> listSubscribers(String id, Integer skip, Integer limit);
+  List<ChannelSubscriber> listSubscribers(@Nonnull String id, @Nullable Integer skip, @Nullable Integer limit);
 
   /**
-   * Get the subscribers for a specified signal.
+   * Get the subscribers for a specified signal with default limit equal to 100.
+   * {@link SignalService#listSubscribers(String)}
+   *
+   * @param id      The id of the specified signal.
+   * @return List of subscribers of the signal.
+   * @see <a href="https://developers.symphony.com/restapi/reference#subscribers">Subscribers</a>
+   */
+  List<ChannelSubscriber> listSubscribers(@Nonnull String id);
+
+  /**
+   * Get the paginated stream of subscribers for a specified signal.
    * {@link SignalService#listSubscribersStream(String, Integer, Integer)}
    *
    * @param id        The id of the specified signal.
    * @param chunkSize The size of elements to retrieve in one call. Optional and defaults to 100.
-   * @param totalSize The size of elements to retrieve in one call. Optional and defaults to 100.
+   * @param totalSize Total maximum number of subscribers to return. Optional and defaults to 100.
    * @return a {@link Stream} containing the subscribers.
    * @see <a href="https://developers.symphony.com/restapi/reference#subscribers">Subscribers</a>
    */
-  Stream<ChannelSubscriber> listSubscribersStream(String id, Integer chunkSize, Integer totalSize);
+  Stream<ChannelSubscriber> listSubscribersStream(@Nonnull String id, @Nullable Integer chunkSize, @Nullable Integer totalSize);
+
+  /**
+   * Get the paginated stream of subscribers for a specified signal with the default chunkSize and totalSize equal to 100.
+   * {@link SignalService#listSubscribersStream(String)}
+   *
+   * @param id  The id of the specified signal.
+   * @return a {@link Stream} containing the subscribers.
+   * @see <a href="https://developers.symphony.com/restapi/reference#subscribers">Subscribers</a>
+   */
+  Stream<ChannelSubscriber> listSubscribersStream(@Nonnull String id);
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/signal/OboSignalService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/signal/OboSignalService.java
@@ -54,7 +54,7 @@ public interface OboSignalService {
    *
    * @param signal  A signal object to be created.
    * @return A new created signal object.
-   * @see <a href=https://developers.symphony.com/restapi/reference#create-signal">Create Signal</a>
+   * @see <a href="https://developers.symphony.com/restapi/reference#create-signal">Create Signal</a>
    */
   Signal createSignal(BaseSignal signal);
 
@@ -104,7 +104,7 @@ public interface OboSignalService {
 
   /**
    * Get the subscribers for a specified signal.
-   * {@link SignalService#subscribers(String, Integer, Integer)}
+   * {@link SignalService#listSubscribers(String, Integer, Integer)}
    *
    * @param id      The id of the specified signal.
    * @param skip    The number of results to skip.
@@ -112,11 +112,11 @@ public interface OboSignalService {
    * @return List of subscribers of the signal.
    * @see <a href="https://developers.symphony.com/restapi/reference#subscribers">Subscribers</a>
    */
-  List<ChannelSubscriber> subscribers(String id, Integer skip, Integer limit);
+  List<ChannelSubscriber> listSubscribers(String id, Integer skip, Integer limit);
 
   /**
    * Get the subscribers for a specified signal.
-   * {@link SignalService#subscribersStream(String, Integer, Integer)}
+   * {@link SignalService#listSubscribersStream(String, Integer, Integer)}
    *
    * @param id        The id of the specified signal.
    * @param chunkSize The size of elements to retrieve in one call. Optional and defaults to 100.
@@ -124,5 +124,5 @@ public interface OboSignalService {
    * @return a {@link Stream} containing the subscribers.
    * @see <a href="https://developers.symphony.com/restapi/reference#subscribers">Subscribers</a>
    */
-  Stream<ChannelSubscriber> subscribersStream(String id, Integer chunkSize, Integer totalSize);
+  Stream<ChannelSubscriber> listSubscribersStream(String id, Integer chunkSize, Integer totalSize);
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/signal/SignalService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/signal/SignalService.java
@@ -30,7 +30,6 @@ import java.util.stream.Stream;
  * <li>Update a signal</li>
  * <li>Delete a signal</li>
  * <li>Subscribe or unsubscribe a signal</li>
- * <li></li>
  * </ul></p>
  */
 @API(status = API.Status.STABLE)
@@ -135,7 +134,7 @@ public class SignalService implements OboSignalService, OboService<OboSignalServ
    * @return
    */
   @Override
-  public List<ChannelSubscriber> subscribers(String id, Integer skip, Integer limit) {
+  public List<ChannelSubscriber> listSubscribers(String id, Integer skip, Integer limit) {
     return executeAndRetry("subscribers",
         () -> signalsApi.v1SignalsIdSubscribersGet(authSession.getSessionToken(), id, authSession.getKeyManagerToken(), skip, limit)).getData();
   }
@@ -145,8 +144,8 @@ public class SignalService implements OboSignalService, OboService<OboSignalServ
    * @return
    */
   @Override
-  public Stream<ChannelSubscriber> subscribersStream(String id, Integer chunkSize, Integer totalSize) {
-    PaginatedApi<ChannelSubscriber> api = (((offset, limit) -> subscribers(id, offset, limit)));
+  public Stream<ChannelSubscriber> listSubscribersStream(String id, Integer chunkSize, Integer totalSize) {
+    PaginatedApi<ChannelSubscriber> api = (((offset, limit) -> listSubscribers(id, offset, limit)));
 
     final int actualChunkSize = chunkSize == null ? 100 : chunkSize;
     final int actualTotalSize = totalSize == null ? 100 : totalSize;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/signal/SignalService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/signal/SignalService.java
@@ -1,0 +1,163 @@
+package com.symphony.bdk.core.service.signal;
+
+import com.symphony.bdk.core.auth.AuthSession;
+import com.symphony.bdk.core.retry.RetryWithRecovery;
+import com.symphony.bdk.core.retry.RetryWithRecoveryBuilder;
+import com.symphony.bdk.core.service.OboService;
+import com.symphony.bdk.core.service.pagination.PaginatedApi;
+import com.symphony.bdk.core.service.pagination.PaginatedService;
+import com.symphony.bdk.core.util.function.SupplierWithApiException;
+import com.symphony.bdk.gen.api.SignalsApi;
+import com.symphony.bdk.gen.api.model.BaseSignal;
+import com.symphony.bdk.gen.api.model.ChannelSubscriber;
+import com.symphony.bdk.gen.api.model.ChannelSubscriptionResponse;
+import com.symphony.bdk.gen.api.model.Signal;
+
+import com.symphony.bdk.http.api.ApiException;
+
+import org.apiguardian.api.API;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Service class for managing signal information.
+ * <p>
+ * This service is used for listing signals related to the user, get information of a specified signal
+ * or perform some actions related to the signal like:
+ * <p><ul>
+ * <li>Create a signal</li>
+ * <li>Update a signal</li>
+ * <li>Delete a signal</li>
+ * <li>Subscribe or unsubscribe a signal</li>
+ * <li></li>
+ * </ul></p>
+ */
+@API(status = API.Status.STABLE)
+public class SignalService implements OboSignalService, OboService<OboSignalService> {
+
+  private final SignalsApi signalsApi;
+  private final AuthSession authSession;
+  private final RetryWithRecoveryBuilder<?> retryBuilder;
+
+  public SignalService(SignalsApi signalsApi, AuthSession authSession, RetryWithRecoveryBuilder<?> retryBuilder) {
+    this.signalsApi = signalsApi;
+    this.authSession = authSession;
+    this.retryBuilder = retryBuilder;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public OboSignalService obo(AuthSession oboSession) {
+    return new SignalService(signalsApi, oboSession, retryBuilder);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public List<Signal> listSignals(Integer skip, Integer limit) {
+    return executeAndRetry("listSignals",
+        () -> signalsApi.v1SignalsListGet(authSession.getSessionToken(), authSession.getKeyManagerToken(), skip, limit));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Stream<Signal> listSignalsStream(Integer chunkSize, Integer totalSize) {
+    PaginatedApi<Signal> api = ((this::listSignals));
+
+    final int actualChunkSize = chunkSize == null ? 50 : chunkSize;
+    final int actualTotalSize = totalSize == null ? 50 : totalSize;
+
+    return new PaginatedService<>(api, actualChunkSize, actualTotalSize).stream();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Signal getSignal(String id) {
+    return executeAndRetry("getSignal",
+        () -> signalsApi.v1SignalsIdGetGet(authSession.getSessionToken(), id, authSession.getKeyManagerToken()));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Signal createSignal(BaseSignal signal) {
+    return executeAndRetry("createSignal",
+        () -> signalsApi.v1SignalsCreatePost(authSession.getSessionToken(), signal, authSession.getKeyManagerToken()));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Signal updateSignal(String id, BaseSignal signal) {
+    return executeAndRetry("updateSignal",
+        () -> signalsApi.v1SignalsIdUpdatePost(authSession.getSessionToken(), id, signal, authSession.getKeyManagerToken()));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void deleteSignal(String id) {
+    executeAndRetry("deleteSignal",
+        () -> signalsApi.v1SignalsIdDeletePost(authSession.getSessionToken(), id, authSession.getKeyManagerToken()));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ChannelSubscriptionResponse subscribeSignal(String id, Boolean pushed, List<Long> userIds) {
+    return executeAndRetry("subscribeSignal",
+        () -> signalsApi.v1SignalsIdSubscribePost(authSession.getSessionToken(), id, authSession.getKeyManagerToken(), pushed, userIds));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ChannelSubscriptionResponse unsubscribeSignal(String id, List<Long> userIds) {
+    return executeAndRetry("unsubscribeSignal",
+        () -> signalsApi.v1SignalsIdUnsubscribePost(authSession.getSessionToken(), id, authSession.getKeyManagerToken(), userIds));
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public List<ChannelSubscriber> subscribers(String id, Integer skip, Integer limit) {
+    return executeAndRetry("subscribers",
+        () -> signalsApi.v1SignalsIdSubscribersGet(authSession.getSessionToken(), id, authSession.getKeyManagerToken(), skip, limit)).getData();
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public Stream<ChannelSubscriber> subscribersStream(String id, Integer chunkSize, Integer totalSize) {
+    PaginatedApi<ChannelSubscriber> api = (((offset, limit) -> subscribers(id, offset, limit)));
+
+    final int actualChunkSize = chunkSize == null ? 100 : chunkSize;
+    final int actualTotalSize = totalSize == null ? 100 : totalSize;
+
+    return new PaginatedService<>(api, actualChunkSize, actualTotalSize).stream();
+  }
+
+  private <T> T executeAndRetry(String name, SupplierWithApiException<T> supplier) {
+    final RetryWithRecoveryBuilder<?> retryBuilderWithAuthSession = RetryWithRecoveryBuilder.from(retryBuilder)
+        .clearRecoveryStrategies()
+        .recoveryStrategy(ApiException::isUnauthorized, authSession::refresh);
+    return RetryWithRecovery.executeAndRetry(retryBuilderWithAuthSession, name, supplier);
+  }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/signal/SignalService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/signal/SignalService.java
@@ -12,13 +12,15 @@ import com.symphony.bdk.gen.api.model.BaseSignal;
 import com.symphony.bdk.gen.api.model.ChannelSubscriber;
 import com.symphony.bdk.gen.api.model.ChannelSubscriptionResponse;
 import com.symphony.bdk.gen.api.model.Signal;
-
 import com.symphony.bdk.http.api.ApiException;
 
 import org.apiguardian.api.API;
 
 import java.util.List;
 import java.util.stream.Stream;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Service class for managing signal information.
@@ -57,7 +59,7 @@ public class SignalService implements OboSignalService, OboService<OboSignalServ
    * {@inheritDoc}
    */
   @Override
-  public List<Signal> listSignals(Integer skip, Integer limit) {
+  public List<Signal> listSignals(@Nullable Integer skip, @Nullable Integer limit) {
     return executeAndRetry("listSignals",
         () -> signalsApi.v1SignalsListGet(authSession.getSessionToken(), authSession.getKeyManagerToken(), skip, limit));
   }
@@ -66,7 +68,15 @@ public class SignalService implements OboSignalService, OboService<OboSignalServ
    * {@inheritDoc}
    */
   @Override
-  public Stream<Signal> listSignalsStream(Integer chunkSize, Integer totalSize) {
+  public List<Signal> listSignals() {
+    return listSignals(null, null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Stream<Signal> listSignalsStream(@Nullable Integer chunkSize, @Nullable Integer totalSize) {
     PaginatedApi<Signal> api = ((this::listSignals));
 
     final int actualChunkSize = chunkSize == null ? 50 : chunkSize;
@@ -79,7 +89,15 @@ public class SignalService implements OboSignalService, OboService<OboSignalServ
    * {@inheritDoc}
    */
   @Override
-  public Signal getSignal(String id) {
+  public Stream<Signal> listSignalsStream() {
+    return listSignalsStream(null, null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Signal getSignal(@Nonnull String id) {
     return executeAndRetry("getSignal",
         () -> signalsApi.v1SignalsIdGetGet(authSession.getSessionToken(), id, authSession.getKeyManagerToken()));
   }
@@ -88,7 +106,7 @@ public class SignalService implements OboSignalService, OboService<OboSignalServ
    * {@inheritDoc}
    */
   @Override
-  public Signal createSignal(BaseSignal signal) {
+  public Signal createSignal(@Nonnull BaseSignal signal) {
     return executeAndRetry("createSignal",
         () -> signalsApi.v1SignalsCreatePost(authSession.getSessionToken(), signal, authSession.getKeyManagerToken()));
   }
@@ -97,7 +115,7 @@ public class SignalService implements OboSignalService, OboService<OboSignalServ
    * {@inheritDoc}
    */
   @Override
-  public Signal updateSignal(String id, BaseSignal signal) {
+  public Signal updateSignal(@Nonnull String id, @Nonnull BaseSignal signal) {
     return executeAndRetry("updateSignal",
         () -> signalsApi.v1SignalsIdUpdatePost(authSession.getSessionToken(), id, signal, authSession.getKeyManagerToken()));
   }
@@ -106,7 +124,7 @@ public class SignalService implements OboSignalService, OboService<OboSignalServ
    * {@inheritDoc}
    */
   @Override
-  public void deleteSignal(String id) {
+  public void deleteSignal(@Nonnull String id) {
     executeAndRetry("deleteSignal",
         () -> signalsApi.v1SignalsIdDeletePost(authSession.getSessionToken(), id, authSession.getKeyManagerToken()));
   }
@@ -115,7 +133,7 @@ public class SignalService implements OboSignalService, OboService<OboSignalServ
    * {@inheritDoc}
    */
   @Override
-  public ChannelSubscriptionResponse subscribeSignal(String id, Boolean pushed, List<Long> userIds) {
+  public ChannelSubscriptionResponse subscribeSignal(@Nonnull String id, @Nullable Boolean pushed, @Nonnull List<Long> userIds) {
     return executeAndRetry("subscribeSignal",
         () -> signalsApi.v1SignalsIdSubscribePost(authSession.getSessionToken(), id, authSession.getKeyManagerToken(), pushed, userIds));
   }
@@ -124,33 +142,48 @@ public class SignalService implements OboSignalService, OboService<OboSignalServ
    * {@inheritDoc}
    */
   @Override
-  public ChannelSubscriptionResponse unsubscribeSignal(String id, List<Long> userIds) {
+  public ChannelSubscriptionResponse unsubscribeSignal(@Nonnull String id, @Nullable List<Long> userIds) {
     return executeAndRetry("unsubscribeSignal",
         () -> signalsApi.v1SignalsIdUnsubscribePost(authSession.getSessionToken(), id, authSession.getKeyManagerToken(), userIds));
   }
 
   /**
    * {@inheritDoc}
-   * @return
    */
   @Override
-  public List<ChannelSubscriber> listSubscribers(String id, Integer skip, Integer limit) {
+  public List<ChannelSubscriber> listSubscribers(@Nonnull String id, @Nullable Integer skip, @Nullable Integer limit) {
     return executeAndRetry("subscribers",
         () -> signalsApi.v1SignalsIdSubscribersGet(authSession.getSessionToken(), id, authSession.getKeyManagerToken(), skip, limit)).getData();
   }
 
   /**
    * {@inheritDoc}
-   * @return
    */
   @Override
-  public Stream<ChannelSubscriber> listSubscribersStream(String id, Integer chunkSize, Integer totalSize) {
+  public List<ChannelSubscriber> listSubscribers(@Nonnull String id) {
+    return listSubscribers(id, null, null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Stream<ChannelSubscriber> listSubscribersStream(
+      @Nonnull String id, @Nullable Integer chunkSize, @Nullable Integer totalSize) {
     PaginatedApi<ChannelSubscriber> api = (((offset, limit) -> listSubscribers(id, offset, limit)));
 
     final int actualChunkSize = chunkSize == null ? 100 : chunkSize;
     final int actualTotalSize = totalSize == null ? 100 : totalSize;
 
     return new PaginatedService<>(api, actualChunkSize, actualTotalSize).stream();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Stream<ChannelSubscriber> listSubscribersStream(@Nonnull String id) {
+    return listSubscribersStream(id, null, null);
   }
 
   private <T> T executeAndRetry(String name, SupplierWithApiException<T> supplier) {

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/OboServicesTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/OboServicesTest.java
@@ -9,6 +9,7 @@ import com.symphony.bdk.core.config.model.BdkConfig;
 import com.symphony.bdk.core.service.connection.OboConnectionService;
 import com.symphony.bdk.core.service.message.OboMessageService;
 import com.symphony.bdk.core.service.presence.OboPresenceService;
+import com.symphony.bdk.core.service.signal.OboSignalService;
 import com.symphony.bdk.core.service.stream.OboStreamService;
 
 import com.symphony.bdk.core.service.user.OboUserService;
@@ -53,5 +54,11 @@ public class OboServicesTest {
   void testOboConnections() {
     OboConnectionService connectionService = oboServices.connections();
     assertNotNull(connectionService);
+  }
+
+  @Test
+  void testOboSignals() {
+    OboSignalService signalService = oboServices.signals();
+    assertNotNull(signalService);
   }
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/ServiceFactoryTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/ServiceFactoryTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.symphony.bdk.core.service.connection.ConnectionService;
 import com.symphony.bdk.core.service.presence.PresenceService;
+import com.symphony.bdk.core.service.signal.SignalService;
 import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.client.ApiClientFactory;
@@ -69,6 +70,12 @@ public class ServiceFactoryTest {
   void getConnectionServiceTest() {
     ConnectionService connectionService = this.serviceFactory.getConnectionService();
     assertNotNull(connectionService);
+  }
+
+  @Test
+  void getSignalServiceTest() {
+    SignalService signalService = this.serviceFactory.getSignalService();
+    assertNotNull(signalService);
   }
 
   @Test

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/SymphonyBdkTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/SymphonyBdkTest.java
@@ -18,6 +18,7 @@ import com.symphony.bdk.core.service.message.MessageService;
 import com.symphony.bdk.core.service.datafeed.DatafeedService;
 import com.symphony.bdk.core.service.datafeed.impl.DatafeedServiceV1;
 import com.symphony.bdk.core.service.presence.PresenceService;
+import com.symphony.bdk.core.service.signal.SignalService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
 import com.symphony.bdk.core.test.JsonHelper;
@@ -107,6 +108,12 @@ public class SymphonyBdkTest {
   void getMessageServiceTest() {
     MessageService messageService = this.symphonyBdk.messages();
     assertNotNull(messageService);
+  }
+
+  @Test
+  void getSignalServiceTest() {
+    SignalService signalService = this.symphonyBdk.signals();
+    assertNotNull(signalService);
   }
 
   @Test

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/signal/SignalServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/signal/SignalServiceTest.java
@@ -79,6 +79,27 @@ public class SignalServiceTest {
   }
 
   @Test
+  void listSignalsDefaultLimit() {
+    this.mockApiClient.onGet(V1_LIST_SIGNAL,
+        "[\n"
+            + "  {\n"
+            + "    \"name\": \"Mention and keyword\",\n"
+            + "    \"query\": \"HASHTAG:Hello OR POSTEDBY:10854618893681\",\n"
+            + "    \"visibleOnProfile\": false,\n"
+            + "    \"companyWide\": false,\n"
+            + "    \"id\": \"5a0068344b570777718322a3\",\n"
+            + "    \"timestamp\": 1509976116525\n"
+            + "  }\n"
+            + "]");
+
+    List<Signal> signals = this.service.listSignals();
+
+    assertEquals(signals.size(), 1);
+    assertEquals(signals.get(0).getId(), "5a0068344b570777718322a3");
+    assertEquals(signals.get(0).getName(), "Mention and keyword");
+  }
+
+  @Test
   void listSignalFailed() {
     this.mockApiClient.onGet(400, V1_LIST_SIGNAL, "{}");
 
@@ -100,6 +121,27 @@ public class SignalServiceTest {
             + "]");
 
     Stream<Signal> signals = this.service.listSignalsStream(2, 2);
+    List<Signal> signalList = signals.collect(Collectors.toList());
+
+    assertEquals(signalList.size(), 1);
+    assertEquals(signalList.get(0).getQuery(), "HASHTAG:Hello OR POSTEDBY:10854618893681");
+  }
+
+  @Test
+  void listSignalStreamDefaultPagination() {
+    this.mockApiClient.onGet(V1_LIST_SIGNAL,
+        "[\n"
+            + "  {\n"
+            + "    \"name\": \"Mention and keyword\",\n"
+            + "    \"query\": \"HASHTAG:Hello OR POSTEDBY:10854618893681\",\n"
+            + "    \"visibleOnProfile\": false,\n"
+            + "    \"companyWide\": false,\n"
+            + "    \"id\": \"5a0068344b570777718322a3\",\n"
+            + "    \"timestamp\": 1509976116525\n"
+            + "  }\n"
+            + "]");
+
+    Stream<Signal> signals = this.service.listSignalsStream();
     List<Signal> signalList = signals.collect(Collectors.toList());
 
     assertEquals(signalList.size(), 1);
@@ -274,6 +316,31 @@ public class SignalServiceTest {
   }
 
   @Test
+  void subscribersDefaultLimit() {
+    this.mockApiClient.onGet(V1_SUBSCRIBERS.replace("{id}", "1234"),
+        "{\n"
+            + "    \"offset\": 0,\n"
+            + "    \"hasMore\": true,\n"
+            + "    \"total\": 150,\n"
+            + "    \"data\": [\n"
+            + "        {\n"
+            + "            \"pushed\": false,\n"
+            + "            \"owner\": true,\n"
+            + "            \"subscriberName\": \"John Doe 01\",\n"
+            + "            \"userId\": 68719476742,\n"
+            + "            \"timestamp\": 1519231972000\n"
+            + "        }\n"
+            + "    ]\n"
+            + "}");
+
+    List<ChannelSubscriber> subscribers = this.service.listSubscribers("1234");
+
+    assertEquals(subscribers.size(), 1);
+    assertEquals(subscribers.get(0).getUserId(), 68719476742L);
+    assertEquals(subscribers.get(0).getSubscriberName(), "John Doe 01");
+  }
+
+  @Test
   void subscribersFailed() {
     this.mockApiClient.onGet(400, V1_SUBSCRIBERS.replace("{id}", "1234"), "{}");
 
@@ -299,6 +366,32 @@ public class SignalServiceTest {
             + "}");
 
     Stream<ChannelSubscriber> subscribers = this.service.listSubscribersStream("1234", 2, 2);
+    List<ChannelSubscriber> subscriberList = subscribers.collect(Collectors.toList());
+
+    assertEquals(subscriberList.size(), 1);
+    assertEquals(subscriberList.get(0).getUserId(), 68719476742L);
+    assertEquals(subscriberList.get(0).getSubscriberName(), "John Doe 01");
+  }
+
+  @Test
+  void subscribersStreamDefaultPagination() {
+    this.mockApiClient.onGet(V1_SUBSCRIBERS.replace("{id}", "1234"),
+        "{\n"
+            + "    \"offset\": 0,\n"
+            + "    \"hasMore\": true,\n"
+            + "    \"total\": 150,\n"
+            + "    \"data\": [\n"
+            + "        {\n"
+            + "            \"pushed\": false,\n"
+            + "            \"owner\": true,\n"
+            + "            \"subscriberName\": \"John Doe 01\",\n"
+            + "            \"userId\": 68719476742,\n"
+            + "            \"timestamp\": 1519231972000\n"
+            + "        }\n"
+            + "    ]\n"
+            + "}");
+
+    Stream<ChannelSubscriber> subscribers = this.service.listSubscribersStream("1234");
     List<ChannelSubscriber> subscriberList = subscribers.collect(Collectors.toList());
 
     assertEquals(subscriberList.size(), 1);

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/signal/SignalServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/signal/SignalServiceTest.java
@@ -1,0 +1,308 @@
+package com.symphony.bdk.core.service.signal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.symphony.bdk.core.auth.AuthSession;
+import com.symphony.bdk.core.retry.RetryWithRecoveryBuilder;
+import com.symphony.bdk.core.test.MockApiClient;
+import com.symphony.bdk.gen.api.SignalsApi;
+import com.symphony.bdk.gen.api.model.BaseSignal;
+import com.symphony.bdk.gen.api.model.ChannelSubscriber;
+import com.symphony.bdk.gen.api.model.ChannelSubscriptionResponse;
+import com.symphony.bdk.gen.api.model.Signal;
+import com.symphony.bdk.http.api.ApiClient;
+import com.symphony.bdk.http.api.ApiException;
+import com.symphony.bdk.http.api.ApiRuntimeException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class SignalServiceTest {
+
+  private static final String V1_LIST_SIGNAL = "/agent/v1/signals/list";
+  private static final String V1_GET_SIGNAL = "/agent/v1/signals/{id}/get";
+  private static final String V1_CREATE_SIGNAL = "/agent/v1/signals/create";
+  private static final String V1_UPDATE_SIGNAL = "/agent/v1/signals/{id}/update";
+  private static final String V1_DELETE_SIGNAL = "/agent/v1/signals/{id}/delete";
+  private static final String V1_SUBSCRIBE_SIGNAL = "/agent/v1/signals/{id}/subscribe";
+  private static final String V1_UNSUBSCRIBE_SIGNAL = "/agent/v1/signals/{id}/unsubscribe";
+  private static final String V1_SUBSCRIBERS = "/agent/v1/signals/{id}/subscribers";
+
+  private SignalService service;
+  private SignalsApi spiedSignalApi;
+  private MockApiClient mockApiClient;
+
+  @BeforeEach
+  void init() {
+    this.mockApiClient = new MockApiClient();
+    AuthSession authSession = mock(AuthSession.class);
+    ApiClient agentClient = mockApiClient.getApiClient("/agent");
+    SignalsApi signalsApi = new SignalsApi(agentClient);
+    this.spiedSignalApi = spy(signalsApi);
+    this.service = new SignalService(spiedSignalApi, authSession, new RetryWithRecoveryBuilder<>());
+
+    when(authSession.getSessionToken()).thenReturn("1234");
+    when(authSession.getKeyManagerToken()).thenReturn("1234");
+  }
+
+  @Test
+  void listSignalTest() {
+    this.mockApiClient.onGet(V1_LIST_SIGNAL,
+        "[\n"
+        + "  {\n"
+        + "    \"name\": \"Mention and keyword\",\n"
+        + "    \"query\": \"HASHTAG:Hello OR POSTEDBY:10854618893681\",\n"
+        + "    \"visibleOnProfile\": false,\n"
+        + "    \"companyWide\": false,\n"
+        + "    \"id\": \"5a0068344b570777718322a3\",\n"
+        + "    \"timestamp\": 1509976116525\n"
+        + "  }\n"
+        + "]");
+
+    List<Signal> signals = this.service.listSignals(0, 100);
+
+    assertEquals(signals.size(), 1);
+    assertEquals(signals.get(0).getId(), "5a0068344b570777718322a3");
+    assertEquals(signals.get(0).getName(), "Mention and keyword");
+  }
+
+  @Test
+  void listSignalFailed() {
+    this.mockApiClient.onGet(400, V1_LIST_SIGNAL, "{}");
+
+    assertThrows(ApiRuntimeException.class, () -> this.service.listSignals(0, 100));
+  }
+
+  @Test
+  void listSignalStreamTest() {
+    this.mockApiClient.onGet(V1_LIST_SIGNAL,
+        "[\n"
+            + "  {\n"
+            + "    \"name\": \"Mention and keyword\",\n"
+            + "    \"query\": \"HASHTAG:Hello OR POSTEDBY:10854618893681\",\n"
+            + "    \"visibleOnProfile\": false,\n"
+            + "    \"companyWide\": false,\n"
+            + "    \"id\": \"5a0068344b570777718322a3\",\n"
+            + "    \"timestamp\": 1509976116525\n"
+            + "  }\n"
+            + "]");
+
+    Stream<Signal> signals = this.service.listSignalsStream(2, 2);
+    List<Signal> signalList = signals.collect(Collectors.toList());
+
+    assertEquals(signalList.size(), 1);
+    assertEquals(signalList.get(0).getQuery(), "HASHTAG:Hello OR POSTEDBY:10854618893681");
+  }
+
+  @Test
+  void getSignalTest() {
+    this.mockApiClient.onGet(V1_GET_SIGNAL.replace("{id}", "1234"),
+        "{\n"
+        + "    \"name\": \"my signal\",\n"
+        + "    \"query\": \"HASHTAG:hashtag AND CASHTAG:cash\",\n"
+        + "    \"visibleOnProfile\": true,\n"
+        + "    \"companyWide\": false,\n"
+        + "    \"id\": \"5a8daa0bb9d82100011d5095\",\n"
+        + "    \"timestamp\": 1519233547982\n"
+        + "}");
+
+    Signal signal = this.service.getSignal("1234");
+
+    assertEquals(signal.getId(), "5a8daa0bb9d82100011d5095");
+    assertEquals(signal.getQuery(), "HASHTAG:hashtag AND CASHTAG:cash");
+    assertFalse(signal.getCompanyWide());
+  }
+
+  @Test
+  void getSignalFailed() {
+    this.mockApiClient.onGet(400, V1_GET_SIGNAL.replace("{id}", "1234"), "{}");
+
+    assertThrows(ApiRuntimeException.class, () -> this.service.getSignal("1234"));
+  }
+
+  @Test
+  void createSignalTest() {
+    this.mockApiClient.onPost(V1_CREATE_SIGNAL,
+        "{\n"
+        + "    \"name\": \"hash and cash\",\n"
+        + "    \"query\": \"HASHTAG:hash AND CASHTAG:cash\",\n"
+        + "    \"visibleOnProfile\": true,\n"
+        + "    \"companyWide\": false,\n"
+        + "    \"id\": \"5a8da7edb9d82100011d508f\",\n"
+        + "    \"timestamp\": 1519233005107\n"
+        + "}");
+
+    Signal signal = this.service.createSignal(new BaseSignal());
+
+    assertEquals(signal.getId(), "5a8da7edb9d82100011d508f");
+    assertEquals(signal.getQuery(), "HASHTAG:hash AND CASHTAG:cash");
+    assertFalse(signal.getCompanyWide());
+  }
+
+  @Test
+  void createSignalFailed() {
+    this.mockApiClient.onPost(400, V1_CREATE_SIGNAL, "{}");
+
+    assertThrows(ApiRuntimeException.class, () -> this.service.createSignal(new BaseSignal()));
+  }
+
+  @Test
+  void updateSignalTest() {
+    this.mockApiClient.onPost(V1_UPDATE_SIGNAL.replace("{id}", "1234"),
+        "{\n"
+            + "    \"name\": \"hashtag only\",\n"
+            + "    \"query\": \"HASHTAG:hash\",\n"
+            + "    \"visibleOnProfile\": false,\n"
+            + "    \"companyWide\": false,\n"
+            + "    \"id\": \"1234\",\n"
+            + "    \"timestamp\": 1519233005107\n"
+            + "}");
+
+    Signal signal = this.service.updateSignal("1234", new BaseSignal());
+
+    assertEquals(signal.getQuery(), "HASHTAG:hash");
+    assertFalse(signal.getVisibleOnProfile());
+    assertFalse(signal.getCompanyWide());
+  }
+
+  @Test
+  void updateSignalFailed() {
+    this.mockApiClient.onPost(400, V1_UPDATE_SIGNAL.replace("{id}", "1234"), "{}");
+
+    assertThrows(ApiRuntimeException.class, () -> this.service.updateSignal("1234", new BaseSignal()));
+  }
+
+  @Test
+  void deleteSignalTest() throws ApiException {
+    this.mockApiClient.onPost(V1_DELETE_SIGNAL.replace("{id}", "signal-id"), "{}");
+
+    this.service.deleteSignal("signal-id");
+
+    verify(this.spiedSignalApi).v1SignalsIdDeletePost("1234", "signal-id", "1234");
+  }
+
+  @Test
+  void deleteSignalFailed() {
+    this.mockApiClient.onPost(400, V1_DELETE_SIGNAL.replace("{id}", "signal-id"), "{}");
+
+    assertThrows(ApiRuntimeException.class, () -> this.service.deleteSignal("signal-id"));
+  }
+
+  @Test
+  void subscribeSignalTest() throws ApiException {
+    this.mockApiClient.onPost(V1_SUBSCRIBE_SIGNAL.replace("{id}", "1234"),
+        "{\n"
+            + "    \"requestedSubscription\": 3,\n"
+            + "    \"successfulSubscription\": 3,\n"
+            + "    \"failedSubscription\": 0,\n"
+            + "    \"subscriptionErrors\": []\n"
+            + "}");
+
+    ChannelSubscriptionResponse response = this.service.subscribeSignal("1234", true, Arrays.asList(1234L, 1235L, 1236L));
+
+    verify(spiedSignalApi).v1SignalsIdSubscribePost("1234", "1234", "1234", true, Arrays.asList(1234L, 1235L, 1236L));
+    assertEquals(response.getRequestedSubscription(), 3);
+    assertEquals(response.getSuccessfulSubscription(), 3);
+  }
+
+  @Test
+  void subscribeSignalFailed() {
+    this.mockApiClient.onPost(400, V1_SUBSCRIBE_SIGNAL.replace("{id}", "1234"), "{}");
+
+    assertThrows(ApiRuntimeException.class, () -> this.service.subscribeSignal("1234", true, Collections.singletonList(1234L)));
+  }
+
+  @Test
+  void unsubscribeSignalTest() throws ApiException {
+    this.mockApiClient.onPost(V1_UNSUBSCRIBE_SIGNAL.replace("{id}", "1234"),
+        "{\n"
+            + "    \"requestedSubscription\": 3,\n"
+            + "    \"successfulSubscription\": 3,\n"
+            + "    \"failedSubscription\": 0,\n"
+            + "    \"subscriptionErrors\": []\n"
+            + "}");
+
+    ChannelSubscriptionResponse response = this.service.unsubscribeSignal("1234", Arrays.asList(1234L, 1235L, 1236L));
+
+    verify(spiedSignalApi).v1SignalsIdUnsubscribePost("1234", "1234", "1234", Arrays.asList(1234L, 1235L, 1236L));
+    assertEquals(response.getSuccessfulSubscription(), 3);
+    assertEquals(response.getRequestedSubscription(), 3);
+  }
+
+  @Test
+  void unsubscribeSignalFailed() {
+    this.mockApiClient.onPost(400, V1_UNSUBSCRIBE_SIGNAL.replace("{id}", "1234"), "{}");
+
+    assertThrows(ApiRuntimeException.class, () -> this.service.unsubscribeSignal("1234", Collections.singletonList(1234L)));
+  }
+
+  @Test
+  void subscribersTest() {
+    this.mockApiClient.onGet(V1_SUBSCRIBERS.replace("{id}", "1234"),
+        "{\n"
+            + "    \"offset\": 0,\n"
+            + "    \"hasMore\": true,\n"
+            + "    \"total\": 150,\n"
+            + "    \"data\": [\n"
+            + "        {\n"
+            + "            \"pushed\": false,\n"
+            + "            \"owner\": true,\n"
+            + "            \"subscriberName\": \"John Doe 01\",\n"
+            + "            \"userId\": 68719476742,\n"
+            + "            \"timestamp\": 1519231972000\n"
+            + "        }\n"
+            + "    ]\n"
+            + "}");
+
+    List<ChannelSubscriber> subscribers = this.service.subscribers("1234", 0, 100);
+
+    assertEquals(subscribers.size(), 1);
+    assertEquals(subscribers.get(0).getUserId(), 68719476742L);
+    assertEquals(subscribers.get(0).getSubscriberName(), "John Doe 01");
+  }
+
+  @Test
+  void subscribersFailed() {
+    this.mockApiClient.onGet(400, V1_SUBSCRIBERS.replace("{id}", "1234"), "{}");
+
+    assertThrows(ApiRuntimeException.class, () -> this.service.subscribers("1234", 0, 100));
+  }
+
+  @Test
+  void subscribersStreamTest() {
+    this.mockApiClient.onGet(V1_SUBSCRIBERS.replace("{id}", "1234"),
+        "{\n"
+            + "    \"offset\": 0,\n"
+            + "    \"hasMore\": true,\n"
+            + "    \"total\": 150,\n"
+            + "    \"data\": [\n"
+            + "        {\n"
+            + "            \"pushed\": false,\n"
+            + "            \"owner\": true,\n"
+            + "            \"subscriberName\": \"John Doe 01\",\n"
+            + "            \"userId\": 68719476742,\n"
+            + "            \"timestamp\": 1519231972000\n"
+            + "        }\n"
+            + "    ]\n"
+            + "}");
+
+    Stream<ChannelSubscriber> subscribers = this.service.subscribersStream("1234", 2, 2);
+    List<ChannelSubscriber> subscriberList = subscribers.collect(Collectors.toList());
+
+    assertEquals(subscriberList.size(), 1);
+    assertEquals(subscriberList.get(0).getUserId(), 68719476742L);
+    assertEquals(subscriberList.get(0).getSubscriberName(), "John Doe 01");
+  }
+}

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/signal/SignalServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/signal/SignalServiceTest.java
@@ -266,7 +266,7 @@ public class SignalServiceTest {
             + "    ]\n"
             + "}");
 
-    List<ChannelSubscriber> subscribers = this.service.subscribers("1234", 0, 100);
+    List<ChannelSubscriber> subscribers = this.service.listSubscribers("1234", 0, 100);
 
     assertEquals(subscribers.size(), 1);
     assertEquals(subscribers.get(0).getUserId(), 68719476742L);
@@ -277,7 +277,7 @@ public class SignalServiceTest {
   void subscribersFailed() {
     this.mockApiClient.onGet(400, V1_SUBSCRIBERS.replace("{id}", "1234"), "{}");
 
-    assertThrows(ApiRuntimeException.class, () -> this.service.subscribers("1234", 0, 100));
+    assertThrows(ApiRuntimeException.class, () -> this.service.listSubscribers("1234", 0, 100));
   }
 
   @Test
@@ -298,7 +298,7 @@ public class SignalServiceTest {
             + "    ]\n"
             + "}");
 
-    Stream<ChannelSubscriber> subscribers = this.service.subscribersStream("1234", 2, 2);
+    Stream<ChannelSubscriber> subscribers = this.service.listSubscribersStream("1234", 2, 2);
     List<ChannelSubscriber> subscriberList = subscribers.collect(Collectors.toList());
 
     assertEquals(subscriberList.size(), 1);

--- a/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/ServiceExampleMain.java
+++ b/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/ServiceExampleMain.java
@@ -5,6 +5,7 @@ import static com.symphony.bdk.core.config.BdkConfigLoader.loadFromSymphonyDir;
 import com.symphony.bdk.core.SymphonyBdk;
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.service.user.constant.UserFeature;
+import com.symphony.bdk.gen.api.model.Signal;
 import com.symphony.bdk.gen.api.model.StreamAttributes;
 import com.symphony.bdk.gen.api.model.StreamFilter;
 import com.symphony.bdk.gen.api.model.StreamType;
@@ -16,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 
 @Slf4j
-public class UserExampleMain {
+public class ServiceExampleMain {
 
   public static void main(String[] args) throws Exception {
 
@@ -37,8 +38,15 @@ public class UserExampleMain {
     log.info("Role: {}", userDetailList.get(0).getRoles());
 
     AuthSession oboSession = bdk.obo("hong.le");
+
     StreamFilter streamFilter = new StreamFilter().addStreamTypesItem(new StreamType().type(StreamType.TypeEnum.IM));
-    List<StreamAttributes> streamsList = bdk.obo(oboSession).streams().listStreams(streamFilter);
+    final List<StreamAttributes> streamsList = bdk.obo(oboSession).streams().listStreams(streamFilter);
     log.info("Streams List: {}", streamsList);
+
+    final List<Signal> signalList = bdk.obo(oboSession).signals().listSignals();
+    log.info("Retrieve {} signals", signalList.size());
+    log.info("First signal:");
+    log.info("Signal name: {}", signalList.get(0).getName());
+    log.info("Signal query: {}", signalList.get(0).getQuery());
   }
 }

--- a/symphony-bdk-legacy/build.gradle
+++ b/symphony-bdk-legacy/build.gradle
@@ -163,6 +163,11 @@ subprojects {
             }
         }
     }
+
+    signing {
+        required { rootProject.isReleaseVersion }
+        sign publishing.publications.maven
+    }
 }
 
 tasks.withType(Sign) {

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkServiceConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkServiceConfig.java
@@ -7,6 +7,7 @@ import com.symphony.bdk.core.service.SessionService;
 import com.symphony.bdk.core.service.connection.ConnectionService;
 import com.symphony.bdk.core.service.message.MessageService;
 import com.symphony.bdk.core.service.presence.PresenceService;
+import com.symphony.bdk.core.service.signal.SignalService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
 import com.symphony.bdk.gen.api.AttachmentsApi;
@@ -20,6 +21,7 @@ import com.symphony.bdk.gen.api.PresenceApi;
 import com.symphony.bdk.gen.api.RoomMembershipApi;
 import com.symphony.bdk.gen.api.SessionApi;
 import com.symphony.bdk.gen.api.ShareApi;
+import com.symphony.bdk.gen.api.SignalsApi;
 import com.symphony.bdk.gen.api.StreamsApi;
 import com.symphony.bdk.gen.api.UserApi;
 import com.symphony.bdk.gen.api.UsersApi;
@@ -66,6 +68,12 @@ public class BdkServiceConfig {
   @ConditionalOnMissingBean
   public ConnectionService connectionService(ConnectionApi connectionApi, AuthSession botSession, BdkConfig config) {
     return new ConnectionService(connectionApi, botSession, new RetryWithRecoveryBuilder<>().retryConfig(config.getRetry()));
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public SignalService signalService(SignalsApi signalsApi, AuthSession botSession, BdkConfig config) {
+    return new SignalService(signalsApi, botSession, new RetryWithRecoveryBuilder<>().retryConfig(config.getRetry()));
   }
 
   @Bean


### PR DESCRIPTION
### Ticket
[APP-3142](https://perzoinc.atlassian.net/browse/APP-3142)

### Description
OboSignalService to enable the Obo service for SignalService.

SignalService exposing all endpoints relate to signals information.

Entry to get SignalService from SymphonyBdk entry point.

PaginatedService for SignalService#listSignals and SignalService#subscribers

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
