### PR TITLE
PLAT-10113: Create Activity class reacting to room created

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/model/ActivityType.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/model/ActivityType.java
@@ -14,5 +14,9 @@ public enum ActivityType {
   /**
    * Form submitted.
    */
-  FORM
+  FORM,
+  /**
+   * Room created.
+   */
+  ROOM_CREATED
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/room/RoomCreatedActivity.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/room/RoomCreatedActivity.java
@@ -1,0 +1,36 @@
+package com.symphony.bdk.core.activity.room;
+
+import static com.symphony.bdk.core.service.datafeed.util.RealTimeEventsBinder.bindOnRoomCreated;
+
+import com.symphony.bdk.core.activity.AbstractActivity;
+import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
+import com.symphony.bdk.gen.api.model.V4RoomCreated;
+
+import org.apiguardian.api.API;
+
+import java.util.function.Consumer;
+
+/**
+ * A room created activity corresponds to an Room Created event.
+ */
+@API(status = API.Status.STABLE)
+public abstract class RoomCreatedActivity<C extends RoomCreatedContext> extends AbstractActivity<V4RoomCreated, C> {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected void bindToRealTimeEventsSource(Consumer<RealTimeEventListener> realTimeEventsSource) {
+    bindOnRoomCreated(realTimeEventsSource, this::processEvent);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected void beforeMatcher(C context) {
+    super.beforeMatcher(context);
+    // copy room info at the context root level
+    context.setRoom(context.getSourceEvent().getStream());
+  }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/room/RoomCreatedActivity.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/room/RoomCreatedActivity.java
@@ -11,7 +11,7 @@ import org.apiguardian.api.API;
 import java.util.function.Consumer;
 
 /**
- * A room created activity corresponds to an Room Created event.
+ * A room created activity corresponds to a Room Created event.
  */
 @API(status = API.Status.STABLE)
 public abstract class RoomCreatedActivity<C extends RoomCreatedContext> extends AbstractActivity<V4RoomCreated, C> {

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/room/RoomCreatedContext.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/room/RoomCreatedContext.java
@@ -1,0 +1,33 @@
+package com.symphony.bdk.core.activity.room;
+
+import com.symphony.bdk.core.activity.ActivityContext;
+import com.symphony.bdk.gen.api.model.V4Initiator;
+import com.symphony.bdk.gen.api.model.V4RoomCreated;
+
+import com.symphony.bdk.gen.api.model.V4Stream;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apiguardian.api.API;
+
+/**
+ * Default implementation of the {@link ActivityContext} handled by the {@link RoomCreatedActivity}.
+ */
+@Getter
+@Setter
+@API(status = API.Status.STABLE)
+public class RoomCreatedContext extends ActivityContext<V4RoomCreated> {
+
+  /** The room information extracted from event source */
+  private V4Stream room;
+
+  /**
+   * Default constructor matching super.
+   *
+   * @param initiator Activity initiator.
+   * @param sourceEvent Event source of the activity.
+   */
+  public RoomCreatedContext(V4Initiator initiator, V4RoomCreated sourceEvent) {
+    super(initiator, sourceEvent);
+  }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/AbstractDatafeedLoop.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/AbstractDatafeedLoop.java
@@ -76,7 +76,8 @@ abstract class AbstractDatafeedLoop implements DatafeedLoop {
       if (event == null || event.getType() == null) {
         continue;
       }
-      if (this.isSelfGeneratedEvent(event)) {
+      if (!event.getType().equals(RealTimeEventType.ROOMCREATED.name())
+          && this.isSelfGeneratedEvent(event)) {
         continue;
       }
       try {

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/util/RealTimeEventsBinder.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/util/RealTimeEventsBinder.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.core.service.datafeed.util;
 import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
 import com.symphony.bdk.gen.api.model.V4Initiator;
 import com.symphony.bdk.gen.api.model.V4MessageSent;
+import com.symphony.bdk.gen.api.model.V4RoomCreated;
 import com.symphony.bdk.gen.api.model.V4SymphonyElementsAction;
 
 import org.apiguardian.api.API;
@@ -47,6 +48,22 @@ public class RealTimeEventsBinder {
 
       @Override
       public void onSymphonyElementsAction(V4Initiator initiator, V4SymphonyElementsAction event) {
+        target.accept(initiator, event);
+      }
+    });
+  }
+
+  /**
+   * Bind "onRoomCreated" real-time event to a target method.
+   *
+   * @param subscriber The Datafeed real-time events subscriber.
+   * @param target Target method.
+   */
+  public static void bindOnRoomCreated(Consumer<RealTimeEventListener> subscriber, BiConsumer<V4Initiator, V4RoomCreated> target) {
+    subscriber.accept(new RealTimeEventListener() {
+
+      @Override
+      public void onRoomCreated(V4Initiator initiator, V4RoomCreated event) {
         target.accept(initiator, event);
       }
     });

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/room/RoomCreatedActivityTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/room/RoomCreatedActivityTest.java
@@ -1,0 +1,55 @@
+package com.symphony.bdk.core.activity.room;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.symphony.bdk.core.service.datafeed.DatafeedLoop;
+import com.symphony.bdk.gen.api.model.V4Initiator;
+import com.symphony.bdk.gen.api.model.V4RoomCreated;
+import com.symphony.bdk.gen.api.model.V4Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class RoomCreatedActivityTest {
+
+  private TestRoomCreatedActivity activity;
+
+  @Mock DatafeedLoop datafeedLoop;
+
+  @BeforeEach
+  void setUp() {
+    activity = new TestRoomCreatedActivity();
+    activity.bindToRealTimeEventsSource(datafeedLoop::subscribe);
+  }
+
+  @Test
+  void testMatcher() {
+    activity.setMatcher(c -> c.getRoom().getStreamId().equals("test-room-id"));
+
+    final RoomCreatedContext context = createContext();
+
+    context.setRoom(new V4Stream().streamId("test-room-id"));
+    assertTrue(activity.matcher().matches(context));
+  }
+
+  @Test
+  void testBeforeMatcher() {
+    final String streamId = "test-room-id";
+
+    final RoomCreatedContext context = createContext();
+    context.getSourceEvent().setStream(new V4Stream().streamId(streamId));
+
+    activity.beforeMatcher(context);
+
+    assertEquals(context.getRoom().getStreamId(), streamId);
+  }
+
+  private static RoomCreatedContext createContext() {
+    return new RoomCreatedContext(new V4Initiator(), new V4RoomCreated());
+  }
+}

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/room/TestRoomCreatedActivity.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/room/TestRoomCreatedActivity.java
@@ -1,0 +1,41 @@
+package com.symphony.bdk.core.activity.room;
+
+import com.symphony.bdk.core.activity.ActivityMatcher;
+import com.symphony.bdk.core.activity.model.ActivityInfo;
+import com.symphony.bdk.core.activity.model.ActivityType;
+
+import lombok.Setter;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class TestRoomCreatedActivity extends RoomCreatedActivity<RoomCreatedContext> {
+
+  @Setter
+  private Consumer<RoomCreatedContext> onActivity = c -> {};
+  @Setter
+  private Function<RoomCreatedContext, Boolean> matcher = c -> true;
+  @Setter
+  private Consumer<RoomCreatedContext> beforeMatcher = c -> {};
+
+  @Override
+  protected ActivityMatcher<RoomCreatedContext> matcher() {
+    return this.matcher::apply;
+  }
+
+  @Override
+  protected void onActivity(RoomCreatedContext context) {
+    this.onActivity.accept(context);
+  }
+
+  @Override
+  protected void beforeMatcher(RoomCreatedContext context) {
+    super.beforeMatcher(context);
+    this.beforeMatcher.accept(context);
+  }
+
+  @Override
+  protected ActivityInfo info() {
+    return new ActivityInfo().type(ActivityType.ROOM_CREATED);
+  }
+}

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/util/RealTimeEventsBinderTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/util/RealTimeEventsBinderTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
 import com.symphony.bdk.gen.api.model.V4Initiator;
 import com.symphony.bdk.gen.api.model.V4MessageSent;
+import com.symphony.bdk.gen.api.model.V4RoomCreated;
 import com.symphony.bdk.gen.api.model.V4SymphonyElementsAction;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +48,15 @@ class RealTimeEventsBinderTest {
     final BiConsumer<V4Initiator, V4SymphonyElementsAction> methodToBind = (initiator, v4SymphonyElementsAction) -> methodCalled.set(true);
     RealTimeEventsBinder.bindOnSymphonyElementsAction(this.realTimeEventsProvider::setListener, methodToBind);
     this.realTimeEventsProvider.trigger(l -> l.onSymphonyElementsAction(new V4Initiator(), new V4SymphonyElementsAction()));
+    assertTrue(methodCalled.get());
+  }
+
+  @Test
+  void testBindOnRoomCreated() {
+    final AtomicBoolean methodCalled = new AtomicBoolean(false);
+    final BiConsumer<V4Initiator, V4RoomCreated> methodToBind = (initiator, v4RoomCreated) -> methodCalled.set(true);
+    RealTimeEventsBinder.bindOnRoomCreated(this.realTimeEventsProvider::setListener, methodToBind);
+    this.realTimeEventsProvider.trigger(l -> l.onRoomCreated(new V4Initiator(), new V4RoomCreated()));
     assertTrue(methodCalled.get());
   }
 

--- a/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/activity/GifActivityMain.java
+++ b/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/activity/GifActivityMain.java
@@ -54,6 +54,8 @@ public class GifActivityMain {
     // register a "formReply" activity that handles the Gif category form submission
     bdk.activities().register(new GifFormReplyActivity());
 
+    bdk.activities().register(new GifRoomCreatedActivity());
+
     // display activities documentation in the console
     reportActivities(bdk.activities());
 

--- a/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/activity/GifRoomCreatedActivity.java
+++ b/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/activity/GifRoomCreatedActivity.java
@@ -1,0 +1,28 @@
+package com.symphony.bdk.examples.activity;
+
+import com.symphony.bdk.core.activity.ActivityMatcher;
+import com.symphony.bdk.core.activity.model.ActivityInfo;
+import com.symphony.bdk.core.activity.model.ActivityType;
+import com.symphony.bdk.core.activity.room.RoomCreatedActivity;
+import com.symphony.bdk.core.activity.room.RoomCreatedContext;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GifRoomCreatedActivity extends RoomCreatedActivity<RoomCreatedContext> {
+
+  @Override
+  protected ActivityMatcher<RoomCreatedContext> matcher() {
+    return context -> context.getRoom().getRoomName().contains("Gif-room");
+  }
+
+  @Override
+  protected void onActivity(RoomCreatedContext context) {
+    log.info("Gif Room is just created!");
+  }
+
+  @Override
+  protected ActivityInfo info() {
+    return new ActivityInfo().type(ActivityType.ROOM_CREATED).name("Room created activity info");
+  }
+}


### PR DESCRIPTION
### Ticket
[PLAT-10113](https://perzoinc.atlassian.net/browse/PLAT-10113)

### Description
RoomCreatedActivity class created to reacting to room created real-time events.

Created class RoomCreatedContext to be handled by the RoomCreatedActivity containing the information of the created room.

Created method RealTimeEventsBinder#bindOnRoomCreated to bind the "onRoomCreated" real-time event to a target method.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
