### PR TITLE
APP-3178 Removed deprecation on MessageService#send(V4Stream|String, String), auto append <messageML> tag to message content if not set

### DIFF
--- a/docs/message.md
+++ b/docs/message.md
@@ -26,11 +26,13 @@ public class Example {
     // Create BDK entry point
     final SymphonyBdk bdk = new SymphonyBdk(loadFromClasspath("/config.yaml"));
     // send a regular message
-    final V4Message regularMessage = bdk.message().send(STREAM_ID, Message.builder().content("<messageML>Hello, World!</messageML>").build());
+    final V4Message regularMessage = bdk.message().send(STREAM_ID, Message.builder().content("Hello, World!").build());
     log.info("Message sent, id: " + regularMessage.getMessageId());
   }
 }
 ```
+> `Message.builder().content("Hello, World!").build()` will automatically prefix and suffix content with `"<messageML>"` and `"</messageML>"`.
+> Therefore, the actual `Message.getContent()` result will be `"<messageML>Hello, World!</messageML>"`
 
 ## Using templates
 The `MessageService` also allows you to send messages using templates. So far, the BDK supports two different template

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
@@ -31,7 +31,6 @@ public interface OboMessageService {
    * @param message the MessageML content. Note: <code>&lt;messageML&gt;&lt;/messageML&gt;</code> is automatically appended if not set.
    * @return a {@link V4Message} object containing the details of the sent message
    * @see <a href="https://developers.symphony.com/restapi/reference#create-message-v4">Create Message v4</a>
-   * @deprecated this method will be replaced by {@link MessageService#send(V4Stream, Message)}
    */
   V4Message send(@Nonnull V4Stream stream, @Nonnull String message);
 
@@ -42,7 +41,6 @@ public interface OboMessageService {
    * @param message the MessageML content. Note: <code>&lt;messageML&gt;&lt;/messageML&gt;</code> is automatically appended if not set.
    * @return a {@link V4Message} object containing the details of the sent message
    * @see <a href="https://developers.symphony.com/restapi/reference#create-message-v4">Create Message v4</a>
-   * @deprecated this method will be replaced by {@link MessageService#send(String, Message)}
    */
   V4Message send(@Nonnull String streamId, @Nonnull String message);
 

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
@@ -28,26 +28,22 @@ public interface OboMessageService {
    * Sends a message to the stream ID of the passed {@link V4Stream} object.
    *
    * @param stream  the stream to send the message to
-   * @param message the message payload in MessageML
+   * @param message the MessageML content. Note: <code>&lt;messageML&gt;&lt;/messageML&gt;</code> is automatically appended if not set.
    * @return a {@link V4Message} object containing the details of the sent message
    * @see <a href="https://developers.symphony.com/restapi/reference#create-message-v4">Create Message v4</a>
    * @deprecated this method will be replaced by {@link MessageService#send(V4Stream, Message)}
    */
-  @Deprecated
-  @API(status = API.Status.DEPRECATED)
   V4Message send(@Nonnull V4Stream stream, @Nonnull String message);
 
   /**
    * Sends a message to the stream ID passed in parameter.
    *
    * @param streamId the ID of the stream to send the message to
-   * @param message  the message payload in MessageML
+   * @param message the MessageML content. Note: <code>&lt;messageML&gt;&lt;/messageML&gt;</code> is automatically appended if not set.
    * @return a {@link V4Message} object containing the details of the sent message
    * @see <a href="https://developers.symphony.com/restapi/reference#create-message-v4">Create Message v4</a>
    * @deprecated this method will be replaced by {@link MessageService#send(String, Message)}
    */
-  @Deprecated
-  @API(status = API.Status.DEPRECATED)
   V4Message send(@Nonnull String streamId, @Nonnull String message);
 
   /**

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/model/Message.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/model/Message.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apiguardian.api.API;
 
@@ -72,6 +73,7 @@ public class Message {
   /**
    * {@link Message} class builder. Accessible via {@link Message#builder()}.
    */
+  @Slf4j
   @Getter
   @Setter
   @Accessors(fluent = true)
@@ -164,9 +166,17 @@ public class Message {
      * @throws MessageCreationException if mandatory content is empty.
      */
     public Message build() {
+      // content is mandatory
       if (StringUtils.isEmpty(this.content)) {
         throw new MessageCreationException("Message content is mandatory.");
       }
+
+      // check if content is encapsulated in <messageML/> node
+      if (!this.content.startsWith("<messageML>") && !this.content.endsWith("</messageML>")) {
+        log.trace("Processing content to prefix with <messageML> and suffix with </messageML>");
+        this.content = "<messageML>" + this.content + "</messageML>";
+      }
+
       // check done below because it will rejected by the agent otherwise
       if (!this.previews.isEmpty() && this.previews.size() != this.attachments().size()) {
         throw new MessageCreationException("Message should contain either no preview or as many previews as attachments");

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
@@ -77,7 +77,7 @@ public class MessageServiceTest {
 
   private static final String STREAM_ID = "streamId";
   private static final String MESSAGE_ID = "messageId";
-  private static final String MESSAGE = "message";
+  private static final String MESSAGE = "<messageML>message</messageML>";
   private static final String TOKEN = "1234";
 
   private MockApiClient mockApiClient;

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/model/MessageTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/model/MessageTest.java
@@ -18,4 +18,14 @@ class MessageTest {
   void checkDefaultVersion() {
     assertEquals("2.0", Message.builder().content("foobar").build().getVersion());
   }
+
+  @Test
+  void checkMessageMLAppendedToContentIfNotSet() {
+    assertEquals("<messageML>hello</messageML>", Message.builder().content("hello").build().getContent());
+  }
+
+  @Test
+  void checkMessageMLNotAppendedToContentIfSet() {
+    assertEquals("<messageML>hello</messageML>", Message.builder().content("<messageML>hello</messageML>").build().getContent());
+  }
 }


### PR DESCRIPTION
### Ticket
[APP-3178](https://perzoinc.atlassian.net/browse/APP-3178)

### Description
- methods `MessageService#send(V4Stream, String)` and `MessageService#send(String, String)` are not deprecated anymore
- auto append `<messageML/>` tag to message content if not set

### Dependencies
N/A

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
