### PR TITLE
APP-3281: Wrapped exceptions occurring during pkcs1 key parsing in a GeneralSecurityException

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/jwt/JwtHelper.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/jwt/JwtHelper.java
@@ -136,7 +136,7 @@ public class JwtHelper {
 			);
 
 			return new JcaPEMKeyConverter().getPrivateKey(PrivateKeyInfoFactory.createPrivateKeyInfo(privateKeyParameter));
-		} catch (IOException e) {
+		} catch (IOException | IllegalStateException | IllegalArgumentException e) {
 			throw new GeneralSecurityException("Invalid private key.", e);
 		}
 	}

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/JwtHelperTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/JwtHelperTest.java
@@ -30,6 +30,7 @@ import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
+import java.security.spec.InvalidKeySpecException;
 import java.util.Date;
 
 /**
@@ -43,14 +44,30 @@ class JwtHelperTest {
 
   @Test
   void loadPkcs8PrivateKey() throws GeneralSecurityException {
-    final PrivateKey privateKey = new JwtHelper().parseRsaPrivateKey(generatePkcs8RsaPrivateKey());
+    final PrivateKey privateKey = JwtHelper.parseRsaPrivateKey(generatePkcs8RsaPrivateKey());
     assertNotNull(privateKey);
   }
 
   @Test
+  void loadInvalidPkcs8PrivateKey() {
+    String invalidPkc8PrivateKey = "-----BEGIN PRIVATE KEY-----\n"
+        + "abcdef\n"
+        + "-----END PRIVATE KEY-----";
+    assertThrows(InvalidKeySpecException.class, () -> JwtHelper.parseRsaPrivateKey(invalidPkc8PrivateKey));
+  }
+
+  @Test
   void loadPkcs1PrivateKey() throws GeneralSecurityException {
-    final PrivateKey privateKey = new JwtHelper().parseRsaPrivateKey(generatePkcs1RsaPrivateKey());
+    final PrivateKey privateKey = JwtHelper.parseRsaPrivateKey(generatePkcs1RsaPrivateKey());
     assertNotNull(privateKey);
+  }
+
+  @Test
+  void loadInvalidPkcs1PrivateKey() {
+    String invalidPkc8PrivateKey = "-----BEGIN RSA PRIVATE KEY-----\n"
+        + "abcde\nf"
+        + "-----END RSA PRIVATE KEY-----";
+    assertThrows(GeneralSecurityException.class, () -> JwtHelper.parseRsaPrivateKey(invalidPkc8PrivateKey));
   }
 
   @Test


### PR DESCRIPTION
### Ticket
[APP-3281](https://perzoinc.atlassian.net/browse/APP-3281)

### Description
Some errors were not properly caught during pkcs1 key parsing (e.g. in case of an invalid key) therefore making exception message and stack trace not so obvious to understand.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
