### PR TITLE
PLAT-10150: Support of system properties in configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,9 +205,10 @@ look like:
 }
 ``` 
 
-In both formats, you can use system properties. For instance, `${user.home}` in any field will be replaced by the actual
-value of system property `user.home`. If a property is not defined, no interpolation will be done and string will be left as is.
-A default value can be provided after `:-`, for instance `${property.name:-defaultValue}`.
+### Field interpolation using system properties
+In both formats, you can use system properties as field values. For instance, `${user.home}` in any field will be
+replaced by the actual value of system property `user.home`. If a property is not defined, no interpolation will be done
+and string will be left as is. A default value can be provided after `:-`, for instance `${property.name:-defaultValue}`.
 Therefore, the following is a valid configuration file:
 
 ```json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,11 +206,13 @@ look like:
 ``` 
 
 In both formats, you can use system properties. For instance, `${user.home}` in any field will be replaced by the actual
-value of system property `user.home`. Therefore, the following is a valid configuration file:
+value of system property `user.home`. If a property is not defined, no interpolation will be done and string will be left as is.
+A default value can be provided after `:-`, for instance `${property.name:-defaultValue}`.
+Therefore, the following is a valid configuration file:
 
 ```json
 {
-  "host": "acme.symphony.com",
+  "host": "${subdomain:-acme}.symphony.com",
   "bot": {
     "username": "bot-username",
     "privateKey": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,6 +221,7 @@ Therefore, the following is a valid configuration file:
   }
 }
 ```
+Please mind that if you want to escape the `$` sign, `$${value}` will be replaced by `${value}`.
 
 Reading a `JSON` configuration file is completely transparent: 
 ```java

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -204,6 +204,22 @@ look like:
   }
 }
 ``` 
+
+In both formats, you can use system properties. For instance, `${user.home}` in any field will be replaced by the actual
+value of system property `user.home`. Therefore, the following is a valid configuration file:
+
+```json
+{
+  "host": "acme.symphony.com",
+  "bot": {
+    "username": "bot-username",
+    "privateKey": {
+      "path": "${user.home}/rsa-private-key.pem"
+    }
+  }
+}
+```
+
 Reading a `JSON` configuration file is completely transparent: 
 ```java
 public class Example {

--- a/docs/spring-boot/app-starter.md
+++ b/docs/spring-boot/app-starter.md
@@ -95,7 +95,7 @@ bdk-app:
     cors: # enable Cross-Origin Resource Sharing (CORS) communication
       "[/**]": # url mapping
         allowed-origins: "*" # list of allowed origins path pattern that be specific origins,
-        allowed-credentials: true # Access-Control-Allow-Credentials response header for CORS request
+        allowed-credentials: false # Access-Control-Allow-Credentials response header for CORS request
         allowed-method: ["POST", "GET"] # list of HTTP methods to allow
         allowed-headers: "*" # list of headers that a request can list as allowed (multiple values allowed by using ["header-name-1", "header-name-2"])
         exposed-headers: ["header-name-1", "header-name-2"] # list of response headers that a response can have and can be exposed, the value "*" is not allowed for this field.

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -41,6 +41,7 @@ dependencies {
         api 'commons-codec:commons-codec:1.15'
         api 'commons-beanutils:commons-beanutils:1.9.4'
         api 'org.apache.commons:commons-lang3:3.11'
+        api 'org.apache.commons:commons-text:1.9'
         api 'commons-logging:commons-logging:1.2'
         api 'com.brsanthu:migbase64:2.2'
         api 'io.jsonwebtoken:jjwt:0.9.1'

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
     implementation 'commons-io:commons-io'
     implementation 'org.apache.commons:commons-lang3'
+    implementation 'org.apache.commons:commons-text'
     implementation 'com.brsanthu:migbase64'
     implementation 'io.jsonwebtoken:jjwt'
     implementation 'org.bouncycastle:bcpkix-jdk15on'

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/BdkConfigParser.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/BdkConfigParser.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.text.StringSubstitutor;
 import org.apiguardian.api.API;
 
 import java.io.BufferedReader;
@@ -27,10 +28,11 @@ class BdkConfigParser {
     public static JsonNode parse(InputStream inputStream) throws BdkConfigException {
         JSON_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         YAML_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        String content = new BufferedReader(
-                new InputStreamReader(inputStream, StandardCharsets.UTF_8))
-                .lines()
-                .collect(Collectors.joining("\n"));
+
+      String content = StringSubstitutor.replaceSystemProperties(new BufferedReader(
+          new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+          .lines()
+          .collect(Collectors.joining("\n")));
         try {
             return JSON_MAPPER.readTree(content);
         } catch (IOException e) {

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/BdkConfigParser.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/BdkConfigParser.java
@@ -63,8 +63,8 @@ class BdkConfigParser {
 
     public static void interpolateProperties(JsonNode jsonNode) {
         if (jsonNode.isArray()) {
-            for (final JsonNode objNode : jsonNode) {
-                interpolateProperties(objNode);
+            for (final JsonNode arrayItem : jsonNode) {
+                interpolateProperties(arrayItem);
             }
         } else if (jsonNode.isObject()) {
             interpolatePropertiesInObject((ObjectNode) jsonNode);
@@ -72,9 +72,9 @@ class BdkConfigParser {
     }
 
     private static void interpolatePropertiesInObject(ObjectNode objectNode) {
-        final Iterator<String> stringIterator = objectNode.fieldNames();
-        while (stringIterator.hasNext()) {
-            interpolatePropertyInField(objectNode, stringIterator.next());
+        final Iterator<String> fieldNames = objectNode.fieldNames();
+        while (fieldNames.hasNext()) {
+            interpolatePropertyInField(objectNode, fieldNames.next());
         }
     }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigParserTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigParserTest.java
@@ -33,6 +33,7 @@ public class BdkConfigParserTest {
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config_properties.json");
         JsonNode jsonNode = BdkConfigParser.parse(inputStream);
 
+        assertEquals("${escaped}", jsonNode.at("/host").asText());
         assertEquals("propvalue/privatekey.pem", jsonNode.at("/bot/privateKeyPath").asText());
         assertEquals("default/value/privatekey.pem", jsonNode.at("/app/privateKeyPath").asText());
     }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigParserTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigParserTest.java
@@ -6,21 +6,27 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.symphony.bdk.core.config.exception.BdkConfigException;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 
 public class BdkConfigParserTest {
 
+    @AfterEach
+    void tearDown() {
+        System.clearProperty("my.property");
+    }
+
     @Test
-    public void parseJsonConfigTest() throws BdkConfigException {
+    void parseJsonConfigTest() throws BdkConfigException {
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config.json");
         JsonNode jsonNode = BdkConfigParser.parse(inputStream);
         assertEquals("tibot", jsonNode.at("/bot").at("/username").asText());
     }
 
     @Test
-    public void parseJsonConfigWithPropertyTest() throws BdkConfigException {
+    void parseJsonConfigWithPropertyTest() throws BdkConfigException {
         System.setProperty("my.property", "propvalue");
 
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config_properties.json");
@@ -29,14 +35,23 @@ public class BdkConfigParserTest {
     }
 
     @Test
-    public void parseYamlConfigTest() throws BdkConfigException {
+    void parseJsonConfigWithPropertyContainingSpecialCharsTest() throws BdkConfigException {
+        System.setProperty("my.property", "propvalue:\"\n");
+
+        InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config_properties.json");
+        JsonNode jsonNode = BdkConfigParser.parse(inputStream);
+        assertEquals("propvalue:\"\n/privatekey.pem", jsonNode.at("/bot").at("/privateKeyPath").asText());
+    }
+
+    @Test
+    void parseYamlConfigTest() throws BdkConfigException {
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config.yaml");
         JsonNode jsonNode = BdkConfigParser.parse(inputStream);
         assertEquals("tibot", jsonNode.at("/bot").at("/username").asText());
     }
 
     @Test
-    public void parseYamlConfigWithPropertyTest() throws BdkConfigException {
+    void parseYamlConfigWithPropertyTest() throws BdkConfigException {
         System.setProperty("my.property", "propvalue");
 
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config_properties.yaml");
@@ -45,7 +60,23 @@ public class BdkConfigParserTest {
     }
 
     @Test
-    public void parseInvalidConfigTest() {
+    void parseYamlConfigWithPropertiesInArray() throws BdkConfigException {
+        System.setProperty("my.property", "agent-lb.acme.org");
+
+        InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config_lb_properties.yaml");
+        final JsonNode loadBalancing = BdkConfigParser.parse(inputStream).at("/agent/loadBalancing");
+
+        assertEquals("roundRobin", loadBalancing.at("/mode").asText());
+        assertEquals(true, loadBalancing.at("/stickiness").asBoolean());
+
+        assertEquals("agent1.acme.org", loadBalancing.at("/nodes/0/host").asText());
+        assertEquals(1234, loadBalancing.at("/nodes/0/port").asInt());
+
+        assertEquals("agent-lb.acme.org", loadBalancing.at("/nodes/1/host").asText());
+    }
+
+    @Test
+    void parseInvalidConfigTest() {
         BdkConfigException exception = assertThrows(BdkConfigException.class, () -> {
             InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/invalid_config.html");
             BdkConfigParser.parse(inputStream);
@@ -54,7 +85,7 @@ public class BdkConfigParserTest {
     }
 
     @Test
-    public void parseInvalidYamlConfigTest() {
+    void parseInvalidYamlConfigTest() {
         BdkConfigException exception = assertThrows(BdkConfigException.class, () -> {
             InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/invalid_config.yaml");
             BdkConfigParser.parse(inputStream);

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigParserTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigParserTest.java
@@ -1,12 +1,14 @@
 package com.symphony.bdk.core.config;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.symphony.bdk.core.config.exception.BdkConfigException;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class BdkConfigParserTest {
 
@@ -14,14 +16,32 @@ public class BdkConfigParserTest {
     public void parseJsonConfigTest() throws BdkConfigException {
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config.json");
         JsonNode jsonNode = BdkConfigParser.parse(inputStream);
-        assertEquals(jsonNode.at("/bot").at("/username").asText(), "tibot");
+        assertEquals("tibot", jsonNode.at("/bot").at("/username").asText());
+    }
+
+    @Test
+    public void parseJsonConfigWithPropertyTest() throws BdkConfigException {
+        System.setProperty("my.property", "propvalue");
+
+        InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config_properties.json");
+        JsonNode jsonNode = BdkConfigParser.parse(inputStream);
+        assertEquals("propvalue/privatekey.pem", jsonNode.at("/bot").at("/privateKeyPath").asText());
     }
 
     @Test
     public void parseYamlConfigTest() throws BdkConfigException {
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config.yaml");
         JsonNode jsonNode = BdkConfigParser.parse(inputStream);
-        assertEquals(jsonNode.at("/bot").at("/username").asText(), "tibot");
+        assertEquals("tibot", jsonNode.at("/bot").at("/username").asText());
+    }
+
+    @Test
+    public void parseYamlConfigWithPropertyTest() throws BdkConfigException {
+        System.setProperty("my.property", "propvalue");
+
+        InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config_properties.yaml");
+        JsonNode jsonNode = BdkConfigParser.parse(inputStream);
+        assertEquals("propvalue/privatekey.pem", jsonNode.at("/bot").at("/privateKey").at("/path").asText());
     }
 
     @Test
@@ -30,7 +50,7 @@ public class BdkConfigParserTest {
             InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/invalid_config.html");
             BdkConfigParser.parse(inputStream);
         });
-        assertEquals(exception.getMessage(), "Config file is not in a valid format");
+        assertEquals("Config file is not in a valid format", exception.getMessage());
     }
 
     @Test
@@ -39,6 +59,6 @@ public class BdkConfigParserTest {
             InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/invalid_config.yaml");
             BdkConfigParser.parse(inputStream);
         });
-        assertEquals(exception.getMessage(), "Config file is not in a valid format");
+        assertEquals("Config file is not in a valid format", exception.getMessage());
     }
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigParserTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigParserTest.java
@@ -32,7 +32,9 @@ public class BdkConfigParserTest {
 
         InputStream inputStream = BdkConfigLoaderTest.class.getResourceAsStream("/config/config_properties.json");
         JsonNode jsonNode = BdkConfigParser.parse(inputStream);
+
         assertEquals("propvalue/privatekey.pem", jsonNode.at("/bot/privateKeyPath").asText());
+        assertEquals("default/value/privatekey.pem", jsonNode.at("/app/privateKeyPath").asText());
     }
 
     @Test

--- a/symphony-bdk-core/src/test/resources/config/config_lb_properties.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config_lb_properties.yaml
@@ -1,0 +1,8 @@
+agent:
+  loadBalancing:
+    mode: roundRobin
+    stickiness: true
+    nodes:
+      - host: agent1.acme.org
+        port: 1234
+      - host: ${my.property}

--- a/symphony-bdk-core/src/test/resources/config/config_properties.json
+++ b/symphony-bdk-core/src/test/resources/config/config_properties.json
@@ -1,0 +1,21 @@
+{
+    "_version": "2.0",
+
+    "pod": {
+        "host": "devx1.symphony.com"
+    },
+    "agent": {
+        "host": "devx1.symphony.com"
+    },
+    "keyManager": {
+        "host": "devx1.symphony.com"
+    },
+    "bot": {
+        "username": "tibot",
+        "privateKeyPath": "${my.property}/privatekey.pem"
+    },
+    "app": {
+        "appId": "tibapp",
+        "privateKeyPath": "/Users/local/conf/agent/privatekey.pem"
+    }
+}

--- a/symphony-bdk-core/src/test/resources/config/config_properties.json
+++ b/symphony-bdk-core/src/test/resources/config/config_properties.json
@@ -1,21 +1,12 @@
 {
     "_version": "2.0",
 
-    "pod": {
-        "host": "devx1.symphony.com"
-    },
-    "agent": {
-        "host": "devx1.symphony.com"
-    },
-    "keyManager": {
-        "host": "devx1.symphony.com"
-    },
     "bot": {
         "username": "tibot",
         "privateKeyPath": "${my.property}/privatekey.pem"
     },
     "app": {
         "appId": "tibapp",
-        "privateKeyPath": "/Users/local/conf/agent/privatekey.pem"
+        "privateKeyPath": "${other.property:-default/value}/privatekey.pem"
     }
 }

--- a/symphony-bdk-core/src/test/resources/config/config_properties.json
+++ b/symphony-bdk-core/src/test/resources/config/config_properties.json
@@ -1,6 +1,8 @@
 {
     "_version": "2.0",
 
+    "host" : "$${escaped}",
+
     "bot": {
         "username": "tibot",
         "privateKeyPath": "${my.property}/privatekey.pem"

--- a/symphony-bdk-core/src/test/resources/config/config_properties.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config_properties.yaml
@@ -1,0 +1,20 @@
+_version: '2.0'
+
+pod:
+  host: devx1.symphony.com
+
+agent:
+  host: devx1.symphony.com
+
+keyManager:
+  host: devx1.symphony.com
+
+bot:
+  username: tibot
+  privateKey:
+    path: ${my.property}/privatekey.pem
+
+app:
+  appId: tibapp
+  privateKey:
+    path: /Users/local/conf/agent/privatekey.pem

--- a/symphony-bdk-core/src/test/resources/config/config_properties.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config_properties.yaml
@@ -1,20 +1,7 @@
 _version: '2.0'
 
-pod:
-  host: devx1.symphony.com
-
-agent:
-  host: devx1.symphony.com
-
-keyManager:
-  host: devx1.symphony.com
-
 bot:
   username: tibot
   privateKey:
     path: ${my.property}/privatekey.pem
 
-app:
-  appId: tibapp
-  privateKey:
-    path: /Users/local/conf/agent/privatekey.pem

--- a/symphony-bdk-core/src/test/resources/config/config_recursive_props.json
+++ b/symphony-bdk-core/src/test/resources/config/config_recursive_props.json
@@ -1,0 +1,21 @@
+{
+    "_version": "2.0",
+
+    "pod": {
+        "host": "devx1.symphony.com"
+    },
+    "agent": {
+        "host": "devx1.symphony.com"
+    },
+    "keyManager": {
+        "host": "devx1.symphony.com"
+    },
+    "bot": {
+        "username": "tibot",
+        "privateKeyPath": "${${recursive}}/privatekey.pem"
+    },
+    "app": {
+        "appId": "tibapp",
+        "privateKeyPath": "/Users/local/conf/agent/privatekey.pem"
+    }
+}

--- a/symphony-bdk-core/src/test/resources/config/config_recursive_props.json
+++ b/symphony-bdk-core/src/test/resources/config/config_recursive_props.json
@@ -1,21 +1,8 @@
 {
     "_version": "2.0",
 
-    "pod": {
-        "host": "devx1.symphony.com"
-    },
-    "agent": {
-        "host": "devx1.symphony.com"
-    },
-    "keyManager": {
-        "host": "devx1.symphony.com"
-    },
     "bot": {
         "username": "tibot",
         "privateKeyPath": "${${recursive}}/privatekey.pem"
-    },
-    "app": {
-        "appId": "tibapp",
-        "privateKeyPath": "/Users/local/conf/agent/privatekey.pem"
     }
 }


### PR DESCRIPTION
### Ticket
PLAT-10150

### Description
Before parsing the json or yaml, we apply [StringSubstitutor.replaceSystemProperties](https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StringSubstitutor.html#replaceSystemProperties(java.lang.Object)).

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [ ] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
