### PR TITLE
APP-3113: Throw exception if multiple implementations found in classpath for http-api and template-api

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/util/ServiceLookup.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/util/ServiceLookup.java
@@ -18,19 +18,20 @@ public class ServiceLookup {
    * Load a service implementation class using {@link ServiceLoader}.
    *
    * @return a service implementation class.
+   * @throws IllegalStateException if no implementation or several implementations found in classpath.
    */
   public static <T> T lookupSingleService(Class<T> clz) {
 
     final ServiceLoader<T> classServiceLoader = ServiceLoader.load(clz);
 
     final List<T> services = StreamSupport.stream(classServiceLoader.spliterator(), false)
-            .collect(Collectors.toList());
+        .collect(Collectors.toList());
 
     if (services.isEmpty()) {
       throw new IllegalStateException("No service implementation found in classpath.");
     } else if (services.size() > 1) {
-      log.warn("More than 1 service implementation found in classpath, will use : {}",
-          services.get(0));
+      throw new IllegalStateException("More than 1 service implementation found in classpath for "
+          + clz.getCanonicalName());
     }
 
     return services.get(0);

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/util/ServiceLookup.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/util/ServiceLookup.java
@@ -21,17 +21,18 @@ public class ServiceLookup {
    * @throws IllegalStateException if no implementation or several implementations found in classpath.
    */
   public static <T> T lookupSingleService(Class<T> clz) {
-
     final ServiceLoader<T> classServiceLoader = ServiceLoader.load(clz);
 
     final List<T> services = StreamSupport.stream(classServiceLoader.spliterator(), false)
         .collect(Collectors.toList());
 
     if (services.isEmpty()) {
-      throw new IllegalStateException("No service implementation found in classpath.");
+      throw new IllegalStateException(
+          "No service implementation found in classpath for " + clz.getCanonicalName() + ". "
+              + "Likely cause is a missing dependency to one of the symphony-bdk-http-* (jersey2 or webclient) modules.");
     } else if (services.size() > 1) {
       throw new IllegalStateException("More than 1 service implementation found in classpath for "
-          + clz.getCanonicalName());
+          + clz.getCanonicalName() + ". Try to remove a dependency to one of the symphony-bdk-http-* modules.");
     }
 
     return services.get(0);

--- a/symphony-bdk-template/symphony-bdk-template-api/src/main/java/com/symphony/bdk/template/api/TemplateEngine.java
+++ b/symphony-bdk-template/symphony-bdk-template-api/src/main/java/com/symphony/bdk/template/api/TemplateEngine.java
@@ -24,11 +24,12 @@ public interface TemplateEngine {
 
   /**
    * Create a {@link Template} instance from a file in the classpath
+   *
    * @param templatePath full path to a template file in the classpath
    * @return a new {@link Template} instantiated from the provided classpath resource
    * @throws TemplateException when template cannot be loaded, e.g. resource not accessible
    */
-  Template newTemplateFromClasspath(String templatePath) ;
+  Template newTemplateFromClasspath(String templatePath);
 
   static TemplateEngine getDefaultImplementation() {
     final ServiceLoader<TemplateEngine> engineServiceLoader = ServiceLoader.load(TemplateEngine.class);
@@ -37,9 +38,11 @@ public interface TemplateEngine {
         .collect(Collectors.toList());
 
     if (templateEngines.isEmpty()) {
-      throw new IllegalStateException("No TemplateEngine implementation found in classpath.");
+      throw new IllegalStateException("No TemplateEngine implementation found in classpath. "
+          + "Please add a symphony-bdk-template-* (freemarker or handlebars) dependency to your project.");
     } else if (templateEngines.size() > 1) {
-      throw new IllegalStateException("More than 1 TemplateEngine implementation found in classpath.");
+      throw new IllegalStateException("More than 1 TemplateEngine implementation found in classpath. "
+          + "Please remove the extra symphony-bdk-template-* dependency from your project");
     }
     return templateEngines.stream().findFirst().get();
   }

--- a/symphony-bdk-template/symphony-bdk-template-api/src/main/java/com/symphony/bdk/template/api/TemplateEngine.java
+++ b/symphony-bdk-template/symphony-bdk-template-api/src/main/java/com/symphony/bdk/template/api/TemplateEngine.java
@@ -1,7 +1,6 @@
 package com.symphony.bdk.template.api;
 
 import org.apiguardian.api.API;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.ServiceLoader;
@@ -35,14 +34,12 @@ public interface TemplateEngine {
     final ServiceLoader<TemplateEngine> engineServiceLoader = ServiceLoader.load(TemplateEngine.class);
 
     final List<TemplateEngine> templateEngines = StreamSupport.stream(engineServiceLoader.spliterator(), false)
-            .collect(Collectors.toList());
+        .collect(Collectors.toList());
 
     if (templateEngines.isEmpty()) {
       throw new IllegalStateException("No TemplateEngine implementation found in classpath.");
     } else if (templateEngines.size() > 1) {
-      LoggerFactory.getLogger(TemplateEngine.class)
-          .warn("More than 1 TemplateEngine implementation found in classpath, will use : {}",
-          templateEngines.stream().findFirst().get());
+      throw new IllegalStateException("More than 1 TemplateEngine implementation found in classpath.");
     }
     return templateEngines.stream().findFirst().get();
   }


### PR DESCRIPTION
### Ticket
[APP-3113](https://perzoinc.atlassian.net/browse/APP-3113)

### Description
Instead of a warn log, an exception is thrown in `ServiceLookup.singleService(Class<?>)`.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [ ] Unit tests updated or added
- [x] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
