### PR TITLE
SDK-181 Java SDK: create test coverage for sdk.symphony.ExtensionAppAuthClientImpl

### DIFF
--- a/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/test/java/com/symphony/bdk/bot/sdk/symphony/ExtensionAppAuthClientTest.java
+++ b/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/test/java/com/symphony/bdk/bot/sdk/symphony/ExtensionAppAuthClientTest.java
@@ -54,6 +54,12 @@ public class ExtensionAppAuthClientTest {
   }
 
   @Test
+  public void validateTokensFalseTest() {
+    when(extensionAppAuthenticator.validateTokens("appToken", "symphonyToken")).thenReturn(false);
+    assertFalse(extensionAppAuthClient.validateTokens("appToken", "symphonyToken"));
+  }
+
+  @Test
   public void verifyJWTTest() {
     UserInfo userInfo = new UserInfo();
     userInfo.setId(123456L);

--- a/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/test/java/com/symphony/bdk/bot/sdk/symphony/ExtensionAppAuthClientTest.java
+++ b/symphony-bdk-legacy/symphony-bdk-bot-sdk-java/src/test/java/com/symphony/bdk/bot/sdk/symphony/ExtensionAppAuthClientTest.java
@@ -1,0 +1,69 @@
+package com.symphony.bdk.bot.sdk.symphony;
+
+import com.symphony.bdk.bot.sdk.symphony.authentication.ExtensionAppAuthenticator;
+import com.symphony.bdk.bot.sdk.symphony.exception.AppAuthenticateException;
+import com.symphony.bdk.bot.sdk.symphony.exception.SymphonyClientException;
+import com.symphony.bdk.bot.sdk.symphony.model.AuthenticateResponse;
+import lombok.SneakyThrows;
+import model.AppAuthResponse;
+import model.UserInfo;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class ExtensionAppAuthClientTest {
+  private ExtensionAppAuthenticator extensionAppAuthenticator;
+  private ExtensionAppAuthClient extensionAppAuthClient;
+
+  @BeforeEach
+  public void init() {
+    extensionAppAuthenticator = mock(ExtensionAppAuthenticator.class);
+    extensionAppAuthClient = new ExtensionAppAuthClientImpl(extensionAppAuthenticator);
+  }
+
+  @SneakyThrows
+  @Test
+  public void appAuthenticateSuccess() {
+    AppAuthResponse appAuthResponse = new AppAuthResponse();
+    appAuthResponse.setAppToken("testToken");
+    when(extensionAppAuthenticator.appAuthenticate()).thenReturn(appAuthResponse);
+    AuthenticateResponse authResponse = extensionAppAuthClient.appAuthenticate("testAppId");
+    assertEquals("testAppId", authResponse.getAppId());
+    assertEquals("testToken", authResponse.getAppToken());
+  }
+
+  @SneakyThrows
+  @Test
+  public void appAuthenticateFailed() {
+    when(extensionAppAuthenticator.appAuthenticate()).thenThrow(new RuntimeException());
+    assertThrows(SymphonyClientException.class, () -> extensionAppAuthClient.appAuthenticate("testAppId"));
+  }
+
+  @SneakyThrows
+  @Test
+  public void appAuthenticateAppTokenNull() {
+    when(extensionAppAuthenticator.appAuthenticate()).thenReturn(null);
+    assertThrows(AppAuthenticateException.class, () -> extensionAppAuthClient.appAuthenticate("testAppId"));
+  }
+
+  @Test
+  public void validateTokensTest() {
+    when(extensionAppAuthenticator.validateTokens("appToken", "symphonyToken")).thenReturn(true);
+    assertTrue(extensionAppAuthClient.validateTokens("appToken", "symphonyToken"));
+  }
+
+  @Test
+  public void verifyJWTTest() {
+    UserInfo userInfo = new UserInfo();
+    userInfo.setId(123456L);
+    when(extensionAppAuthenticator.verifyJWT("testJwt")).thenReturn(userInfo);
+    assertEquals(123456L, extensionAppAuthClient.verifyJWT("testJwt"));
+  }
+
+  @Test
+  public void verifyJWTFailedTest() {
+    when(extensionAppAuthenticator.verifyJWT("testJwt")).thenReturn(null);
+    assertThrows(AppAuthenticateException.class, () -> extensionAppAuthClient.verifyJWT("testJwt"));
+  }
+}


### PR DESCRIPTION
### Ticket
[SDK-181](https://perzoinc.atlassian.net/browse/SDK-181)

### Description
Added unit test for ExtensionAppAuthClientImpl.

### Coverage
<img width="546" alt="ExtensionAppAuthClient" src="https://user-images.githubusercontent.com/68892340/102323106-576c2100-3f80-11eb-9382-d65e9a98a2fc.png">
