### PR TITLE
PLAT-10151: Support of classpath paths in configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ public class Example {
 ```
 1. Load configuration from a system location path
 2. Load configuration from a classpath location
-3. Load configuration from an [`InputStream`](https://docs.oracle.com/javase/7/docs/api/java/io/InputStream.html)
+3. Load configuration from an [`InputStream`](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html)
 4. Load configuration from the Symphony directory. The Symphony directory is located under your `${user.home}/.symphony` 
     folder. It can be useful when you don't want to share your own Symphony credentials within your project codebase
 5. Last but not least, you can obviously define your configuration object as a [POJO](https://en.wikipedia.org/wiki/Plain_old_Java_object) 
@@ -84,17 +84,21 @@ sessionAuth:
 
 bot:
   username: bot-name
-  privateKeyPath: /path/to/bot/rsa-private-key.pem
-  certificatePath: /path/to/bot-certificate.p12
-  certificatePassword: changeit
+  privateKey:
+    path: /path/to/bot/rsa-private-key.pem
+  certificate:
+    path: /path/to/bot-certificate.p12
+    password: changeit
 
 ssl:
-  trustStorePath: /path/to/all_symphony_certs_truststore
-  trustStorePassword: changeit
+  trustStore:
+    path: /path/to/all_symphony_certs_truststore
+    password: changeit
 
 app:
   appId: app-id
-  privateKeyPath: path/to/private-key.pem
+  privateKey:
+    path: path/to/private-key.pem
 
 datafeed:
   version: v1
@@ -134,6 +138,11 @@ the appId, the private key or the certificate for authenticating the extension a
 - `ssl` contains trustStore and trustStore password for SSL communication.
 - `datafeed` contains information of the datafeed service to be used by the bot.
 - `retry` contains information for retry mechanism to be used by the bot.
+
+Although not recommended for RSA private keys, you can specify paths to classpath resources for the following fields:
+- `bot.privateKey.path`, `bot.certificate.path`
+- `app.privateKey.path`, `app.certificate.path`
+- `ssl.trustStore.path`
 
 #### Retry Configuration
 The retry mechanism used by the bot will be configured by these following properties:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,10 +139,12 @@ the appId, the private key or the certificate for authenticating the extension a
 - `datafeed` contains information of the datafeed service to be used by the bot.
 - `retry` contains information for retry mechanism to be used by the bot.
 
-Although not recommended for RSA private keys, you can specify paths to classpath resources for the following fields:
+Although not recommended for RSA private keys, you can specify absolute paths to classpath resources for the following fields:
 - `bot.privateKey.path`, `bot.certificate.path`
 - `app.privateKey.path`, `app.certificate.path`
 - `ssl.trustStore.path`
+
+Only absolute paths to classpath resources are supported (i.e. paths beginning with `/`).
 
 #### Retry Configuration
 The retry mechanism used by the bot will be configured by these following properties:

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/AuthenticatorFactory.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/AuthenticatorFactory.java
@@ -193,7 +193,7 @@ public class AuthenticatorFactory {
     }
   }
 
-  private static String loadPrivateKey(String privateKeyPath) throws IOException {
+  private static String loadPrivateKey(String privateKeyPath) throws IOException, AuthInitializationException {
     log.debug("Loading private key from : {}", privateKeyPath);
     InputStream is;
 
@@ -202,6 +202,9 @@ public class AuthenticatorFactory {
       log.warn("Warning: Keeping RSA private keys into project resources is dangerous. "
           + "You should consider another location for production.");
       is = AuthenticatorFactory.class.getResourceAsStream(privateKeyPath.replace("classpath:", ""));
+      if (is == null) {
+        throw new AuthInitializationException("Unable to find RSA private key as classpath resource from: " + privateKeyPath);
+      }
     } else {
       is = new FileInputStream(privateKeyPath);
     }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkCertificateConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkCertificateConfig.java
@@ -73,7 +73,10 @@ public class BdkCertificateConfig {
     try {
       if (filePath.startsWith("classpath:")) {
         final URL resource = getClass().getResource(filePath.replace("classpath:", ""));
-        return Files.readAllBytes(Paths.get(resource.toURI()));
+        if (resource != null) {
+          return Files.readAllBytes(Paths.get(resource.toURI()));
+        }
+        throw new ApiClientInitializationException("File not found in classpath: " + filePath);
       }
       return Files.readAllBytes(new File(filePath).toPath());
     } catch (IOException | URISyntaxException e) {

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkCertificateConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkCertificateConfig.java
@@ -10,7 +10,10 @@ import org.apiguardian.api.API;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @Getter
 @Setter
@@ -68,8 +71,12 @@ public class BdkCertificateConfig {
 
   private byte[] getBytesFromFile(String filePath) {
     try {
+      if (filePath.startsWith("classpath:")) {
+        final URL resource = getClass().getResource(filePath.replace("classpath:", ""));
+        return Files.readAllBytes(Paths.get(resource.toURI()));
+      }
       return Files.readAllBytes(new File(filePath).toPath());
-    } catch (IOException e) {
+    } catch (IOException | URISyntaxException e) {
       throw new ApiClientInitializationException("Could not read file " + filePath, e);
     }
   }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/AuthenticatorFactoryTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/AuthenticatorFactoryTest.java
@@ -67,6 +67,24 @@ class AuthenticatorFactoryTest {
   }
 
   @Test
+  void testGetBotAuthenticatorWithValidPrivateKeyInClasspath() throws AuthInitializationException {
+    final BdkConfig config = createRsaConfig(() -> "classpath:/keys/private-key.pem");
+
+    final AuthenticatorFactory factory = new AuthenticatorFactory(config, DUMMY_API_CLIENT_FACTORY);
+    final BotAuthenticator botAuth = factory.getBotAuthenticator();
+    assertNotNull(botAuth);
+    assertEquals(BotAuthenticatorRsaImpl.class, botAuth.getClass());
+  }
+
+  @Test
+  void testGetBotAuthenticatorWithPrivateKeyNotFoundInClasspath() {
+    final BdkConfig config = createRsaConfig(() -> "classpath:/keys/notfound.pem");
+
+    final AuthenticatorFactory factory = new AuthenticatorFactory(config, DUMMY_API_CLIENT_FACTORY);
+    assertThrows(AuthInitializationException.class, () -> factory.getBotAuthenticator());
+  }
+
+  @Test
   void testGetAuthenticatorWithValidPrivateKeyContent() throws AuthInitializationException {
 
     final BdkConfig config = new BdkConfig();

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigTest.java
@@ -1,8 +1,12 @@
 package com.symphony.bdk.core.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.symphony.bdk.core.client.exception.ApiClientInitializationException;
 import com.symphony.bdk.core.config.model.BdkBotConfig;
+import com.symphony.bdk.core.config.model.BdkCertificateConfig;
 import com.symphony.bdk.core.config.model.BdkConfig;
 import com.symphony.bdk.core.config.model.BdkExtAppConfig;
 
@@ -11,7 +15,7 @@ import org.junit.jupiter.api.Test;
 public class BdkConfigTest {
 
   @Test
-  public void testIsBotCertificateAuthenticationConfigured() {
+  void testIsBotCertificateAuthenticationConfigured() {
     assertIsCertificateAuthenticationConfigured(null, null, false);
     assertIsCertificateAuthenticationConfigured("", "", false);
 
@@ -22,7 +26,7 @@ public class BdkConfigTest {
   }
 
   @Test
-  public void testIsOboConfigured() {
+  void testIsOboConfigured() {
     assertIsOboConfigured(null, "pk", null, null, false);
     assertIsOboConfigured(null, null, "cert", "pass", false);
 
@@ -35,6 +39,22 @@ public class BdkConfigTest {
     assertIsOboConfigured("appId", null, "cert", "", true);
     assertIsOboConfigured("appId", null, "cert", "pass", true);
   }
+
+  @Test
+  void testBdkCertificateConfigFromClasspath() {
+    BdkCertificateConfig certificateConfig = new BdkCertificateConfig("classpath:/certs/identity.p12", "password");
+    final byte[] certificateBytes = certificateConfig.getCertificateBytes();
+
+    assertTrue(certificateBytes != null && certificateBytes.length > 0);
+  }
+
+  @Test
+  void testBdkCertificateConfigNotFoundInClasspath() {
+    BdkCertificateConfig certificateConfig = new BdkCertificateConfig("classpath:/certs/notfound", "password");
+
+    assertThrows(ApiClientInitializationException.class, () -> certificateConfig.getCertificateBytes());
+  }
+
 
   private void assertIsCertificateAuthenticationConfigured(String certificatePath, String certificatePassword,
       boolean expected) {


### PR DESCRIPTION
### Ticket
PLAT-10151

### Description
Support of classpath resource paths in configuration for certificates and truststore.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [ ] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
