### PR TITLE
APP-3137: Moved configuration field from agents to agent.loadBalancing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,14 @@ pod:
   port: 443
 
 agent:
-  context: agent
+  loadBalancing:
+    mode: roundRobin
+    stickiness: false
+    nodes:
+      - host: agent1.symphony.com
+        port: 7443
+        context: app/
+      - host: agent2.symphony.com
 
 keyManager:
   host: dev-key.symphony.com
@@ -67,15 +74,6 @@ keyManager:
 sessionAuth:
   host: dev-session.symphony.com
   port: 8444
-
-agents:
-  mode: roundRobin
-  stickiness: false
-  nodes:
-    - host: agent1.symphony.com
-      port: 7443
-      context: app/
-    - host: agent2.symphony.com
 
 bot:
   username: bot-name
@@ -115,10 +113,10 @@ user specify the dedicated `host`, `port`, `context`, `scheme` inside the client
 - `pod` contains information like host, port, scheme, context, proxy... of the pod on which 
 the service account using by the bot is created.
 - `agent` contains information like host, port, scheme, context, proxy... of the agent which 
-the bot connects to.
+the bot connects to. It can also contain a `loadBalancing` field: if defined,
+it should not any field among scheme, host, port, context.
 - `keyManager` contains information like host, port, scheme, context, proxy... of the key 
 manager which manages the key token of the bot.
-- `agents` contains information about agent load-balancing. It must not be defined with an `agent` field.
 - `bot` contains information about the bot like the username, the private key or 
 the certificate for authenticating the service account on pod.
 - `app` contains information about the extension app that the bot will use like 
@@ -157,9 +155,9 @@ datafeed service v1 is used.
 retry configuration is defined, the global one will be used.
 
 #### Agent load-balancing configuration
-The `agents` part of the configuration contains the information in order to load balance calls to the agent if wanted.
-The fields `agent` and `agents` must not be defined in the same configuration.
-Fields are:
+The `agent.loadBalancing` part of the configuration contains the information in order to load balance calls to the agent if wanted.
+None of the fields `scheme`, `host`, `port`, `context` should be set if field `loadBalancing` is defined.
+Fields inside `loadBalancing` are:
 - `mode`: mandatory, can be `external`, `roundRobin` or `random`.
 - `stickiness`: optional boolean, default value is true.
 - `nodes`: mandatory and must contain at least one element. List items must have at least `host` field put and can contain the following other fields: `scheme`, `port`, `context`.

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/ApiClientFactory.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/ApiClientFactory.java
@@ -81,7 +81,7 @@ public class ApiClientFactory {
    * @return a new {@link ApiClient} instance.
    */
   public ApiClient getAgentClient() {
-    if (config.getAgents() != null) {
+    if (config.getAgent().getLoadBalancing() != null) {
       return new RegularLoadBalancedApiClient(this.config, this);
     }
     return getRegularAgentClient();
@@ -94,7 +94,7 @@ public class ApiClientFactory {
    * @return a new {@link ApiClient} instance.
    */
   public ApiClient getDatafeedAgentClient() {
-    if (config.getAgents() != null) {
+    if (config.getAgent().getLoadBalancing() != null) {
       return new DatafeedLoadBalancedApiClient(this.config, this);
     }
     return getRegularAgentClient();

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/loadbalancing/LoadBalancedApiClient.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/loadbalancing/LoadBalancedApiClient.java
@@ -34,7 +34,7 @@ public abstract class LoadBalancedApiClient implements ApiClient {
     validateLoadBalancingConfiguration(config);
 
     this.apiClientFactory = apiClientFactory;
-    this.loadBalancingConfig = config.getAgents();
+    this.loadBalancingConfig = config.getAgent().getLoadBalancing();
     this.loadBalancingStrategy = LoadBalancingStrategyFactory.getInstance(config, apiClientFactory);
 
     rotate();
@@ -108,19 +108,19 @@ public abstract class LoadBalancedApiClient implements ApiClient {
   }
 
   private void validateLoadBalancingConfiguration(BdkConfig config) {
-    final BdkLoadBalancingConfig agentLoadBalancing = config.getAgents();
+    final BdkLoadBalancingConfig agentLoadBalancing = config.getAgent().getLoadBalancing();
     if (agentLoadBalancing == null) {
       return;
     }
 
     if (config.getAgent().overridesParentConfig()) {
-      throw new ApiClientInitializationException("Both agent and agents fields are defined");
+      throw new ApiClientInitializationException("Both agent url (scheme, host, port, context) and loadBalancing are defined");
     }
     if (agentLoadBalancing.getMode() == null) {
-      throw new ApiClientInitializationException("Field \"mode\" in agents is mandatory");
+      throw new ApiClientInitializationException("Field \"mode\" in loadBalancing is mandatory");
     }
     if (agentLoadBalancing.getNodes() == null || agentLoadBalancing.getNodes().isEmpty()) {
-      throw new ApiClientInitializationException("Field \"nodes\" in agents is mandatory and must contain at least one element");
+      throw new ApiClientInitializationException("Field \"nodes\" in loadBalancing is mandatory and must contain at least one element");
     }
   }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/loadbalancing/LoadBalancingStrategyFactory.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/loadbalancing/LoadBalancingStrategyFactory.java
@@ -26,9 +26,10 @@ public class LoadBalancingStrategyFactory {
    */
   static LoadBalancingStrategy getInstance(BdkConfig config,
       ApiClientFactory apiClientFactory) {
-    final List<BdkServerConfig> nodes = config.getAgents().getNodes();
+    final BdkLoadBalancingConfig loadBalancing = config.getAgent().getLoadBalancing();
+    final List<BdkServerConfig> nodes = loadBalancing.getNodes();
 
-    switch (config.getAgents().getMode()) {
+    switch (loadBalancing.getMode()) {
       case EXTERNAL:
         final String agentLbBasePath = nodes.get(0).getBasePath();
         final SignalsApi signalsApi = new SignalsApi(apiClientFactory.getRegularAgentClient(agentLbBasePath));

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/legacy/LegacyConfigMapper.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/legacy/LegacyConfigMapper.java
@@ -22,7 +22,7 @@ public class LegacyConfigMapper {
         pod.setPort(legacySymConfig.getPodPort());
         pod.setContext(legacySymConfig.getPodContextPath());
 
-        BdkClientConfig agent = new BdkClientConfig();
+        BdkAgentConfig agent = new BdkAgentConfig();
         agent.setHost(legacySymConfig.getAgentHost());
         agent.setPort(legacySymConfig.getAgentPort());
         agent.setContext(legacySymConfig.getAgentContextPath());

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkAgentConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkAgentConfig.java
@@ -1,0 +1,21 @@
+package com.symphony.bdk.core.config.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apiguardian.api.API;
+
+@Getter
+@Setter
+@API(status = API.Status.STABLE)
+public class BdkAgentConfig extends BdkClientConfig {
+
+  private BdkLoadBalancingConfig loadBalancing;
+
+  public BdkAgentConfig() {
+    super();
+  }
+
+  public BdkAgentConfig(BdkConfig parentConfig) {
+    super(parentConfig);
+  }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkConfig.java
@@ -12,7 +12,7 @@ import org.apiguardian.api.API;
 @API(status = API.Status.STABLE)
 public class BdkConfig extends BdkServerConfig {
 
-  private BdkClientConfig agent = new BdkClientConfig(this);
+  private BdkAgentConfig agent = new BdkAgentConfig(this);
   private BdkClientConfig pod = new BdkClientConfig(this);
   private BdkClientConfig keyManager = new BdkClientConfig(this);
   private BdkClientConfig sessionAuth = new BdkClientConfig(this);
@@ -23,8 +23,6 @@ public class BdkConfig extends BdkServerConfig {
 
   private BdkRetryConfig retry = new BdkRetryConfig();
   private BdkDatafeedConfig datafeed = new BdkDatafeedConfig();
-
-  private BdkLoadBalancingConfig agents;
 
   /**
    * Check if OBO is configured. Checks {@link BdkExtAppConfig#isConfigured()} on field {@link #app}.
@@ -44,7 +42,7 @@ public class BdkConfig extends BdkServerConfig {
     return datafeed.getRetry() == null ? retry : datafeed.getRetry();
   }
 
-  public void setAgent(BdkClientConfig agent) {
+  public void setAgent(BdkAgentConfig agent) {
     this.agent = attachParent(agent);
   }
 
@@ -60,7 +58,7 @@ public class BdkConfig extends BdkServerConfig {
     this.sessionAuth = attachParent(sessionAuth);
   }
 
-  private BdkClientConfig attachParent(BdkClientConfig config) {
+  private <T extends BdkClientConfig> T attachParent(T config) {
     config.setParentConfig(this);
     return config;
   }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/AbstractDatafeedService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/AbstractDatafeedService.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.core.service.datafeed.impl;
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.auth.exception.AuthUnauthorizedException;
 import com.symphony.bdk.core.config.model.BdkConfig;
+import com.symphony.bdk.core.config.model.BdkLoadBalancingConfig;
 import com.symphony.bdk.core.retry.RetryWithRecoveryBuilder;
 import com.symphony.bdk.core.service.datafeed.DatafeedService;
 import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
@@ -43,7 +44,8 @@ abstract class AbstractDatafeedService implements DatafeedService {
         .recoveryStrategy(Exception.class, () -> this.apiClient.rotate())  //always rotate in case of any error
         .recoveryStrategy(ApiException::isUnauthorized, this::refresh);
 
-    if (config.getAgents() != null && !config.getAgents().isStickiness()) {
+    final BdkLoadBalancingConfig loadBalancing = config.getAgent().getLoadBalancing();
+    if (loadBalancing != null && !loadBalancing.isStickiness()) {
       log.warn("DF used with agent load balancing configured with stickiness false. DF calls will still be sticky.");
     }
   }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/client/ApiClientFactoryTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/client/ApiClientFactoryTest.java
@@ -271,7 +271,7 @@ class ApiClientFactoryTest {
 
     final BdkConfig config = new BdkConfig();
     config.setHost("global-host");
-    config.setAgents(loadBalancingConfig);
+    config.getAgent().setLoadBalancing(loadBalancingConfig);
 
     return config;
   }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/client/loadbalancing/DatafeedLoadBalancedApiClientTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/client/loadbalancing/DatafeedLoadBalancedApiClientTest.java
@@ -50,7 +50,7 @@ class DatafeedLoadBalancedApiClientTest {
     agentLoadBalancing.setNodes(Collections.singletonList(serverConfig));
 
     final BdkConfig config = new BdkConfig();
-    config.setAgents(agentLoadBalancing);
+    config.getAgent().setLoadBalancing(agentLoadBalancing);
     return config;
   }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/client/loadbalancing/LoadBalancingStrategyTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/client/loadbalancing/LoadBalancingStrategyTest.java
@@ -146,7 +146,7 @@ public class LoadBalancingStrategyTest {
     loadBalancingConfig.setMode(mode);
 
     BdkConfig config = new BdkConfig();
-    config.setAgents(loadBalancingConfig);
+    config.getAgent().setLoadBalancing(loadBalancingConfig);
 
     return config;
   }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/client/loadbalancing/RegularLoadBalancedApiClientTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/client/loadbalancing/RegularLoadBalancedApiClientTest.java
@@ -65,7 +65,7 @@ class RegularLoadBalancedApiClientTest {
     agentLoadBalancing.setNodes(Collections.singletonList(serverConfig));
 
     final BdkConfig config = new BdkConfig();
-    config.setAgents(agentLoadBalancing);
+    config.getAgent().setLoadBalancing(agentLoadBalancing);
     return config;
   }
 
@@ -75,41 +75,42 @@ class RegularLoadBalancedApiClientTest {
     ApiClientInitializationException exception = assertThrows(ApiClientInitializationException.class,
         () -> new RegularLoadBalancedApiClient(config, apiClientFactory));
 
-    assertEquals("Both agent and agents fields are defined", exception.getMessage());
+    assertEquals("Both agent url (scheme, host, port, context) and loadBalancing are defined",
+        exception.getMessage());
   }
 
   @Test
   public void configWithMissingModeShouldFail() {
-    config.getAgents().setMode(null);
+    config.getAgent().getLoadBalancing().setMode(null);
     ApiClientInitializationException exception = assertThrows(ApiClientInitializationException.class,
         () -> new RegularLoadBalancedApiClient(config, apiClientFactory));
 
-    assertEquals("Field \"mode\" in agents is mandatory", exception.getMessage());
+    assertEquals("Field \"mode\" in loadBalancing is mandatory", exception.getMessage());
   }
 
   @Test
   public void configWithMissingNodesShouldFail() {
-    config.getAgents().setNodes(null);
+    config.getAgent().getLoadBalancing().setNodes(null);
     ApiClientInitializationException exception = assertThrows(ApiClientInitializationException.class,
         () -> new RegularLoadBalancedApiClient(config, apiClientFactory));
 
-    assertEquals("Field \"nodes\" in agents is mandatory and must contain at least one element",
+    assertEquals("Field \"nodes\" in loadBalancing is mandatory and must contain at least one element",
         exception.getMessage());
   }
 
   @Test
   public void configWithEmptyNodesListShouldFail() {
-    config.getAgents().setNodes(Collections.emptyList());
+    config.getAgent().getLoadBalancing().setNodes(Collections.emptyList());
     ApiClientInitializationException exception = assertThrows(ApiClientInitializationException.class,
         () -> new RegularLoadBalancedApiClient(config, apiClientFactory));
 
-    assertEquals("Field \"nodes\" in agents is mandatory and must contain at least one element",
+    assertEquals("Field \"nodes\" in loadBalancing is mandatory and must contain at least one element",
         exception.getMessage());
   }
 
   @Test
   public void testInvokeApiIsDelegatedAndRotateNotCalledWhenSticky() throws ApiException {
-    config.getAgents().setStickiness(true);
+    config.getAgent().getLoadBalancing().setStickiness(true);
     RegularLoadBalancedApiClient loadBalancedApiClient =
         spy(new RegularLoadBalancedApiClient(config, apiClientFactory));
 
@@ -124,7 +125,7 @@ class RegularLoadBalancedApiClientTest {
 
   @Test
   public void testInvokeApiIsDelegatedAndRotateCalledWhenNonSticky() throws ApiException {
-    config.getAgents().setStickiness(false);
+    config.getAgent().getLoadBalancing().setStickiness(false);
     RegularLoadBalancedApiClient loadBalancedApiClient =
         spy(new RegularLoadBalancedApiClient(config, apiClientFactory));
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigLoaderTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigLoaderTest.java
@@ -128,7 +128,7 @@ public class BdkConfigLoaderTest {
   @Test
   public void parseLbAgentField() throws BdkConfigException {
     BdkConfig config = BdkConfigLoader.loadFromClasspath("/config/config_lb.yaml");
-    final BdkLoadBalancingConfig agentLoadBalancing = config.getAgents();
+    final BdkLoadBalancingConfig agentLoadBalancing = config.getAgent().getLoadBalancing();
     final List<BdkServerConfig> nodes = agentLoadBalancing.getNodes();
 
     assertEquals(BdkLoadBalancingMode.RANDOM, agentLoadBalancing.getMode());
@@ -149,13 +149,13 @@ public class BdkConfigLoaderTest {
   @Test
   public void parseLbAgentFieldsWithNoDefinedStickiness() throws BdkConfigException {
     BdkConfig config = BdkConfigLoader.loadFromClasspath("/config/config_lb_no_stickiness.yaml");
-    assertEquals(true, config.getAgents().isStickiness());
+    assertEquals(true, config.getAgent().getLoadBalancing().isStickiness());
   }
 
   @Test
   public void parseLbAgentFieldsWithRoundRobinMode() throws BdkConfigException {
     final BdkConfig config = BdkConfigLoader.loadFromClasspath("/config/config_lb_round_robin.yaml");
-    final BdkLoadBalancingConfig agentLoadBalancing = config.getAgents();
+    final BdkLoadBalancingConfig agentLoadBalancing = config.getAgent().getLoadBalancing();
 
     assertEquals(true, agentLoadBalancing.isStickiness());
     assertEquals(BdkLoadBalancingMode.ROUND_ROBIN, agentLoadBalancing.getMode());
@@ -164,7 +164,7 @@ public class BdkConfigLoaderTest {
   @Test
   public void parseLbAgentFieldsWithExternalMode() throws BdkConfigException {
     final BdkConfig config = BdkConfigLoader.loadFromClasspath("/config/config_lb_external.yaml");
-    final BdkLoadBalancingConfig agentLoadBalancing = config.getAgents();
+    final BdkLoadBalancingConfig agentLoadBalancing = config.getAgent().getLoadBalancing();
 
     assertEquals(BdkLoadBalancingMode.EXTERNAL, agentLoadBalancing.getMode());
   }

--- a/symphony-bdk-core/src/test/resources/config/config_lb.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config_lb.yaml
@@ -1,9 +1,10 @@
-agents:
-  mode: random
-  stickiness: false
-  nodes:
-    - host: agent1.acme.org
-      port: 8443
-      context: /app
-      scheme: http
-    - host: agent2.acme.org
+agent:
+  loadBalancing:
+    mode: random
+    stickiness: false
+    nodes:
+      - host: agent1.acme.org
+        port: 8443
+        context: /app
+        scheme: http
+      - host: agent2.acme.org

--- a/symphony-bdk-core/src/test/resources/config/config_lb_external.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config_lb_external.yaml
@@ -1,5 +1,6 @@
-agents:
-  mode: external
-  stickiness: true
-  nodes:
-    - host: agent1.acme.org
+agent:
+  loadBalancing:
+    mode: external
+    stickiness: true
+    nodes:
+      - host: agent1.acme.org

--- a/symphony-bdk-core/src/test/resources/config/config_lb_invalid_mode.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config_lb_invalid_mode.yaml
@@ -1,4 +1,5 @@
-agents:
-  mode: invalid
-  nodes:
-    - host: agent1.acme.org
+agent:
+  loadBalancing:
+    mode: invalid
+    nodes:
+      - host: agent1.acme.org

--- a/symphony-bdk-core/src/test/resources/config/config_lb_no_stickiness.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config_lb_no_stickiness.yaml
@@ -1,4 +1,5 @@
-agents:
-  mode: random
-  nodes:
-    - host: agent1.acme.org
+agent:
+  loadBalancing:
+    mode: random
+    nodes:
+      - host: agent1.acme.org

--- a/symphony-bdk-core/src/test/resources/config/config_lb_round_robin.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config_lb_round_robin.yaml
@@ -1,5 +1,6 @@
-agents:
-  mode: roundRobin
-  stickiness: true
-  nodes:
-    - host: agent1.acme.org
+agent:
+  loadBalancing:
+    mode: roundRobin
+    stickiness: true
+    nodes:
+      - host: agent1.acme.org

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/SymphonyBdkAutoConfigurationTest.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/SymphonyBdkAutoConfigurationTest.java
@@ -129,8 +129,8 @@ class SymphonyBdkAutoConfigurationTest {
             "bdk.bot.username=testbot",
             "bdk.bot.privateKeyPath=classpath:/privatekey.pem",
 
-            "bdk.agents.mode=roundRobin",
-            "bdk.agents.nodes[0].host=agent-lb"
+            "bdk.agent.loadBalancing.mode=roundRobin",
+            "bdk.agent.loadBalancing.nodes[0].host=agent-lb"
         )
         .withUserConfiguration(SymphonyBdkMockedConfiguration.class)
         .withConfiguration(AutoConfigurations.of(SymphonyBdkAutoConfiguration.class));


### PR DESCRIPTION
### Ticket
[APP-3137](https://perzoinc.atlassian.net/browse/APP-3137)

### Description
Moved configuration field from agents to agent.loadBalancing

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
