### PR TITLE
Generated POM for legacy bot SDK is missing versions

### DIFF
--- a/symphony-bdk-legacy/build.gradle
+++ b/symphony-bdk-legacy/build.gradle
@@ -1,6 +1,6 @@
 description = 'Symphony Java BDK Legacy Module'
 
-ext.projectVersion = '1.3.0'
+ext.projectVersion = '1.3.1'
 ext.isReleaseVersion = !ext.projectVersion.endsWith('SNAPSHOT')
 
 ext.symphonyRepoUrl = project.properties['symphonyRepoUrl'] ?: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'

--- a/symphony-bdk-legacy/build.gradle
+++ b/symphony-bdk-legacy/build.gradle
@@ -55,6 +55,7 @@ nexusStaging {
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'jacoco'
     apply plugin: 'signing'
     apply plugin: 'maven-publish'

--- a/symphony-bdk-legacy/build.gradle
+++ b/symphony-bdk-legacy/build.gradle
@@ -99,7 +99,9 @@ subprojects {
             implementation 'org.springframework.boot:spring-boot-starter-security:2.3.0.RELEASE'
             implementation 'org.springframework.boot:spring-boot-starter-web:2.3.0.RELEASE'
             implementation 'org.springframework.boot:spring-boot-starter-aop:2.3.0.RELEASE'
+            implementation 'org.springframework.boot:spring-boot-starter-actuator:2.3.0.RELEASE'
             implementation 'org.symphonyoss.symphony:messageml:0.9.57'
+            implementation 'io.micrometer:micrometer-registry-prometheus:1.5.1'
 
             testCompileOnly 'org.projectlombok:lombok:1.18.12'
             testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'

--- a/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/build.gradle
+++ b/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/build.gradle
@@ -7,8 +7,8 @@ processResources {
 }
 
 dependencies {
-    implementation project(':symphony-api-client-java')
-    implementation project(':sms-sdk-renderer-java')
+    api project(':symphony-api-client-java')
+    api project(':sms-sdk-renderer-java')
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
Versions for Spring Boot Actuator and Micrometer were not defined in the
constraints. While it was not breaking the build because transitive
dependencies were used, it was breaking the POM generation, leaving the
versions empty.

A project using the SDK as a dependency would then not get the
transitive dependencies automatically.

(cherry picked from commit 8e231d4e24b5b6264d8afb15540b3771f6ab082f)
