### PR TITLE
PLAT-10295: Prepare 2.0.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-ext.projectVersion = '1.7.0-SNAPSHOT'
+ext.projectVersion = '2.0.0-SNAPSHOT'
 ext.isReleaseVersion = !ext.projectVersion.endsWith('SNAPSHOT')
 
 ext.symphonyRepoUrl = project.properties['symphonyRepoUrl'] ?: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ If you want to use [Maven](https://maven.apache.org/) as build system, you have 
             <dependency>
                 <groupId>com.symphony.platformsolutions</groupId>
                 <artifactId>symphony-bdk-bom</artifactId>
-                <version>1.3.2.BETA</version>
+                <version>2.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -91,7 +91,7 @@ repositories {
 dependencies {
 
     // import a BOM
-    implementation platform('com.symphony.platformsolutions:symphony-bdk-bom:1.3.2.BETA')
+    implementation platform('com.symphony.platformsolutions:symphony-bdk-bom:2.0.0')
 
     // define dependencies without versions
     implementation 'com.symphony.platformsolutions:symphony-bdk-core'

--- a/docs/spring-boot/app-starter.md
+++ b/docs/spring-boot/app-starter.md
@@ -30,7 +30,7 @@ The following listing shows the `pom.xml` file that has to be created when using
             <dependency>
                 <groupId>com.symphony.platformsolutions</groupId>
                 <artifactId>symphony-bdk-bom</artifactId>
-                <version>1.3.2.BETA</version>
+                <version>2.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -65,7 +65,7 @@ plugins {
 }
 
 dependencies {
-    implementation platform('com.symphony.platformsolutions:symphony-bdk-bom:1.3.2.BETA')
+    implementation platform('com.symphony.platformsolutions:symphony-bdk-bom:2.0.0')
     
     implementation 'com.symphony.platformsolutions:symphony-bdk-app-spring-boot-starter'
 }

--- a/docs/spring-boot/core-starter.md
+++ b/docs/spring-boot/core-starter.md
@@ -72,7 +72,7 @@ plugins {
 }
 
 dependencies {
-    implementation platform('com.symphony.platformsolutions:symphony-bdk-bom:1.3.2.BETA')
+    implementation platform('com.symphony.platformsolutions:symphony-bdk-bom:2.0.0')
     
     implementation 'com.symphony.platformsolutions:symphony-bdk-core-spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter'

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
     // import Spring Boot's BOM
-    api platform('org.springframework.boot:spring-boot-dependencies:2.4.0')
+    api platform('org.springframework.boot:spring-boot-dependencies:2.4.1')
 
     // define all our dependencies versions
     constraints {
@@ -30,28 +30,28 @@ dependencies {
         api "com.symphony.platformsolutions:symphony-bdk-template-handlebars:$project.version"
 
         // External dependencies
-        api 'org.projectlombok:lombok:1.18.12'
+        api 'org.projectlombok:lombok:1.18.16'
 
         api 'org.apiguardian:apiguardian-api:1.1.0'
 
         api 'org.slf4j:slf4j-api:1.7.30'
         api 'org.slf4j:slf4j-log4j12:1.7.30'
 
-        api 'commons-io:commons-io:2.6'
+        api 'commons-io:commons-io:2.8.0'
         api 'commons-codec:commons-codec:1.15'
         api 'commons-beanutils:commons-beanutils:1.9.4'
-        api 'org.apache.commons:commons-lang3:3.9'
+        api 'org.apache.commons:commons-lang3:3.11'
         api 'commons-logging:commons-logging:1.2'
         api 'com.brsanthu:migbase64:2.2'
         api 'io.jsonwebtoken:jjwt:0.9.1'
         api 'org.bouncycastle:bcpkix-jdk15on:1.66'
         api 'com.google.code.findbugs:jsr305:3.0.2'
 
-        api 'io.github.resilience4j:resilience4j-retry:1.4.0'
+        api 'io.github.resilience4j:resilience4j-retry:1.6.1'
 
-        api 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
-        api 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.2'
-        api 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.2'
+        api 'com.fasterxml.jackson.core:jackson-databind:2.11.4'
+        api 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.4'
+        api 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.4'
 
         api 'io.swagger:swagger-annotations:1.6.0'
         api 'org.openapitools:jackson-databind-nullable:0.2.1'
@@ -72,8 +72,8 @@ dependencies {
         api 'ch.qos.logback:logback-classic:1.2.3'
         api 'com.tngtech.archunit:archunit-junit5:0.14.1'
         api 'org.mock-server:mockserver-netty:5.11.1'
-        api 'org.mockito:mockito-core:3.4.6'
-        api 'org.mockito:mockito-junit-jupiter:3.4.6'
+        api 'org.mockito:mockito-core:3.6.28'
+        api 'org.mockito:mockito-junit-jupiter:3.6.28'
     }
 }
 

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -44,7 +44,7 @@ dependencies {
         api 'commons-logging:commons-logging:1.2'
         api 'com.brsanthu:migbase64:2.2'
         api 'io.jsonwebtoken:jjwt:0.9.1'
-        api 'org.bouncycastle:bcpkix-jdk15on:1.66'
+        api 'org.bouncycastle:bcpkix-jdk15on:1.67'
         api 'com.google.code.findbugs:jsr305:3.0.2'
 
         api 'io.github.resilience4j:resilience4j-retry:1.6.1'

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 }
 
 // OpenAPI code generation
-def apiBaseUrl = "https://raw.githubusercontent.com/symphonyoss/symphony-api-spec/master"
+def apiBaseUrl = "https://raw.githubusercontent.com/symphonyoss/symphony-api-spec/20.9"
 def generatedFolder = "$buildDir/generated/openapi"
 def apisToGenerate = [
         Agent: 'agent/agent-api-public.yaml',

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientWebClientTest.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientWebClientTest.java
@@ -261,7 +261,6 @@ class ApiClientWebClientTest {
         httpRequest -> httpRequest
             .withMethod("POST")
             .withPath("/test-api")
-            .withHeader(Header.header("Content-Type", "multipart/form-data;boundary=.*;charset=UTF-8"))
             .withHeader(Header.header("sessionToken", "test-token"))
             .withBody(anyString())
             .withCookie("cookie", "test-cookie"),

--- a/symphony-bdk-legacy/build.gradle
+++ b/symphony-bdk-legacy/build.gradle
@@ -66,8 +66,8 @@ subprojects {
 
     dependencies {
         constraints {
-            compileOnly 'org.projectlombok:lombok:1.18.12'
-            annotationProcessor 'org.projectlombok:lombok:1.18.12'
+            compileOnly 'org.projectlombok:lombok:1.18.16'
+            annotationProcessor 'org.projectlombok:lombok:1.18.16'
 
             implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
 
@@ -115,8 +115,8 @@ subprojects {
             implementation 'org.symphonyoss.symphony:messageml:0.9.60'
             implementation 'io.micrometer:micrometer-registry-prometheus:1.5.1'
 
-            testCompileOnly 'org.projectlombok:lombok:1.18.12'
-            testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
+            testCompileOnly 'org.projectlombok:lombok:1.18.16'
+            testAnnotationProcessor 'org.projectlombok:lombok:1.18.16'
 
             implementation 'junit:junit:4.13.1'
             implementation 'org.mockito:mockito-core:3.6.0'

--- a/symphony-bdk-legacy/symphony-api-client-java/src/main/java/authentication/SymOBOAuth.java
+++ b/symphony-bdk-legacy/symphony-api-client-java/src/main/java/authentication/SymOBOAuth.java
@@ -89,18 +89,16 @@ public final class SymOBOAuth extends APIClient implements ISymOBOAuth {
   }
 
   public SymOBOUserAuth getUserAuth(final String username) {
-        SymOBOUserAuth userAuth = new SymOBOUserAuth(config,
-                sessionAuthClient, username, this);
-        userAuth.authenticate();
-        return userAuth;
-    }
+    SymOBOUserAuth userAuth = new SymOBOUserAuth(config, sessionAuthClient, username, this, timeout);
+    userAuth.authenticate();
+    return userAuth;
+  }
 
-    public SymOBOUserAuth getUserAuth(final Long uid) {
-        SymOBOUserAuth userAuth = new SymOBOUserAuth(config, sessionAuthClient,
-                uid, this);
-        userAuth.authenticate();
-        return userAuth;
-    }
+  public SymOBOUserAuth getUserAuth(final Long uid) {
+    SymOBOUserAuth userAuth = new SymOBOUserAuth(config, sessionAuthClient, uid, this, timeout);
+    userAuth.authenticate();
+    return userAuth;
+  }
 
     public void sessionAppAuthenticate() {
         if (config != null) {
@@ -115,8 +113,7 @@ public final class SymOBOAuth extends APIClient implements ISymOBOAuth {
                 try {
                     handleError(response, null);
                 } catch (Exception e) {
-                    logger.error("Unexpected error, "
-                            + "retry authentication in " + this.timeout + " seconds");
+                  logger.error("Unexpected error, retry authentication in {} seconds", this.timeout);
                 }
                 try {
                     TimeUnit.SECONDS.sleep(this.timeout);

--- a/symphony-bdk-legacy/symphony-api-client-java/src/main/java/authentication/SymOBOUserAuth.java
+++ b/symphony-bdk-legacy/symphony-api-client-java/src/main/java/authentication/SymOBOUserAuth.java
@@ -2,14 +2,16 @@ package authentication;
 
 import clients.symphony.api.APIClient;
 import configuration.SymConfig;
+import model.SessionToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.concurrent.TimeUnit;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import model.SessionToken;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class SymOBOUserAuth extends APIClient implements ISymAuth {
   private final Logger logger = LoggerFactory.getLogger(SymOBOUserAuth.class);
@@ -34,11 +36,31 @@ public final class SymOBOUserAuth extends APIClient implements ISymAuth {
 
   public SymOBOUserAuth(final SymConfig config,
       final Client sessionAuthClient,
+      final Long uid, final ISymOBOAuth appAuth, int timeout) {
+    this.config = config;
+    this.sessionAuthClient = sessionAuthClient;
+    this.uid = uid;
+    this.appAuth = appAuth;
+    this.timeout = timeout;
+  }
+
+  public SymOBOUserAuth(final SymConfig config,
+      final Client sessionAuthClient,
       final String username, final ISymOBOAuth appAuth) {
     this.config = config;
     this.sessionAuthClient = sessionAuthClient;
     this.username = username;
     this.appAuth = appAuth;
+  }
+
+  public SymOBOUserAuth(final SymConfig config,
+      final Client sessionAuthClient,
+      final String username, final ISymOBOAuth appAuth, int timeout) {
+    this.config = config;
+    this.sessionAuthClient = sessionAuthClient;
+    this.username = username;
+    this.appAuth = appAuth;
+    this.timeout = timeout;
   }
 
   /** Constructor for testing purpose only */


### PR DESCRIPTION
### Ticket
PLAT-10295

### Description
Bump version to 2.0.0-SNAPSHOT (will be 2.0.0-RC1 in the RC branch)
Update documentation to use 2.0.0 as we expect most of of the readers to
use this version forward.

Use a branch version for Swagger spec for stability and reproductible
builds.

Upgrade dependencies (Spring Boot to 2.4.1 and others)
It caused one of the test to fail because the content type header is a
bit different, relaxed the test to pass.

### Dependencies
Next will be the creation on a 2.0-rc branch.
Upcoming PR on generator.

### Checklist
- [X] Referenced a ticket in the PR title and in the corresponding section
- [X] Filled properly the description and dependencies, if any
- [X] Unit tests updated or added
- [X] Javadoc added or updated
- [X] Updated the documentation in [docs folder](../docs)
