### PR TITLE
PLAT-10294: Upgrade messageml lib to 0.9.64

### DIFF
--- a/symphony-bdk-legacy/build.gradle
+++ b/symphony-bdk-legacy/build.gradle
@@ -112,7 +112,7 @@ subprojects {
             implementation 'org.springframework.boot:spring-boot-starter-test:2.3.5.RELEASE'
             implementation 'org.springframework.security:spring-security-test:5.3.5.RELEASE'
 
-            implementation 'org.symphonyoss.symphony:messageml:0.9.60'
+            implementation 'org.symphonyoss.symphony:messageml:0.9.64'
             implementation 'io.micrometer:micrometer-registry-prometheus:1.5.1'
 
             testCompileOnly 'org.projectlombok:lombok:1.18.16'


### PR DESCRIPTION
### Ticket
PLAT-10294

### Description
This version forces UTF-8 to be used when parsing messageML.
If the bot was not running with UTF-8 encoding special characters
handling could fail when reading messages.

### Dependencies
https://github.com/symphonyoss/messageml-utils/issues/229

### Checklist
- [X] Referenced a ticket in the PR title and in the corresponding section
- [X] Filled properly the description and dependencies, if any
- [N/A] Unit tests updated or added
- [N/A] Javadoc added or updated
- [N/A] Updated the documentation in [docs folder](../docs)
