### PR TITLE
APP-3138: Data Limit Exceed validate before sending message

### DIFF
--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -63,6 +63,8 @@ dependencies {
 
         api 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
 
+        api 'org.symphonyoss.symphony:messageml:0.9.58'
+
         api 'org.freemarker:freemarker:2.3.30'
         api 'org.reflections:reflections:0.9.12'
 

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'io.swagger:swagger-annotations'
     implementation 'com.google.code.findbugs:jsr305'
     implementation 'org.glassfish.jersey.core:jersey-client'
+    implementation 'org.symphonyoss.symphony:messageml'
 
     testImplementation project(':symphony-bdk-http:symphony-bdk-http-jersey2')
     testRuntimeOnly project(':symphony-bdk-template:symphony-bdk-template-freemarker')

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/ServiceFactory.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/ServiceFactory.java
@@ -17,6 +17,7 @@ import com.symphony.bdk.core.service.presence.PresenceService;
 import com.symphony.bdk.core.service.signal.SignalService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
+import com.symphony.bdk.core.util.MessageMLValidator;
 import com.symphony.bdk.gen.api.AppEntitlementApi;
 import com.symphony.bdk.gen.api.ApplicationApi;
 import com.symphony.bdk.gen.api.AttachmentsApi;
@@ -133,6 +134,7 @@ class ServiceFactory {
         new DefaultApi(this.podClient),
         this.authSession,
         this.templateEngine,
+        new MessageMLValidator(this.getUserService()),
         this.retryBuilder
     );
   }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
@@ -12,6 +12,7 @@ import com.symphony.bdk.core.service.message.model.Message;
 import com.symphony.bdk.core.service.pagination.PaginatedApi;
 import com.symphony.bdk.core.service.pagination.PaginatedService;
 import com.symphony.bdk.core.service.stream.constant.AttachmentSort;
+import com.symphony.bdk.core.util.MessageMLValidator;
 import com.symphony.bdk.core.util.function.SupplierWithApiException;
 import com.symphony.bdk.gen.api.AttachmentsApi;
 import com.symphony.bdk.gen.api.DefaultApi;
@@ -69,6 +70,7 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
   private final DefaultApi defaultApi;
   private final AuthSession authSession;
   private final TemplateEngine templateEngine;
+  private final MessageMLValidator messageMLValidator;
   private final RetryWithRecoveryBuilder<?> retryBuilder;
 
   public MessageService(
@@ -81,6 +83,7 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
       final DefaultApi defaultApi,
       final AuthSession authSession,
       final TemplateEngine templateEngine,
+      final MessageMLValidator messageMLValidator,
       final RetryWithRecoveryBuilder<?> retryBuilder
   ) {
     this.messagesApi = messagesApi;
@@ -92,13 +95,14 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
     this.authSession = authSession;
     this.templateEngine = templateEngine;
     this.defaultApi = defaultApi;
+    this.messageMLValidator = messageMLValidator;
     this.retryBuilder = retryBuilder;
   }
 
   @Override
   public OboMessageService obo(AuthSession oboSession) {
     return new MessageService(messagesApi, messageApi, messageSuppressionApi, streamsApi, podApi, attachmentsApi,
-        defaultApi, oboSession, templateEngine, retryBuilder);
+        defaultApi, oboSession, templateEngine, messageMLValidator, retryBuilder);
   }
 
   /**
@@ -241,6 +245,8 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
   }
 
   private Map<String, Object> getForm(Message message) {
+    this.messageMLValidator.dataExceededValidate(message);
+    
     final Map<String, Object> form = new HashMap<>();
     form.put("message", message.getContent());
     form.put("data", message.getData());

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/exception/MessageValidationException.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/exception/MessageValidationException.java
@@ -1,0 +1,18 @@
+package com.symphony.bdk.core.service.message.exception;
+
+import org.apiguardian.api.API;
+
+/**
+ * Exception thrown when a {@link com.symphony.bdk.core.service.message.model.Message} is failed to validate.
+ */
+@API(status = API.Status.STABLE)
+public class MessageValidationException extends RuntimeException {
+
+  public MessageValidationException(String message) {
+    super(message);
+  }
+
+  public MessageValidationException(String message, Exception e) {
+    super(message, e);
+  }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/user/UserService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/user/UserService.java
@@ -199,6 +199,27 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   }
 
   /**
+   * Get user information.
+   * Only one of these attributes: userId, email or username should be specified.
+   * Otherwise, a 400 Bad Request will be returned by pod server.
+   *
+   * @param userId    User Id.
+   * @param email     Email address of the user.
+   * @param username  Username of the user.
+   * @param local     If true then a local DB search will be performed and only local pod users will be
+   *                  returned. If absent or false then a directory search will be performed and users
+   *                  from other pods who are visible to the calling user will also be returned.
+   *                  Note: for username search, the local flag must be true
+   * @return  The information of the user.
+   */
+  @API(status = API.Status.INTERNAL)
+  public UserV2 getUser(@Nullable Long userId, @Nullable String email, @Nullable String username,
+      @Nullable Boolean local) {
+    return executeAndRetry("getUser",
+        () -> usersApi.v2UserGet(authSession.getSessionToken(), userId, email, username, local));
+  }
+
+  /**
    * {@inheritDoc}
    */
   @Override
@@ -226,7 +247,8 @@ public class UserService implements OboUserService, OboService<OboUserService> {
    * @see <a href="https://developers.symphony.com/restapi/reference#get-user-v2">Get User v2</a>
    */
   public V2UserDetail getUserDetailByUid(@Nonnull Long userId) {
-    return executeAndRetry("getUserDetailByUid", () -> userApi.v2AdminUserUidGet(authSession.getSessionToken(), userId));
+    return executeAndRetry("getUserDetailByUid",
+        () -> userApi.v2AdminUserUidGet(authSession.getSessionToken(), userId));
   }
 
   /**
@@ -347,7 +369,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Add a role to an user.
    *
-   * @param userId    User Id
+   * @param userId User Id
    * @param roleId Role Id
    * @see <a href="https://developers.symphony.com/restapi/reference#add-role">Add Role</a>
    */
@@ -360,7 +382,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Remove a role from an user.
    *
-   * @param userId    User Id
+   * @param userId User Id
    * @param roleId Role Id
    * @see <a href="https://developers.symphony.com/restapi/reference#remove-role">Remove Role</a>
    */
@@ -385,8 +407,8 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Update avatar of an user
    *
-   * @param userId   User Id
-   * @param image The avatar image for the user profile picture.The image must be a base64-encoded.
+   * @param userId User Id
+   * @param image  The avatar image for the user profile picture.The image must be a base64-encoded.
    * @see <a href="https://developers.symphony.com/restapi/reference#update-user-avatar">Update User Avatar</a>
    */
   public void updateAvatarOfUser(@Nonnull Long userId, @Nonnull String image) {
@@ -398,8 +420,8 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Update avatar of an user
    *
-   * @param userId   User Id
-   * @param image The avatar image in bytes array for the user profile picture.
+   * @param userId User Id
+   * @param image  The avatar image in bytes array for the user profile picture.
    * @see <a href="https://developers.symphony.com/restapi/reference#update-user-avatar">Update User Avatar</a>
    */
   public void updateAvatarOfUser(@Nonnull Long userId, @Nonnull byte[] image) {
@@ -410,7 +432,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Update avatar of an user
    *
-   * @param userId         User Id
+   * @param userId      User Id
    * @param imageStream The avatar image input stream for the user profile picture.
    * @see <a href="https://developers.symphony.com/restapi/reference#update-user-avatar">Update User Avatar</a>
    */
@@ -445,7 +467,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Assign disclaimer to an user.
    *
-   * @param userId          User Id
+   * @param userId       User Id
    * @param disclaimerId Disclaimer to be assigned
    * @see <a href="https://developers.symphony.com/restapi/reference#update-disclaimer">Update User Disclaimer</a>
    */
@@ -471,7 +493,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Update delegates assigned to an user.
    *
-   * @param userId             User Id
+   * @param userId          User Id
    * @param delegatedUserId Delegated user Id to be assigned
    * @param actionEnum      Action to be performed
    * @see <a href="https://developers.symphony.com/restapi/reference#update-delegates">Update User Delegates</a>
@@ -498,7 +520,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Update feature entitlements of an user.
    *
-   * @param userId      User Id
+   * @param userId   User Id
    * @param features List of feature entitlements to be updated
    * @see <a href="https://developers.symphony.com/restapi/reference#update-features">Update User Features</a>
    */
@@ -522,7 +544,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Update the status of an user
    *
-   * @param userId    User Id
+   * @param userId User Id
    * @param status Status to be updated to the user
    * @see <a href="https://developers.symphony.com/restapi/reference#update-user-status">Update User Status</a>
    */
@@ -534,7 +556,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Returns the list of followers of a specific user.
    *
-   * @param userId   User Id
+   * @param userId User Id
    * @return The list of followers of a specific user with the pagination information.
    * @see <a href="https://developers.symphony.com/restapi/v20.9/reference#list-user-followers">List User Followers</a>
    */
@@ -546,8 +568,8 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Returns the list of followers of a specific user.
    *
-   * @param userId         User Id
-   * @param pagination  The range and limit for pagination.
+   * @param userId     User Id
+   * @param pagination The range and limit for pagination.
    * @return The list of followers of a specific user with the pagination information.
    * @see <a href="https://developers.symphony.com/restapi/v20.9/reference#list-user-followers">List User Followers</a>
    */
@@ -560,7 +582,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Returns the {@link Stream} of followers of a specific user.
    *
-   * @param userId         User Id
+   * @param userId User Id
    * @return The {@link Stream} of followers of a specific user.
    * @see <a href="https://developers.symphony.com/restapi/v20.9/reference#list-user-followers">List User Followers</a>
    */
@@ -575,8 +597,8 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Returns the {@link Stream} of followers of a specific user.
    *
-   * @param userId         User Id
-   * @param pagination  The chunkSize and totalSize for pagination with default value equals 100.
+   * @param userId     User Id
+   * @param pagination The chunkSize and totalSize for pagination with default value equals 100.
    * @return The {@link Stream} of followers of a specific user.
    * @see <a href="https://developers.symphony.com/restapi/v20.9/reference#list-user-followers">List User Followers</a>
    */
@@ -590,7 +612,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Returns the list of users followed by a specific user.
    *
-   * @param userId   User Id
+   * @param userId User Id
    * @return The list of users followed by a specific user with the pagination information.
    * @see <a href="https://developers.symphony.com/restapi/v20.9/reference#list-user-followers">List User Followers</a>
    */
@@ -602,8 +624,8 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Returns the list of users followed by a specific user.
    *
-   * @param userId         User Id
-   * @param pagination  The range and limit for pagination.
+   * @param userId     User Id
+   * @param pagination The range and limit for pagination.
    * @return The list of users followed by a specific user with the pagination information.
    * @see <a href="https://developers.symphony.com/restapi/v20.9/reference#list-users-followed">List Users Followed</a>
    */
@@ -616,7 +638,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Returns a {@link Stream} of users followed by a specific user.
    *
-   * @param userId   User Id
+   * @param userId User Id
    * @return a {@link Stream} of users followed by a specific user with the pagination information.
    * @see <a href="https://developers.symphony.com/restapi/v20.9/reference#list-user-followers">List User Followers</a>
    */
@@ -631,8 +653,8 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   /**
    * Returns a {@link Stream} of users followed by a specific user.
    *
-   * @param userId         User Id
-   * @param pagination  The chunkSize and totalSize for pagination with default value equals 100.
+   * @param userId     User Id
+   * @param pagination The chunkSize and totalSize for pagination with default value equals 100.
    * @return a {@link Stream} of users followed by a specific user with the pagination information.
    * @see <a href="https://developers.symphony.com/restapi/v20.9/reference#list-user-followers">List User Followers</a>
    */

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/util/DataProvider.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/util/DataProvider.java
@@ -1,0 +1,70 @@
+package com.symphony.bdk.core.util;
+
+import com.symphony.bdk.core.service.user.UserService;
+import com.symphony.bdk.gen.api.model.UserV2;
+
+import com.google.common.collect.ImmutableSet;
+import org.apiguardian.api.API;
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.util.IDataProvider;
+import org.symphonyoss.symphony.messageml.util.IUserPresentation;
+
+import java.net.URI;
+import java.util.Set;
+
+/**
+ * Implementation of {@link IDataProvider} being used by {@link MessageMLValidator}.
+ */
+@API(status = API.Status.INTERNAL)
+public class DataProvider implements IDataProvider {
+
+  private static final Set<String> STANDARD_URI_SCHEMES = ImmutableSet.of("http", "https");
+  private final UserService userService;
+
+  public DataProvider(UserService userService) {
+    this.userService = userService;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public IUserPresentation getUserPresentation(String email) throws InvalidInputException {
+    UserV2 user = this.userService.getUser(null, email, null, true);
+    if (user == null) {
+      user = this.userService.getUser(null, email, null, false);
+    }
+    if (user == null) {
+      throw new InvalidInputException("Failed to lookup user \"" + email + "\"");
+    }
+
+    return new UserPresentation(user.getId(), user.getDisplayName(), user.getDisplayName(), user.getEmailAddress());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public IUserPresentation getUserPresentation(Long uid) throws InvalidInputException {
+    UserV2 user = this.userService.getUser(uid, null, null, true);
+    if (user == null) {
+      user = this.userService.getUser(uid, null, null, false);
+    }
+    if (user == null) {
+      throw new InvalidInputException("Failed to lookup user \"" + uid + "\"");
+    }
+
+    return new UserPresentation(user.getId(), user.getDisplayName(), user.getDisplayName(), user.getEmailAddress());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void validateURI(URI uri) throws InvalidInputException {
+    if (!STANDARD_URI_SCHEMES.contains(uri.getScheme().toLowerCase())) {
+      throw new InvalidInputException(
+          "URI scheme \"" + uri.getScheme() + "\" is not supported by the pod.");
+    }
+  }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/util/MessageMLValidator.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/util/MessageMLValidator.java
@@ -1,0 +1,60 @@
+package com.symphony.bdk.core.util;
+
+import com.symphony.bdk.core.service.message.exception.MessageValidationException;
+import com.symphony.bdk.core.service.message.model.Message;
+import com.symphony.bdk.core.service.user.UserService;
+
+import org.apiguardian.api.API;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * The validator being used to validate the length of the message ML markdown text.
+ */
+@API(status = API.Status.INTERNAL)
+public class MessageMLValidator {
+
+  private static final int MARKDOWN_TEXT_LIMIT_LENGTH = 60785;
+
+  private final MessageMLContext context;
+
+  public MessageMLValidator(UserService userService) {
+    DataProvider dataProvider = new DataProvider(userService);
+    this.context = new MessageMLContext(dataProvider);
+  }
+
+  /**
+   * Validate the length of the markdown text extracted from the message.
+   *
+   * @param message message to be validated.
+   * @throws InvalidInputException thrown on invalid MessageMLV2 input
+   * @throws ProcessingException thrown on errors generating the document tree
+   * @throws IOException thrown on invalid EntityJSON input
+   */
+  public void dataExceededValidate(Message message) {
+    String markdownText;
+    try {
+      markdownText = this.extractMarkdownTextFromMessageML(message);
+    } catch (InvalidInputException | IOException | ProcessingException e) {
+      throw new MessageValidationException("Couldn't extract the markdown text length of the message to verify.", e);
+    }
+
+
+    // apply UTF-8 encoding to the resulting markdown into array of bytes
+    byte[] messageBytes = markdownText.getBytes(StandardCharsets.UTF_8);
+
+    if (messageBytes.length > MARKDOWN_TEXT_LIMIT_LENGTH) {
+      throw new MessageValidationException("The length of the markdown text of the message is exceeded.");
+    }
+  }
+
+  private String extractMarkdownTextFromMessageML(Message message)
+      throws InvalidInputException, IOException, ProcessingException {
+    this.context.parseMessageML(message.getContent(), message.getData(), message.getVersion());
+    return this.context.getMarkdown();
+  }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/util/UserPresentation.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/util/UserPresentation.java
@@ -1,0 +1,38 @@
+package com.symphony.bdk.core.util;
+
+import lombok.AllArgsConstructor;
+import org.apiguardian.api.API;
+import org.symphonyoss.symphony.messageml.util.IUserPresentation;
+
+/**
+ * Implementation of {@link IUserPresentation} using by {@link DataProvider}.
+ */
+@AllArgsConstructor
+@API(status = API.Status.INTERNAL)
+public class UserPresentation implements IUserPresentation {
+
+  private final Long uid;
+  private final String screenName;
+  private final String prettyName;
+  private final String email;
+
+  @Override
+  public long getId() {
+    return this.uid;
+  }
+
+  @Override
+  public String getScreenName() {
+    return this.screenName;
+  }
+
+  @Override
+  public String getPrettyName() {
+    return this.prettyName;
+  }
+
+  @Override
+  public String getEmail() {
+    return this.email;
+  }
+}

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
@@ -23,6 +23,7 @@ import com.symphony.bdk.core.test.BdkMockServer;
 import com.symphony.bdk.core.test.BdkMockServerExtension;
 import com.symphony.bdk.core.test.JsonHelper;
 import com.symphony.bdk.core.test.MockApiClient;
+import com.symphony.bdk.core.util.MessageMLValidator;
 import com.symphony.bdk.gen.api.AttachmentsApi;
 import com.symphony.bdk.gen.api.DefaultApi;
 import com.symphony.bdk.gen.api.MessageApi;
@@ -94,6 +95,7 @@ public class MessageServiceTest {
   private StreamsApi streamsApi;
   private AttachmentsApi attachmentsApi;
   private TemplateEngine templateEngine;
+  private MessageMLValidator validator;
   private AuthSession authSession;
 
   @BeforeEach
@@ -109,10 +111,11 @@ public class MessageServiceTest {
     templateEngine = mock(TemplateEngine.class);
     streamsApi = spy(new StreamsApi(podClient));
     attachmentsApi = spy(new AttachmentsApi(agentClient));
+    validator = mock(MessageMLValidator.class);
 
     messageService = new MessageService(new MessagesApi(agentClient), new MessageApi(podClient),
         new MessageSuppressionApi(podClient), streamsApi, new PodApi(podClient),
-        attachmentsApi, new DefaultApi(podClient), authSession, templateEngine, new RetryWithRecoveryBuilder());
+        attachmentsApi, new DefaultApi(podClient), authSession, templateEngine, validator, new RetryWithRecoveryBuilder());
   }
 
   @Test
@@ -478,7 +481,7 @@ public class MessageServiceTest {
 
     ApiClient agentClient = spy(mockServer.newApiClient("/agent"));
     messageService = new MessageService(new MessagesApi(agentClient), null, null, null, null, null, null, authSession,
-        templateEngine, new RetryWithRecoveryBuilder());
+        templateEngine, validator, new RetryWithRecoveryBuilder());
 
     final String response = JsonHelper.readFromClasspath("/message/blast_message.json");
     mockServer.onPost(V4_BLAST_MESSAGE, res -> res.withBody(response));
@@ -536,7 +539,7 @@ public class MessageServiceTest {
       throws IOException, ApiException {
     ApiClient agentClient = spy(mockServer.newApiClient("/agent"));
     messageService = new MessageService(new MessagesApi(agentClient), null, null, null, null, null, null, authSession,
-        templateEngine, new RetryWithRecoveryBuilder());
+        templateEngine, validator, new RetryWithRecoveryBuilder());
 
     final String response = JsonHelper.readFromClasspath("/message/send_message.json");
     mockServer.onPost("/agent/v4/stream/streamid/message/create", res -> res.withBody(response));

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkServiceConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkServiceConfig.java
@@ -12,6 +12,7 @@ import com.symphony.bdk.core.service.session.SessionService;
 import com.symphony.bdk.core.service.signal.SignalService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
+import com.symphony.bdk.core.util.MessageMLValidator;
 import com.symphony.bdk.gen.api.AppEntitlementApi;
 import com.symphony.bdk.gen.api.ApplicationApi;
 import com.symphony.bdk.gen.api.AttachmentsApi;
@@ -115,10 +116,11 @@ public class BdkServiceConfig {
       final DefaultApi defaultApi,
       final AuthSession botSession,
       final TemplateEngine templateEngine,
+      final UserService userService,
       final BdkConfig config
   ) {
     return new MessageService(messagesApi, messageApi, messageSuppressionApi, streamsApi, podApi, attachmentsApi,
-        defaultApi, botSession, templateEngine, getRetryBuilder(config, botSession));
+        defaultApi, botSession, templateEngine, new MessageMLValidator(userService), getRetryBuilder(config, botSession));
   }
 
   private RetryWithRecoveryBuilder getRetryBuilder(BdkConfig config, AuthSession botSession) {


### PR DESCRIPTION
### Ticket
[APP-3138](https://perzoinc.atlassian.net/browse/APP-3138)

### Description
Data Limit Exceed validate before sending message.

MessageMLValidator to validate the length of the plain text extracted from the messageML.

If the MessageML cannot be parsed by messageml-util, an MessageValidationException will be thrown.

If the plain text extracted from MessageML has the length greater than 81172, an MessageValidationException will be thrown due to the Data Limit exceeded.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [ ] Unit tests updated or added
- [x] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
