### PR TITLE
SDK-166 Java-BDK: Create test coverage for MDCTaskDecorator

### DIFF
--- a/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/test/java/com/symphony/bdk/bot/sdk/commons/MDCTaskDecoratorTest.java
+++ b/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/test/java/com/symphony/bdk/bot/sdk/commons/MDCTaskDecoratorTest.java
@@ -65,19 +65,21 @@ public class MDCTaskDecoratorTest {
 
   private void testResultContextMap(Map<String, String> contextMap) {
     Map<String, String> resultMap;
-    if(contextMap == null)
+    if(contextMap == null) {
       resultMap = null;
-    else
+    } else {
       resultMap = MDC.getCopyOfContextMap();
+    }
 
     assertEquals(resultMap, contextMap);
   }
 
   private void setMDCTaskDecoratorAndContextMap(Map<String, String> contextMap) {
     this.mdcTaskDecorator = new MDCTaskDecorator();
-    if(contextMap == null)
+    if(contextMap == null) {
       MDC.setContextMap(new HashMap<>());
-    else
+    } else {
       MDC.setContextMap(contextMap);
+    }
   }
 }

--- a/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/test/java/com/symphony/bdk/bot/sdk/commons/MDCTaskDecoratorTest.java
+++ b/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/test/java/com/symphony/bdk/bot/sdk/commons/MDCTaskDecoratorTest.java
@@ -1,0 +1,55 @@
+package com.symphony.bdk.bot.sdk.commons;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class MDCTaskDecoratorTest {
+
+  private MDCTaskDecorator mdcTaskDecorator;
+  private Map<String, String> emptyContextMap;
+  private Map<String, String> fullContextMap;
+  private Runnable runnable;
+
+  @Before
+  public void init(){
+    this.emptyContextMap = new HashMap();
+
+    this.fullContextMap = new HashMap();
+    this.fullContextMap.put("key1", "value1");
+    this.fullContextMap.put("key2", "value2");
+    this.fullContextMap.put("key3", "value3");
+
+    this.runnable = () -> {};
+  }
+
+  @Test
+  public void testDecorateWithFullHashMap(){
+    this.setMDCMapAndTest(this.fullContextMap);
+  }
+
+  @Test
+  public void testDecorateWithEmptyHashMap(){
+    this.setMDCMapAndTest(this.emptyContextMap);
+  }
+
+  private void setMDCMapAndTest(Map<String, String> contextMap) {
+    this.setMDCTaskDecoratorAndContextMap(contextMap);
+
+    this.mdcTaskDecorator.decorate(this.runnable);
+
+    final Map<String, String> resultMap = MDC.getCopyOfContextMap();
+
+    assertEquals(resultMap, contextMap);
+  }
+
+  private void setMDCTaskDecoratorAndContextMap(Map<String, String> contextMap) {
+    this.mdcTaskDecorator = new MDCTaskDecorator();
+    MDC.setContextMap(contextMap);
+  }
+}


### PR DESCRIPTION
### Ticket
[166](https://perzoinc.atlassian.net/browse/SDK-166?atlOrigin=eyJpIjoiOTM2ZjlhZjViNjI3NGY4MGI2MWRiZjMxNjYwNGMzYjciLCJwIjoiaiJ9)

### Coverage
![coverage_166](https://user-images.githubusercontent.com/68892288/98532854-8822b180-2282-11eb-865a-879dd9fa63d0.JPG)