### PR TITLE
APP-3271: Set SameSite flag equals None to jwtCookies

### DIFF
--- a/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/main/java/com/symphony/bdk/bot/sdk/extapp/authentication/AppAuthController.java
+++ b/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/main/java/com/symphony/bdk/bot/sdk/extapp/authentication/AppAuthController.java
@@ -7,10 +7,13 @@ import com.symphony.bdk.bot.sdk.symphony.exception.SymphonyClientException;
 import com.symphony.bdk.bot.sdk.symphony.model.AuthenticateResponse;
 import com.symphony.bdk.bot.sdk.webapi.security.JwtCookieFilter;
 
+import org.apache.tomcat.util.http.SameSiteCookies;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -98,7 +101,7 @@ public class AppAuthController {
       String jwt = jwtInfo.getJwt();
       Long userId = extAppAuthClient.verifyJWT(jwt);
       if(jwtCookieEnable) {
-        response.addCookie(jwtCookie(jwt, request.getContextPath()));
+        response.addHeader(HttpHeaders.SET_COOKIE, jwtCookie(jwt, request.getContextPath()).toString());
       }
 
       return ResponseEntity.ok(userId);
@@ -108,16 +111,15 @@ public class AppAuthController {
     }
   }
 
-  private Cookie jwtCookie(String jwt, String path) {
-    Cookie jwtCookie = new Cookie(JwtCookieFilter.JWT_COOKIE_NAME, jwt);
+  private ResponseCookie jwtCookie(String jwt, String path) {
 
-    // 1 day
-    jwtCookie.setMaxAge(1 * 24 * 60 * 60);
-    jwtCookie.setSecure(true);
-    jwtCookie.setHttpOnly(true);
-    jwtCookie.setPath(path.concat(configClient.getExtAppAuthPath()));
-
-    return jwtCookie;
+    return ResponseCookie.from(JwtCookieFilter.JWT_COOKIE_NAME, jwt)
+        .maxAge(24 * 60 * 60)
+        .secure(true)
+        .httpOnly(true)
+        .path(path.concat(configClient.getExtAppAuthPath()))
+        .sameSite(SameSiteCookies.NONE.getValue())
+        .build();
   }
 
 }


### PR DESCRIPTION
### Ticket
[APP-3271](https://perzoinc.atlassian.net/browse/APP-3271)

### Description
By default, the SameSite flag will be set automatically to 'Lax' and
will be blocked because it comes from a cross-site response. Setting
it to None to make it available for store in browser cookies.


### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
