### PR TITLE
APP-3280: Fixed event listeners on RealTimeEvent<T> with different param types

### DIFF
--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/events/RealTimeEvent.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/events/RealTimeEvent.java
@@ -7,6 +7,8 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.ResolvableTypeProvider;
 
+import java.util.Objects;
+
 /**
  * Specific {@link ApplicationEvent} used to wrap Real Time Events that are then dispatched by the {@link RealTimeEventsDispatcher}.
  */
@@ -31,5 +33,19 @@ public class RealTimeEvent<T> extends ApplicationEvent implements ResolvableType
   public ResolvableType getResolvableType() {
     return ResolvableType.forClassWithGenerics(getClass(),
         ResolvableType.forInstance(source));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    RealTimeEvent<?> that = (RealTimeEvent<?>) o;
+    return initiator.equals(that.initiator) &&
+        source.equals(that.source);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(initiator, source);
   }
 }

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/events/RealTimeEvent.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/events/RealTimeEvent.java
@@ -4,12 +4,14 @@ import com.symphony.bdk.gen.api.model.V4Initiator;
 
 import lombok.Getter;
 import org.springframework.context.ApplicationEvent;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.ResolvableTypeProvider;
 
 /**
  * Specific {@link ApplicationEvent} used to wrap Real Time Events that are then dispatched by the {@link RealTimeEventsDispatcher}.
  */
 @Getter
-public class RealTimeEvent<T> extends ApplicationEvent {
+public class RealTimeEvent<T> extends ApplicationEvent implements ResolvableTypeProvider {
 
   /** Event initiator, or user that triggered it */
   private final V4Initiator initiator;
@@ -20,5 +22,14 @@ public class RealTimeEvent<T> extends ApplicationEvent {
     super(source);
     this.initiator = initiator;
     this.source = source;
+  }
+
+  /**
+   * Needed in order to be able to discriminate event listeners based on specific source types {@link T}
+   */
+  @Override
+  public ResolvableType getResolvableType() {
+    return ResolvableType.forClassWithGenerics(getClass(),
+        ResolvableType.forInstance(source));
   }
 }

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/events/RealTimeEventListenerTest.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/events/RealTimeEventListenerTest.java
@@ -1,0 +1,172 @@
+package com.symphony.bdk.spring.events;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+
+import com.symphony.bdk.gen.api.model.V4ConnectionAccepted;
+import com.symphony.bdk.gen.api.model.V4Initiator;
+import com.symphony.bdk.gen.api.model.V4InstantMessageCreated;
+import com.symphony.bdk.gen.api.model.V4MessageSent;
+import com.symphony.bdk.gen.api.model.V4MessageSuppressed;
+import com.symphony.bdk.gen.api.model.V4RoomCreated;
+import com.symphony.bdk.gen.api.model.V4RoomDeactivated;
+import com.symphony.bdk.gen.api.model.V4RoomMemberDemotedFromOwner;
+import com.symphony.bdk.gen.api.model.V4RoomMemberPromotedToOwner;
+import com.symphony.bdk.gen.api.model.V4RoomReactivated;
+import com.symphony.bdk.gen.api.model.V4RoomUpdated;
+import com.symphony.bdk.gen.api.model.V4SharedPost;
+import com.symphony.bdk.gen.api.model.V4SymphonyElementsAction;
+import com.symphony.bdk.gen.api.model.V4UserJoinedRoom;
+import com.symphony.bdk.gen.api.model.V4UserLeftRoom;
+import com.symphony.bdk.gen.api.model.V4UserRequestedToJoinRoom;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@SpringBootTest(classes = RealTimeEventsTestListener.class)
+@ExtendWith(SpringExtension.class)
+public class RealTimeEventListenerTest {
+
+  @Autowired
+  private ApplicationEventPublisher publisher;
+
+  @SpyBean
+  private RealTimeEventsTestListener eventListener;
+
+  private RealTimeEventsDispatcher dispatcher;
+
+  private V4Initiator initiator;
+
+  @BeforeEach
+  public void setUp() {
+    dispatcher = new RealTimeEventsDispatcher(publisher);
+    initiator = new V4Initiator();
+  }
+
+  @Test
+  void testOnMessageSent() {
+    final V4MessageSent payload = new V4MessageSent();
+    dispatcher.onMessageSent(initiator, payload);
+
+    verify(eventListener, only()).onMessageSent(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnSharedPost() {
+    final V4SharedPost payload = new V4SharedPost();
+    dispatcher.onSharedPost(initiator, payload);
+
+    verify(eventListener, only()).onSharedPost(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnInstantMessageCreated() {
+    final V4InstantMessageCreated payload = new V4InstantMessageCreated();
+    dispatcher.onInstantMessageCreated(initiator, payload);
+
+    verify(eventListener, only()).onInstantMessageCreated(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnRoomCreated() {
+    final V4RoomCreated payload = new V4RoomCreated();
+    dispatcher.onRoomCreated(initiator, payload);
+
+    verify(eventListener, only()).onRoomCreated(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnRoomUpdated() {
+    final V4RoomUpdated payload = new V4RoomUpdated();
+    dispatcher.onRoomUpdated(initiator, payload);
+
+    verify(eventListener, only()).onRoomUpdated(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnRoomDeactivated() {
+    final V4RoomDeactivated payload = new V4RoomDeactivated();
+
+    dispatcher.onRoomDeactivated(initiator, payload);
+    verify(eventListener, only()).onRoomDeactivated(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnRoomReactivated() {
+    final V4RoomReactivated payload = new V4RoomReactivated();
+    dispatcher.onRoomReactivated(initiator, payload);
+
+    verify(eventListener, only()).onRoomReactivated(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnUserRequestedToJoinRoom() {
+    final V4UserRequestedToJoinRoom payload = new V4UserRequestedToJoinRoom();
+    dispatcher.onUserRequestedToJoinRoom(initiator, payload);
+
+    verify(eventListener, only()).onUserRequestedToJoinRoom(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnUserJoinedRoom() {
+    final V4UserJoinedRoom payload = new V4UserJoinedRoom();
+    dispatcher.onUserJoinedRoom(initiator, payload);
+
+    verify(eventListener, only()).onUserJoinedRoom(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnUserLeftRoom() {
+    final V4UserLeftRoom payload = new V4UserLeftRoom();
+    dispatcher.onUserLeftRoom(initiator, payload);
+
+    verify(eventListener, only()).onUserLeftRoom(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnRoomMemberPromotedToOwner() {
+    final V4RoomMemberPromotedToOwner payload = new V4RoomMemberPromotedToOwner();
+    dispatcher.onRoomMemberPromotedToOwner(initiator, payload);
+
+    verify(eventListener, only()).onRoomMemberPromotedToOwner(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnRoomMemberDemotedFromOwner() {
+    final V4RoomMemberDemotedFromOwner payload = new V4RoomMemberDemotedFromOwner();
+    dispatcher.onRoomMemberDemotedFromOwner(initiator, payload);
+
+    verify(eventListener, only()).onRoomMemberDemotedFromOwner(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnConnectionAccepted() {
+    final V4ConnectionAccepted payload = new V4ConnectionAccepted();
+    dispatcher.onConnectionAccepted(initiator, payload);
+
+    verify(eventListener, only()).onConnectionAccepted(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnMessageSuppressed() {
+    final V4MessageSuppressed payload = new V4MessageSuppressed();
+    dispatcher.onMessageSuppressed(initiator, payload);
+
+    verify(eventListener, only()).onMessageSuppressed(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+
+  @Test
+  void testOnSymphonyElementsAction() {
+    final V4SymphonyElementsAction payload = new V4SymphonyElementsAction();
+    dispatcher.onSymphonyElementsAction(initiator, payload);
+
+    verify(eventListener, only()).onSymphonyElementsAction(eq(new RealTimeEvent<>(initiator, payload)));
+  }
+}

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/events/RealTimeEventsDispatcherTest.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/events/RealTimeEventsDispatcherTest.java
@@ -1,6 +1,5 @@
 package com.symphony.bdk.spring.events;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
@@ -233,15 +232,6 @@ class RealTimeEventsDispatcherTest {
 
     verify(this.listener, only()).onSymphonyElementsAction(eq(initiator), eq(payload));
     verify(this.listener, times(1)).onSymphonyElementsAction(eq(initiator), eq(payload));
-  }
-
-  @Test
-  void realTimeEvent() {
-    final V4Initiator initiator = createInitiator();
-    final RealTimeEvent<Integer> integerRealTimeEvent = new RealTimeEvent<>(initiator, new Integer(3));
-
-    assertEquals(initiator, integerRealTimeEvent.getInitiator());
-    assertEquals(Integer.class, integerRealTimeEvent.getResolvableType().getGeneric(0).getRawClass());
   }
 
   private static V4Initiator createInitiator() {

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/events/RealTimeEventsDispatcherTest.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/events/RealTimeEventsDispatcherTest.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.spring.events;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
@@ -232,6 +233,15 @@ class RealTimeEventsDispatcherTest {
 
     verify(this.listener, only()).onSymphonyElementsAction(eq(initiator), eq(payload));
     verify(this.listener, times(1)).onSymphonyElementsAction(eq(initiator), eq(payload));
+  }
+
+  @Test
+  void realTimeEvent() {
+    final V4Initiator initiator = createInitiator();
+    final RealTimeEvent<Integer> integerRealTimeEvent = new RealTimeEvent<>(initiator, new Integer(3));
+
+    assertEquals(initiator, integerRealTimeEvent.getInitiator());
+    assertEquals(Integer.class, integerRealTimeEvent.getResolvableType().getGeneric(0).getRawClass());
   }
 
   private static V4Initiator createInitiator() {


### PR DESCRIPTION
### Ticket
[APP-3280](https://perzoinc.atlassian.net/browse/APP-3280)

### Description
Spring was not differentiating between an @EventListener on RealTimeEvent<T> and RealTimeEvent<U>.
RealTimeEvent now implements ResolvableTypeProvider, based on example https://github.com/altfatterz/application-events-with-spring/blob/master/src/main/java/com/zoltanaltfatter/events/generics/GenericEventsExample.java
Tested locally on devx3.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [ ] Unit tests updated or added
- [x] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
