### PR TITLE
APP-3203: Optional start of DF loop in spring boot starter

### DIFF
--- a/docs/spring-boot/core-starter.md
+++ b/docs/spring-boot/core-starter.md
@@ -213,6 +213,14 @@ public class CoreServices {
 }
 ```
 
+Unlike subscribing to real time events, using slash commands or activities, solely injecting services does not require
+the datafeed loop to run. If you want to disable the datafeed loop, you can update your `application.yaml` file as follows:
+```yaml
+bdk:
+    datafeed:
+        enabled: false
+```
+
 ## Slash Command
 You can easily register a slash command using the `@Slash` annotation. Note that the `CommandContext` is mandatory to 
 successfully register your command. If not defined, a `warn` message will appear in your application log. Note also that 

--- a/docs/spring-boot/core-starter.md
+++ b/docs/spring-boot/core-starter.md
@@ -221,6 +221,8 @@ bdk:
         enabled: false
 ```
 
+:warning: Disabling the datafeed loop will prevent the use of real time event listeners, of slash commands and activities.
+
 ## Slash Command
 You can easily register a slash command using the `@Slash` annotation. Note that the `CommandContext` is mandatory to 
 successfully register your command. If not defined, a `warn` message will appear in your application log. Note also that 

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkDatafeedConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkDatafeedConfig.java
@@ -13,6 +13,7 @@ import com.symphony.bdk.spring.events.RealTimeEventsDispatcher;
 import com.symphony.bdk.spring.service.DatafeedAsyncLauncherService;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.event.ApplicationEventMulticaster;
@@ -24,6 +25,7 @@ import java.util.List;
 /**
  * Injection of the {@link DatafeedService} instance into the Spring application context.
  */
+@ConditionalOnProperty(value = "bdk.datafeed.enabled", havingValue = "true", matchIfMissing = true)
 public class BdkDatafeedConfig {
 
   @Bean

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/SymphonyBdkAutoConfigurationTest.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/SymphonyBdkAutoConfigurationTest.java
@@ -143,4 +143,31 @@ class SymphonyBdkAutoConfigurationTest {
       assertThat(config.getAgent().getBasePath()).isEqualTo("http://localhost:443/context");
     });
   }
+
+  @Test
+  void shouldNotInitializeDatafeedIfDisabled() {
+    final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withPropertyValues(
+            "bdk.host=localhost",
+
+            "bdk.bot.username=testbot",
+            "bdk.bot.privateKeyPath=classpath:/privatekey.pem",
+
+            "bdk.datafeed.enabled=false"
+        )
+        .withUserConfiguration(SymphonyBdkMockedConfiguration.class)
+        .withConfiguration(AutoConfigurations.of(SymphonyBdkAutoConfiguration.class));
+
+    contextRunner.run(context -> {
+      assertThat(context).hasSingleBean(SymphonyBdkAutoConfiguration.class);
+
+      final SymphonyBdkCoreProperties config = context.getBean(SymphonyBdkCoreProperties.class);
+      assertThat(config.getAgent().getBasePath()).isEqualTo("https://localhost:443");
+
+      assertThat(context).doesNotHaveBean("datafeedService");
+      assertThat(context).doesNotHaveBean("datafeedAsyncLauncherService");
+      assertThat(context).doesNotHaveBean("activityRegistry");
+      assertThat(context).doesNotHaveBean("slashAnnotationProcessor");
+    });
+  }
 }

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/SymphonyBdkAutoConfigurationTest.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/SymphonyBdkAutoConfigurationTest.java
@@ -2,9 +2,12 @@ package com.symphony.bdk.spring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.symphony.bdk.core.activity.ActivityRegistry;
 import com.symphony.bdk.core.auth.OboAuthenticator;
 import com.symphony.bdk.core.auth.exception.AuthInitializationException;
 import com.symphony.bdk.core.client.loadbalancing.DatafeedLoadBalancedApiClient;
+import com.symphony.bdk.core.service.datafeed.DatafeedService;
+import com.symphony.bdk.spring.annotation.SlashAnnotationProcessor;
 import com.symphony.bdk.spring.service.DatafeedAsyncLauncherService;
 
 import org.junit.jupiter.api.Test;
@@ -164,10 +167,10 @@ class SymphonyBdkAutoConfigurationTest {
       final SymphonyBdkCoreProperties config = context.getBean(SymphonyBdkCoreProperties.class);
       assertThat(config.getAgent().getBasePath()).isEqualTo("https://localhost:443");
 
-      assertThat(context).doesNotHaveBean("datafeedService");
-      assertThat(context).doesNotHaveBean("datafeedAsyncLauncherService");
-      assertThat(context).doesNotHaveBean("activityRegistry");
-      assertThat(context).doesNotHaveBean("slashAnnotationProcessor");
+      assertThat(context).doesNotHaveBean(DatafeedService.class);
+      assertThat(context).doesNotHaveBean(DatafeedAsyncLauncherService.class);
+      assertThat(context).doesNotHaveBean(ActivityRegistry.class);
+      assertThat(context).doesNotHaveBean(SlashAnnotationProcessor.class);
     });
   }
 }


### PR DESCRIPTION
### Ticket
[APP-3203](https://perzoinc.atlassian.net/browse/APP-3203)

### Description
Made the start of the datafeed loop optional. Enabled by default, can be disabled with property `bdk.datafeed.enabled = false`
FYI In the legacy BDK (see #302) choice was to have property `datafeed.polling.disabled=true` in order to disable the DF loop. I made the choice (can subject to comments and changes) to remove the intermediary `polling` object and put `enabled` instead of `disabled` to avoid using a "negative" property name.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
