### PR TITLE
APP-3125 Forwarded X-Trace-Id to every API call

### DIFF
--- a/docs/spring-boot/app-starter.md
+++ b/docs/spring-boot/app-starter.md
@@ -97,7 +97,10 @@ bdk-app:
         allowed-method: ["POST", "GET"] # list of HTTP methods to allow
         allowed-headers: "*" # list of headers that a request can list as allowed (multiple values allowed by using ["header-name-1", "header-name-2"])
         exposed-headers: ["header-name-1", "header-name-2"] # list of response headers that a response can have and can be exposed, the value "*" is not allowed for this field.
-
+    tracing:
+        enabled: true # activate the tracing filter
+        urlPatterns:  # Add URL patterns that the tracing filter will be registered against
+          - /api/*
 logging:
   level:
     com.symphony: debug # in development mode, it is strongly recommended to set the BDK logging level at DEBUG

--- a/docs/tech/production-readiness.md
+++ b/docs/tech/production-readiness.md
@@ -1,0 +1,49 @@
+# Production Readiness
+Production readiness documentation for BDK-based applications.
+
+## Logging
+The Symphony BDK setup your logger [MDC](http://logback.qos.ch/manual/mdc.html) (Mapped Diagnostic Context) with a value
+called `X-Trace-Id` (random alphanumeric value of 6 characters). This value is send as header of every request made to
+the Symphony API. This is especially useful for cross-applications debugging, assuming that the `X-Trace-Id` value is 
+also present in your application logs.
+
+As you are obviously free to use your preferred logging technology, the next sections will help you to print the 
+`X-Trace-Id` using either [logback](http://logback.qos.ch/) or [Log4j2](https://logging.apache.org/log4j/2.x/).
+
+### Logback
+For [logback](http://logback.qos.ch/), you will print the `X-Trace-Id` value by adding `%X{X-Trace-Id}` to your log pattern:
+```xml
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %X{X-Trace-Id} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>
+```
+
+### Log4j2
+For [Log4j2](https://logging.apache.org/log4j/2.x/), you will print the `X-Trace-Id` value by adding `%X{X-Trace-Id}` to 
+your log pattern:
+```xml
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %X{X-Trace-Id} %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>
+```
+
+----
+[Home :house:](../index.md)

--- a/symphony-bdk-examples/bdk-app-spring-boot-example/src/main/java/com/symphony/bdk/examples/app/spring/HelloController.java
+++ b/symphony-bdk-examples/bdk-app-spring-boot-example/src/main/java/com/symphony/bdk/examples/app/spring/HelloController.java
@@ -1,0 +1,37 @@
+package com.symphony.bdk.examples.app.spring;
+
+import com.symphony.bdk.core.service.stream.StreamService;
+import com.symphony.bdk.gen.api.model.StreamAttributes;
+import com.symphony.bdk.gen.api.model.StreamFilter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/hello")
+public class HelloController {
+
+  private static final Logger log = LoggerFactory.getLogger(HelloController.class);
+
+  private final StreamService streamService;
+
+  public HelloController(StreamService streamService) {
+    this.streamService = streamService;
+  }
+
+  /**
+   * Dummy controller method used to check {@link com.symphony.bdk.app.spring.filter.TracingFilter} behaviour.
+   */
+  @GetMapping
+  public String hello() {
+    log.info("hello");
+    final List<StreamAttributes> streams = this.streamService.listStreams(new StreamFilter());
+    log.info("{} streams found.", streams.size());
+    return streams.size() + " streams found.";
+  }
+}

--- a/symphony-bdk-examples/bdk-app-spring-boot-example/src/main/resources/application.yaml
+++ b/symphony-bdk-examples/bdk-app-spring-boot-example/src/main/resources/application.yaml
@@ -1,4 +1,4 @@
-
+# BDK Core Configuration
 bdk:
   host: acme.symphony.com
   bot:
@@ -9,6 +9,7 @@ bdk:
     appId: myapp
     privateKeyPath: ${user.home}/.symphony/privatekey.pem
 
+# BDK App Configuration
 bdk-app:
   auth:
     enabled: true
@@ -18,17 +19,28 @@ bdk-app:
   cors:
     "[/**]":
       allowed-origins: "*"
+  tracing:
+    enabled: true
+    urlPatterns:
+      - /api/*
 
 logging:
+  pattern:
+    # Added %clr(%X{X-Trace-Id}){magenta} to output the MDC traceId in logs
+    console: '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID}){magenta} %clr(%X{X-Trace-Id}){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx'
   level:
     com.symphony: debug
 
 server:
+  port: 10443
   ssl:
     key-store: classpath:keystore.p12
     key-store-password: password
     key-store-type: pkcs12
     key-alias: tomcat
-  port: 10443
-spring.security.user.name: user
-spring.security.user.password: password
+
+spring:
+  security:
+    user:
+      name: admin
+      password: password

--- a/symphony-bdk-http/symphony-bdk-http-api/build.gradle
+++ b/symphony-bdk-http/symphony-bdk-http-api/build.gradle
@@ -5,6 +5,11 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    implementation 'org.slf4j:slf4j-api'
+
     implementation 'org.apiguardian:apiguardian-api'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'ch.qos.logback:logback-classic'
 }
 

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/ApiClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/ApiClient.java
@@ -1,6 +1,5 @@
 package com.symphony.bdk.http.api;
 
-import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
 import com.symphony.bdk.http.api.util.TypeReference;
 
 import org.apiguardian.api.API;
@@ -104,15 +103,5 @@ public interface ApiClient {
    */
   default void rotate() {
 
-  }
-
-  default void initTracingHeader(Map<String, String> headerParams) {
-    if (!headerParams.containsKey(DistributedTracingContext.TRACE_ID)) {
-      // if MDC not already set, initialize it
-      if (DistributedTracingContext.getTraceId().isEmpty()) {
-        DistributedTracingContext.setTraceId();
-      }
-      headerParams.put(DistributedTracingContext.TRACE_ID, DistributedTracingContext.getTraceId());
-    }
   }
 }

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/ApiClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/ApiClient.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.http.api;
 
+import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
 import com.symphony.bdk.http.api.util.TypeReference;
 
 import org.apiguardian.api.API;
@@ -103,5 +104,15 @@ public interface ApiClient {
    */
   default void rotate() {
 
+  }
+
+  default void initTracingHeader(Map<String, String> headerParams) {
+    if (!headerParams.containsKey(DistributedTracingContext.TRACE_ID)) {
+      // if MDC not already set, initialize it
+      if (DistributedTracingContext.getTraceId().isEmpty()) {
+        DistributedTracingContext.setTraceId();
+      }
+      headerParams.put(DistributedTracingContext.TRACE_ID, DistributedTracingContext.getTraceId());
+    }
   }
 }

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/tracing/DistributedTracingContext.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/tracing/DistributedTracingContext.java
@@ -37,6 +37,10 @@ public final class DistributedTracingContext {
     return MDC.get(TRACE_ID) != null ? MDC.get(TRACE_ID) : "";
   }
 
+  public static boolean hasTraceId() {
+    return !getTraceId().isEmpty();
+  }
+
   public static void clear() {
     MDC.remove(TRACE_ID);
   }

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/tracing/DistributedTracingContext.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/tracing/DistributedTracingContext.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.http.api.tracing;
 import org.apiguardian.api.API;
 import org.slf4j.MDC;
 
+import java.security.SecureRandom;
 import java.util.Random;
 
 /**
@@ -14,7 +15,7 @@ import java.util.Random;
 public final class DistributedTracingContext {
 
   /** {@link Random} is thread-safe */
-  private static final Random RANDOM = new Random();
+  private static final SecureRandom RANDOM = new SecureRandom();
 
   private static final int TRACE_ID_SIZE = 6;
   private static final char TRACE_ID_SEPARATOR = ':';

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/tracing/DistributedTracingContext.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/tracing/DistributedTracingContext.java
@@ -1,0 +1,55 @@
+package com.symphony.bdk.http.api.tracing;
+
+import org.apiguardian.api.API;
+import org.slf4j.MDC;
+
+import java.util.Random;
+
+/**
+ * Helper class that manipulates underlying logger {@link MDC} for distributed tracing purpose. The Symphony platform
+ * internally relies on header <code>X-Trace-Id</code> value that is printed at server side logs. This is especially
+ * useful when debugging issues across multiple distributed systems.
+ */
+@API(status = API.Status.STABLE)
+public final class DistributedTracingContext {
+
+  /** {@link Random} is thread-safe */
+  private static final Random RANDOM = new Random();
+
+  private static final int TRACE_ID_SIZE = 6;
+  private static final char TRACE_ID_SEPARATOR = ':';
+
+  public static final String TRACE_ID = "X-Trace-Id";
+
+  private DistributedTracingContext() {
+    // nothing to be done here
+  }
+
+  public static void setTraceId() {
+    MDC.put(TRACE_ID, randomAlphanumeric(TRACE_ID_SIZE));
+  }
+
+  public static void setTraceId(String baseTraceId) {
+    MDC.put(TRACE_ID, baseTraceId + TRACE_ID_SEPARATOR + randomAlphanumeric(TRACE_ID_SIZE));
+  }
+
+  public static String getTraceId() {
+    return MDC.get(TRACE_ID) != null ? MDC.get(TRACE_ID) : "";
+  }
+
+  public static void clear() {
+    MDC.remove(TRACE_ID);
+  }
+
+  private static String randomAlphanumeric(int size) {
+
+    final int leftLimit = 48; // ascii code for numeral '0'
+    final int rightLimit = 122; // ascii code for letter 'z'
+
+    return RANDOM.ints(leftLimit, rightLimit + 1)
+        .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+        .limit(size)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
+  }
+}

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/tracing/MDCUtils.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/tracing/MDCUtils.java
@@ -1,0 +1,65 @@
+package com.symphony.bdk.http.api.tracing;
+
+import lombok.RequiredArgsConstructor;
+import org.apiguardian.api.API;
+import org.slf4j.MDC;
+
+import java.util.Map;
+
+/**
+ * Helper class for managing {@link MDC} in multi-thread applications.
+ */
+@API(status = API.Status.STABLE)
+public final class MDCUtils {
+
+  private MDCUtils() {
+    // nothing to be done here
+  }
+
+  /**
+   * Wrap parent {@link MDC} context in child {@link Runnable}. Ensure that {@link MDC} values set in child runnable don't
+   * leak in parent context.
+   *
+   * @param runnable A simple runnable interface
+   * @return the wrapped runnable
+   */
+  public static Runnable wrap(Runnable runnable) {
+    return new MDCUtils.MdcRunnable(runnable);
+  }
+
+  private static Map<String, String> beforeCallMDCSetup(Map<String, String> parentContext) {
+    final Map<String, String> childContext = MDC.getCopyOfContextMap();
+    if (parentContext != null) {
+      if (childContext != null) {
+        parentContext.putAll(childContext);
+      }
+
+      MDC.setContextMap(parentContext);
+    }
+
+    return childContext;
+  }
+
+  private static void afterCallMDCCleanUp(Map<String, String> childContext) {
+    MDC.clear();
+    if (childContext != null) {
+      MDC.setContextMap(childContext);
+    }
+  }
+
+  @RequiredArgsConstructor
+  private static class MdcRunnable implements Runnable {
+
+    private final Map<String, String> parentContext = MDC.getCopyOfContextMap();
+    private final Runnable runnable;
+
+    public void run() {
+      final Map<String, String> childContext = MDCUtils.beforeCallMDCSetup(this.parentContext);
+      try {
+        this.runnable.run();
+      } finally {
+        MDCUtils.afterCallMDCCleanUp(childContext);
+      }
+    }
+  }
+}

--- a/symphony-bdk-http/symphony-bdk-http-api/src/test/java/com/symphony/bdk/http/api/tracing/DistributedTracingContextTest.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/test/java/com/symphony/bdk/http/api/tracing/DistributedTracingContextTest.java
@@ -1,0 +1,30 @@
+package com.symphony.bdk.http.api.tracing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class DistributedTracingContextTest {
+
+  @Test
+  void shouldSetAndClearMDCWithSuccess() {
+
+    DistributedTracingContext.setTraceId();
+
+    final String baseTraceId = DistributedTracingContext.getTraceId();
+
+    assertEquals(6, baseTraceId.length());
+
+    DistributedTracingContext.setTraceId(baseTraceId);
+
+    final String updatedTraceId = DistributedTracingContext.getTraceId();
+
+    assertEquals(13, updatedTraceId.length());
+    assertTrue(updatedTraceId.startsWith(baseTraceId + ":"));
+
+    DistributedTracingContext.clear();
+
+    assertTrue(DistributedTracingContext.getTraceId().isEmpty());
+  }
+}

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientJersey2.java
@@ -5,6 +5,7 @@ import com.symphony.bdk.http.api.ApiClientBodyPart;
 import com.symphony.bdk.http.api.ApiException;
 import com.symphony.bdk.http.api.ApiResponse;
 import com.symphony.bdk.http.api.Pair;
+import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
 import com.symphony.bdk.http.api.util.TypeReference;
 
 import org.apiguardian.api.API;
@@ -90,8 +91,12 @@ public class ApiClientJersey2 implements ApiClient {
 
     Invocation.Builder invocationBuilder = target.request().accept(accept);
 
+    if (!DistributedTracingContext.hasTraceId()) {
+      DistributedTracingContext.setTraceId();
+    }
+    invocationBuilder = invocationBuilder.header(DistributedTracingContext.TRACE_ID, DistributedTracingContext.getTraceId());
+
     if (headerParams != null) {
-      this.initTracingHeader(headerParams);
       for (Entry<String, String> entry : headerParams.entrySet()) {
         String value = entry.getValue();
         if (value != null) {

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientJersey2.java
@@ -90,17 +90,22 @@ public class ApiClientJersey2 implements ApiClient {
 
     Invocation.Builder invocationBuilder = target.request().accept(accept);
 
-    for (Entry<String, String> entry : headerParams.entrySet()) {
-      String value = entry.getValue();
-      if (value != null) {
-        invocationBuilder = invocationBuilder.header(entry.getKey(), value);
+    if (headerParams != null) {
+      this.initTracingHeader(headerParams);
+      for (Entry<String, String> entry : headerParams.entrySet()) {
+        String value = entry.getValue();
+        if (value != null) {
+          invocationBuilder = invocationBuilder.header(entry.getKey(), value);
+        }
       }
     }
 
-    for (Entry<String, String> entry : cookieParams.entrySet()) {
-      String value = entry.getValue();
-      if (value != null) {
-        invocationBuilder = invocationBuilder.cookie(entry.getKey(), value);
+    if (cookieParams != null) {
+      for (Entry<String, String> entry : cookieParams.entrySet()) {
+        String value = entry.getValue();
+        if (value != null) {
+          invocationBuilder = invocationBuilder.cookie(entry.getKey(), value);
+        }
       }
     }
 

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientWebClient.java
@@ -5,6 +5,7 @@ import com.symphony.bdk.http.api.ApiClientBodyPart;
 import com.symphony.bdk.http.api.ApiException;
 import com.symphony.bdk.http.api.ApiResponse;
 import com.symphony.bdk.http.api.Pair;
+import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
 import com.symphony.bdk.http.api.util.TypeReference;
 
 import org.apiguardian.api.API;
@@ -88,8 +89,12 @@ public class ApiClientWebClient implements ApiClient {
       requestBodySpec.accept(MediaType.valueOf(accept));
     }
 
+    if (!DistributedTracingContext.hasTraceId()) {
+      DistributedTracingContext.setTraceId();
+    }
+    requestBodySpec = requestBodySpec.header(DistributedTracingContext.TRACE_ID, DistributedTracingContext.getTraceId());
+
     if (headerParams != null) {
-      this.initTracingHeader(headerParams);
       for (Map.Entry<String, String> headerParam : headerParams.entrySet()) {
         String value = headerParam.getValue();
         if (value != null) {

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientWebClient.java
@@ -89,6 +89,7 @@ public class ApiClientWebClient implements ApiClient {
     }
 
     if (headerParams != null) {
+      this.initTracingHeader(headerParams);
       for (Map.Entry<String, String> headerParam : headerParams.entrySet()) {
         String value = headerParam.getValue();
         if (value != null) {

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/SymphonyBdkAppAutoConfiguration.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/SymphonyBdkAppAutoConfiguration.java
@@ -4,6 +4,8 @@ import com.symphony.bdk.app.spring.config.BdkExtAppControllerConfig;
 
 import com.symphony.bdk.app.spring.config.BdkExtAppSecurityConfig;
 
+import com.symphony.bdk.app.spring.config.BdkExtAppTracingFilterConfig;
+
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 
@@ -12,7 +14,8 @@ import org.springframework.context.annotation.Import;
  */
 @Import({
     BdkExtAppControllerConfig.class,
-    BdkExtAppSecurityConfig.class
+    BdkExtAppSecurityConfig.class,
+    BdkExtAppTracingFilterConfig.class
 })
 @EnableConfigurationProperties(SymphonyBdkAppProperties.class)
 public class SymphonyBdkAppAutoConfiguration {

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/SymphonyBdkAppProperties.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/SymphonyBdkAppProperties.java
@@ -3,6 +3,8 @@ package com.symphony.bdk.app.spring;
 import com.symphony.bdk.app.spring.properties.AppAuthProperties;
 import com.symphony.bdk.app.spring.properties.CorsProperties;
 
+import com.symphony.bdk.app.spring.properties.TracingProperties;
+
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -27,4 +29,9 @@ public class SymphonyBdkAppProperties {
    * CORS support properties
    */
   private Map<String, CorsProperties> cors = Collections.emptyMap();
+
+  /**
+   * {@link com.symphony.bdk.app.spring.filter.TracingFilter} properties.
+   */
+  private TracingProperties tracing = new TracingProperties();
 }

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/config/BdkExtAppTracingFilterConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/config/BdkExtAppTracingFilterConfig.java
@@ -1,0 +1,29 @@
+package com.symphony.bdk.app.spring.config;
+
+import com.symphony.bdk.app.spring.SymphonyBdkAppProperties;
+import com.symphony.bdk.app.spring.filter.TracingFilter;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Configuration of the {@link TracingFilter}, that is activated by default.
+ */
+@ConditionalOnProperty(name = "bdk-app.tracing.enabled", havingValue = "true", matchIfMissing = true)
+public class BdkExtAppTracingFilterConfig {
+
+  @Bean
+  public FilterRegistrationBean<TracingFilter> tracingFilter(SymphonyBdkAppProperties properties) {
+    final FilterRegistrationBean<TracingFilter> registrationBean = new FilterRegistrationBean<>();
+
+    registrationBean.setFilter(new TracingFilter());
+    registrationBean.addUrlPatterns(getUrlPatterns(properties));
+
+    return registrationBean;
+  }
+
+  private static String[] getUrlPatterns(SymphonyBdkAppProperties properties) {
+    return properties.getTracing().getUrlPatterns().toArray(new String[0]);
+  }
+}

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/config/BdkExtAppTracingFilterConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/config/BdkExtAppTracingFilterConfig.java
@@ -6,6 +6,7 @@ import com.symphony.bdk.app.spring.filter.TracingFilter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
 
 /**
  * Configuration of the {@link TracingFilter}, that is activated by default.
@@ -19,6 +20,7 @@ public class BdkExtAppTracingFilterConfig {
 
     registrationBean.setFilter(new TracingFilter());
     registrationBean.addUrlPatterns(getUrlPatterns(properties));
+    registrationBean.setOrder(Ordered.LOWEST_PRECEDENCE);
 
     return registrationBean;
   }

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/filter/TracingFilter.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/filter/TracingFilter.java
@@ -1,0 +1,49 @@
+package com.symphony.bdk.app.spring.filter;
+
+import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Tracing filter based on {@link DistributedTracingContext} defined in symphony-bdk-http-api module.
+ */
+@Slf4j
+public class TracingFilter implements Filter {
+
+  @Override
+  public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+      throws IOException, ServletException {
+
+    final HttpServletRequest request = (HttpServletRequest) servletRequest;
+    final HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+    // Trace ID can be issued from another calling system
+    final String xTraceInHeader = request.getHeader(DistributedTracingContext.TRACE_ID);
+
+    if (xTraceInHeader == null || xTraceInHeader.isEmpty()) {
+      // init default one
+      DistributedTracingContext.setTraceId();
+    } else {
+      // generate new value appended to existing one
+      DistributedTracingContext.setTraceId(xTraceInHeader);
+    }
+
+    response.setHeader(DistributedTracingContext.TRACE_ID, DistributedTracingContext.getTraceId());
+
+    try {
+      filterChain.doFilter(servletRequest, servletResponse);
+    } finally {
+      DistributedTracingContext.clear();
+    }
+  }
+}

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/properties/TracingProperties.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/properties/TracingProperties.java
@@ -1,0 +1,25 @@
+package com.symphony.bdk.app.spring.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Activation or deactivation of the {@link com.symphony.bdk.app.spring.filter.TracingFilter}.
+ */
+@Getter
+@Setter
+public class TracingProperties {
+
+  /**
+   * Activate or deactivate the {@link com.symphony.bdk.app.spring.filter.TracingFilter}.
+   */
+  private Boolean enabled = true;
+
+  /**
+   * Add URL patterns, as defined in the Servlet specification, that the tracing filter will be registered against.
+   */
+  private List<String> urlPatterns = Collections.singletonList("/*");
+}

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/SymphonyBdkAppAutoConfigurationTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/SymphonyBdkAppAutoConfigurationTest.java
@@ -34,6 +34,7 @@ public class SymphonyBdkAppAutoConfigurationTest {
       assertThat(context).hasSingleBean(BdkExtAppControllerConfig.class);
       assertThat(context).hasSingleBean(CircleOfTrustController.class);
       assertThat(context).hasBean("corsConfigurer");
+      assertThat(context).hasBean("tracingFilter");
 
       SymphonyBdkAppProperties properties = context.getBean(SymphonyBdkAppProperties.class);
       assertEquals(properties.getCors().get("test-url").getAllowedOrigins().get(0), "/**");
@@ -55,5 +56,20 @@ public class SymphonyBdkAppAutoConfigurationTest {
     contextRunner.run(context -> {
       assertThat(context).doesNotHaveBean(CircleOfTrustController.class);
     });
+  }
+
+  @Test
+  void shouldLoadContextWithoutTracingFilter() {
+
+    final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withPropertyValues(
+            "bdk.app.appId=test-app",
+            "bdk.app.privateKeyPath=classpath:/privatekey.pem",
+            "bdk-app.tracing.enabled=false"
+        )
+        .withUserConfiguration(SymphonyBdkMockedConfiguration.class)
+        .withConfiguration(AutoConfigurations.of(SymphonyBdkAppAutoConfiguration.class));
+
+    contextRunner.run(context -> assertThat(context).doesNotHaveBean("tracingFilter"));
   }
 }

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/config/BdkExtAppTracingFilterConfigTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/config/BdkExtAppTracingFilterConfigTest.java
@@ -1,0 +1,22 @@
+package com.symphony.bdk.app.spring.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.symphony.bdk.app.spring.SymphonyBdkAppProperties;
+import com.symphony.bdk.app.spring.filter.TracingFilter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.core.Ordered;
+
+class BdkExtAppTracingFilterConfigTest {
+
+  @Test
+  void checkFilterOrder() {
+    final FilterRegistrationBean<TracingFilter> tracingFilterRegistration =
+        new BdkExtAppTracingFilterConfig().tracingFilter(new SymphonyBdkAppProperties());
+
+    assertEquals("/*", tracingFilterRegistration.getUrlPatterns().stream().findFirst().get());
+    assertEquals(Ordered.LOWEST_PRECEDENCE, tracingFilterRegistration.getOrder());
+  }
+}

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/filter/TracingFilterTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/filter/TracingFilterTest.java
@@ -1,0 +1,46 @@
+package com.symphony.bdk.app.spring.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class TracingFilterTest {
+
+  @Test
+  void traceIdPresentInRequest() throws Exception {
+
+    final String incomingTraceId = "123456";
+
+    final TracingFilter filter = new TracingFilter();
+
+    final MockHttpServletRequest req = new MockHttpServletRequest();
+    req.addHeader(DistributedTracingContext.TRACE_ID, incomingTraceId);
+
+    final MockHttpServletResponse res = new MockHttpServletResponse();
+    final MockFilterChain chain = new MockFilterChain();
+
+    filter.doFilter(req, res, chain);
+
+    assertThat(res.getHeader(DistributedTracingContext.TRACE_ID)).startsWith(incomingTraceId + ":");
+  }
+
+  @Test
+  void traceIdNotPresentInRequest() throws Exception {
+
+    final TracingFilter filter = new TracingFilter();
+
+    final MockHttpServletRequest req = new MockHttpServletRequest();
+    final MockHttpServletResponse res = new MockHttpServletResponse();
+    final MockFilterChain chain = new MockFilterChain();
+
+    filter.doFilter(req, res, chain);
+
+    assertThat(res.getHeader(DistributedTracingContext.TRACE_ID)).isNotBlank();
+  }
+
+}

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
@@ -85,7 +85,7 @@ public class SlashAnnotationProcessor implements BeanPostProcessor, ApplicationC
       type = AutoProxyUtils.determineTargetClass(this.applicationContext.getBeanFactory(), beanName);
     } catch (Throwable ex) {
       // An unresolvable bean type, probably from a lazy bean - let's ignore it.
-      log.debug("Could not resolve target class for bean with name '{}'", beanName, ex);
+      log.trace("Could not resolve target class for bean with name '{}'", beanName, ex);
     }
 
     if (type != null && ScopedObject.class.isAssignableFrom(type)) {
@@ -99,7 +99,7 @@ public class SlashAnnotationProcessor implements BeanPostProcessor, ApplicationC
         }
       } catch (Throwable ex) {
         // An invalid scoped proxy arrangement - let's ignore it.
-        log.debug("Could not resolve target bean for scoped proxy '{}'", beanName, ex);
+        log.trace("Could not resolve target bean for scoped proxy '{}'", beanName, ex);
       }
     }
 

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/service/DatafeedAsyncLauncherService.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/service/DatafeedAsyncLauncherService.java
@@ -1,9 +1,11 @@
 package com.symphony.bdk.spring.service;
 
-import com.symphony.bdk.http.api.ApiException;
 import com.symphony.bdk.core.auth.exception.AuthUnauthorizedException;
 import com.symphony.bdk.core.service.datafeed.DatafeedService;
 import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
+import com.symphony.bdk.http.api.ApiException;
+
+import com.symphony.bdk.http.api.tracing.MDCUtils;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apiguardian.api.API;
@@ -43,7 +45,7 @@ public class DatafeedAsyncLauncherService implements Thread.UncaughtExceptionHan
    * Asynchronous execution of the {@link DatafeedService#start()} method.
    */
   public void start() {
-    final Thread datafeedThread = new Thread(this::uncheckedStart, "SymphonyBdk_DatafeedThread");
+    final Thread datafeedThread = new Thread(MDCUtils.wrap(this::uncheckedStart), "SymphonyBdk_DatafeedThread");
     datafeedThread.setUncaughtExceptionHandler(this);
     datafeedThread.start();
   }


### PR DESCRIPTION
### Ticket
[APP-3125](https://perzoinc.atlassian.net/browse/APP-3125)

### Description
Header `X-Trace-Id` is now forwarded to every API call. As well, the value is also set in logger MDC for debugging purpose. 

A `TracingFilter` has been created in `app-starter` to init the `X-Trace-Id` value for each incoming request. 

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
