### PR TITLE
APP-3296 Make BDK CI steps more accurate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run:
           name: Build
           # Jacoco does not support incremental build so we don't run it automatically with check
-          command: ./gradlew build jacocoTestReport jacocoTestCoverageVerification && ./gradlew -p symphony-bdk-legacy build jacocoTestReport jacocoTestCoverageVerification
+          command: ./gradlew build jacocoTestReport jacocoTestCoverageVerification
 
       - run:
           name: Build Legacy


### PR DESCRIPTION
### Ticket
[APP-3296](https://perzoinc.atlassian.net/browse/APP-3296)

### Description
The build-legacy is currently running in the regular build step, and it looks like it was not the intent.

![Screenshot 2020-11-23 at 10 12 17](https://user-images.githubusercontent.com/6943949/99945862-b5d52380-2d75-11eb-8af0-84db18afba49.png)



### Dependencies

### Checklist
- [X] Referenced a ticket in the PR title and in the corresponding section
- [X] Filled properly the description and dependencies, if any
- [X] Unit tests updated or added
- [X] Javadoc added or updated
- [X] Updated the documentation in [docs folder](../docs)
