### PR TITLE
APP-3351: fixed wrong proxy credentials passed for KM client

### DIFF
--- a/symphony-bdk-legacy/symphony-api-client-java/src/main/java/utils/HttpClientBuilderHelper.java
+++ b/symphony-bdk-legacy/symphony-api-client-java/src/main/java/utils/HttpClientBuilderHelper.java
@@ -95,8 +95,8 @@ public class HttpClientBuilderHelper {
         return getClientConfig(
             config,
             getOr(config.getKeyManagerProxyURL(), config.getProxyURL()),
-            getOr(config.getKeyManagerProxyUsername(), config.getProxyURL()),
-            getOr(config.getKeyManagerProxyPassword(), config.getProxyURL())
+            getOr(config.getKeyManagerProxyUsername(), config.getProxyUsername()),
+            getOr(config.getKeyManagerProxyPassword(), config.getProxyPassword())
         );
     }
 

--- a/symphony-bdk-legacy/symphony-api-client-java/src/test/java/utils/HttpClientBuilderHelperTest.java
+++ b/symphony-bdk-legacy/symphony-api-client-java/src/test/java/utils/HttpClientBuilderHelperTest.java
@@ -1,0 +1,31 @@
+package utils;
+
+import configuration.SymConfig;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class HttpClientBuilderHelperTest {
+
+  @Test
+  public void getAgentClientConfig() {
+    final String proxyURL = "http://proxy:1234";
+    final String proxyUser = "user";
+    final String proxyPassword = "pass";
+
+    SymConfig config = new SymConfig();
+    config.setProxyURL(proxyURL);
+    config.setProxyUsername(proxyUser);
+    config.setProxyPassword(proxyPassword);
+
+    final Map<String, Object> properties = HttpClientBuilderHelper.getKMClientConfig(config).getProperties();
+
+    assertEquals(proxyURL, properties.get(ClientProperties.PROXY_URI));
+    assertEquals(proxyUser, properties.get(ClientProperties.PROXY_USERNAME));
+    assertEquals(proxyPassword, properties.get(ClientProperties.PROXY_PASSWORD));
+  }
+}


### PR DESCRIPTION
### Ticket
[APP-3351](https://perzoinc.atlassian.net/browse/APP-3351)

### Description
Wrong proxy credentials were passed to the KeyManager http client.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any