### PR TITLE
PLAT-10338 Rename wrong CORS properties names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-ext.projectVersion = '2.0.0-SNAPSHOT'
+ext.projectVersion = '2.1.0-SNAPSHOT'
 ext.isReleaseVersion = !ext.projectVersion.endsWith('SNAPSHOT')
 
 ext.symphonyRepoUrl = project.properties['symphonyRepoUrl'] ?: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'

--- a/docs/spring-boot/app-starter.md
+++ b/docs/spring-boot/app-starter.md
@@ -95,8 +95,8 @@ bdk-app:
     cors: # enable Cross-Origin Resource Sharing (CORS) communication
       "[/**]": # url mapping
         allowed-origins: "*" # list of allowed origins path pattern that be specific origins,
-        allowed-credentials: false # Access-Control-Allow-Credentials response header for CORS request
-        allowed-method: ["POST", "GET"] # list of HTTP methods to allow
+        allow-credentials: false # Access-Control-Allow-Credentials response header for CORS request
+        allowed-methods: ["POST", "GET"] # list of HTTP methods to allow
         allowed-headers: "*" # list of headers that a request can list as allowed (multiple values allowed by using ["header-name-1", "header-name-2"])
         exposed-headers: ["header-name-1", "header-name-2"] # list of response headers that a response can have and can be exposed, the value "*" is not allowed for this field.
     tracing:

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/config/BdkExtAppSecurityConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/config/BdkExtAppSecurityConfig.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.app.spring.config;
 import com.symphony.bdk.app.spring.SymphonyBdkAppProperties;
 import com.symphony.bdk.app.spring.properties.CorsProperties;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -12,6 +13,7 @@ import java.util.Map;
 /**
  * Configuration and injection of the security beans within the Spring application context.
  */
+@Slf4j
 public class BdkExtAppSecurityConfig {
 
   @Bean
@@ -28,14 +30,27 @@ public class BdkExtAppSecurityConfig {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-      for (Map.Entry<String, CorsProperties> urlMapping : properties.getCors().entrySet()) {
-        CorsProperties corsProperties = urlMapping.getValue();
+      for (Map.Entry<String, CorsProperties> urlMapping : this.properties.getCors().entrySet()) {
+        final CorsProperties corsProperties = urlMapping.getValue();
+        warnDeprecatedProperties(corsProperties);
         registry.addMapping(urlMapping.getKey())
             .allowedOrigins(corsProperties.getAllowedOrigins().toArray(new String[0]))
-            .allowCredentials(corsProperties.getAllowedCredentials())
+            .allowCredentials(corsProperties.getAllowCredentials())
             .allowedHeaders(corsProperties.getAllowedHeaders().toArray(new String[0]))
-            .allowedMethods(corsProperties.getAllowedMethod().toArray(new String[0]))
+            .allowedMethods(corsProperties.getAllowedMethods().toArray(new String[0]))
             .exposedHeaders(corsProperties.getExposedHeaders().toArray(new String[0]));
+      }
+    }
+
+    private static void warnDeprecatedProperties(CorsProperties corsProperties) {
+      final String msg = "CORS property '{}' is now deprecated and has been replaced by '{}'. "
+          + "Please update your application.yaml accordingly.";
+
+      if (corsProperties.getAllowedCredentials() != null) {
+        log.warn(msg, "allowed-credentials", "allow-credentials");
+      }
+      if (corsProperties.getAllowedMethod() != null) {
+        log.warn(msg, "allowed-method", "allowed-methods");
       }
     }
   }

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/properties/CorsProperties.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/properties/CorsProperties.java
@@ -2,6 +2,7 @@ package com.symphony.bdk.app.spring.properties;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apiguardian.api.API;
 
 import java.util.Collections;
 import java.util.List;
@@ -19,9 +20,16 @@ public class CorsProperties {
   private List<String> allowedOrigins = Collections.singletonList("/**");
 
   /**
+   * [deprecated] use property "allow-credentials" instead
+   */
+  @Deprecated
+  @API(status = API.Status.DEPRECATED, since = "2.0")
+  private Boolean allowedCredentials = null;
+
+  /**
    * Access-Control-Allow-Credentials response header for CORS request
    */
-  private Boolean allowedCredentials = true;
+  private Boolean allowCredentials = false;
 
   /**
    * List of headers that a request can list as allowed
@@ -34,8 +42,14 @@ public class CorsProperties {
   private List<String> exposedHeaders = Collections.emptyList();
 
   /**
+   * [deprecated] use property "allow-credentials" instead
+   */
+  @Deprecated
+  @API(status = API.Status.DEPRECATED, since = "2.0")
+  private List<String> allowedMethod = null;
+
+  /**
    * List of HTTP methods to allow
    */
-  private List<String> allowedMethod = Collections.emptyList();
-
+  private List<String> allowedMethods = Collections.emptyList();
 }

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/properties/CorsProperties.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/properties/CorsProperties.java
@@ -20,7 +20,7 @@ public class CorsProperties {
   private List<String> allowedOrigins = Collections.singletonList("/**");
 
   /**
-   * [deprecated] use property "allow-credentials" instead
+   * @deprecated use property "allow-credentials" instead
    */
   @Deprecated
   @API(status = API.Status.DEPRECATED, since = "2.0")
@@ -42,7 +42,7 @@ public class CorsProperties {
   private List<String> exposedHeaders = Collections.emptyList();
 
   /**
-   * [deprecated] use property "allow-credentials" instead
+   * @deprecated use property "allow-credentials" instead
    */
   @Deprecated
   @API(status = API.Status.DEPRECATED, since = "2.0")

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/config/BdkExtAppSecurityConfigTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/config/BdkExtAppSecurityConfigTest.java
@@ -27,7 +27,9 @@ public class BdkExtAppSecurityConfigTest {
     final SymphonyBdkAppProperties props = new SymphonyBdkAppProperties();
     final CorsProperties cors = new CorsProperties();
     cors.setAllowedMethod(Collections.singletonList("POST"));
+    cors.setAllowedMethods(Collections.singletonList("POST"));
     cors.setAllowedCredentials(true);
+    cors.setAllowCredentials(true);
     cors.setExposedHeaders(Arrays.asList("header1", "header2"));
     cors.setAllowedHeaders(Arrays.asList("header1", "header2"));
     props.setCors(Collections.singletonMap("*", cors));

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/config/BdkExtAppSecurityConfigTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/config/BdkExtAppSecurityConfigTest.java
@@ -26,10 +26,41 @@ public class BdkExtAppSecurityConfigTest {
     final BdkExtAppSecurityConfig config = new BdkExtAppSecurityConfig();
     final SymphonyBdkAppProperties props = new SymphonyBdkAppProperties();
     final CorsProperties cors = new CorsProperties();
+    cors.setAllowedMethods(Collections.singletonList("GET"));
+    cors.setAllowCredentials(false);
+    cors.setExposedHeaders(Arrays.asList("header1", "header2"));
+    cors.setAllowedHeaders(Arrays.asList("header1", "header2"));
+    props.setCors(Collections.singletonMap("*", cors));
+
+    WebMvcConfigurer configurer = config.corsConfigurer(props);
+    CorsRegistry registry = mock(CorsRegistry.class);
+    CorsRegistration registration = mock(CorsRegistration.class);
+    when(registry.addMapping(any())).thenReturn(registration);
+    when(registration.allowedOrigins(any())).thenReturn(registration);
+    when(registration.allowCredentials(anyBoolean())).thenReturn(registration);
+    when(registration.allowedHeaders(any())).thenReturn(registration);
+    when(registration.allowedMethods(any())).thenReturn(registration);
+    when(registration.exposedHeaders(any())).thenReturn(registration);
+    configurer.addCorsMappings(registry);
+
+    verify(registry).addMapping("*");
+    verify(registration).allowedMethods("GET");
+    verify(registration).exposedHeaders("header1", "header2");
+    verify(registration).allowCredentials(false);
+    verify(registration).allowedOrigins("/**");
+    verify(registration).allowedHeaders("header1", "header2");
+  }
+
+  @Test
+  void createCorsConfigurer_withBackwardCompatibility() {
+
+    final BdkExtAppSecurityConfig config = new BdkExtAppSecurityConfig();
+    final SymphonyBdkAppProperties props = new SymphonyBdkAppProperties();
+    final CorsProperties cors = new CorsProperties();
     cors.setAllowedMethod(Collections.singletonList("POST"));
-    cors.setAllowedMethods(Collections.singletonList("POST"));
+    cors.setAllowedMethods(Collections.singletonList("GET"));
     cors.setAllowedCredentials(true);
-    cors.setAllowCredentials(true);
+    cors.setAllowCredentials(false);
     cors.setExposedHeaders(Arrays.asList("header1", "header2"));
     cors.setAllowedHeaders(Arrays.asList("header1", "header2"));
     props.setCors(Collections.singletonMap("*", cors));


### PR DESCRIPTION
### Ticket
[PLAT-10338](https://perzoinc.atlassian.net/browse/PLAT-10338)

### Description
Renamed CORS properties: 
- allowed-origin → allowed-origin**s**
- allowed-credentials → **allow**-credentials

A `WARN` message is displayed at application startup if old properties are still configured in `application.yaml`. 

#### Why we did that? 
We initially made 2 small mistakes when naming our CORS properties compared to how they are named in Spring Boot: see [CorsProperties](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html).

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
