### PR TITLE
PLAT-10112: Create Activity class reacting to user joined room event.

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/model/ActivityType.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/model/ActivityType.java
@@ -14,5 +14,9 @@ public enum ActivityType {
   /**
    * Form submitted.
    */
-  FORM
+  FORM,
+  /**
+   * User joined room.
+   */
+  USER_JOINED_ROOM
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/room/UserJoinedRoomActivity.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/room/UserJoinedRoomActivity.java
@@ -1,0 +1,37 @@
+package com.symphony.bdk.core.activity.room;
+
+import static com.symphony.bdk.core.service.datafeed.util.RealTimeEventsBinder.bindOnUserJoinedRoom;
+
+import com.symphony.bdk.core.activity.AbstractActivity;
+import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
+import com.symphony.bdk.gen.api.model.V4UserJoinedRoom;
+
+import org.apiguardian.api.API;
+
+import java.util.function.Consumer;
+
+/**
+ * A user-joined-room activity corresponds to an User joined room event.
+ */
+@API(status = API.Status.STABLE)
+public abstract class UserJoinedRoomActivity<C extends UserJoinedRoomContext>
+    extends AbstractActivity<V4UserJoinedRoom, C> {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected void bindToRealTimeEventsSource(Consumer<RealTimeEventListener> realTimeEventsSource) {
+    bindOnUserJoinedRoom(realTimeEventsSource, this::processEvent);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected void beforeMatcher(C context) {
+    super.beforeMatcher(context);
+    context.setRoomId(context.getSourceEvent().getStream().getStreamId());
+    context.setUserId(context.getSourceEvent().getAffectedUser().getUserId());
+  }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/room/UserJoinedRoomContext.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/room/UserJoinedRoomContext.java
@@ -1,0 +1,32 @@
+package com.symphony.bdk.core.activity.room;
+
+import com.symphony.bdk.core.activity.ActivityContext;
+import com.symphony.bdk.gen.api.model.V4Initiator;
+import com.symphony.bdk.gen.api.model.V4UserJoinedRoom;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apiguardian.api.API;
+
+/**
+ * Default implementation of the {@link ActivityContext} handled by the {@link UserJoinedRoomActivity}.
+ */
+@Getter
+@Setter
+@API(status = API.Status.STABLE)
+public class UserJoinedRoomContext extends ActivityContext<V4UserJoinedRoom> {
+
+  /**
+   * The room id extracted from event source.
+   */
+  private String roomId;
+
+  /**
+   * The user id who joined the room extracted from event source.
+   */
+  private Long userId;
+
+  public UserJoinedRoomContext(V4Initiator initiator, V4UserJoinedRoom sourceEvent) {
+    super(initiator, sourceEvent);
+  }
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/util/RealTimeEventsBinder.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/util/RealTimeEventsBinder.java
@@ -5,6 +5,8 @@ import com.symphony.bdk.gen.api.model.V4Initiator;
 import com.symphony.bdk.gen.api.model.V4MessageSent;
 import com.symphony.bdk.gen.api.model.V4SymphonyElementsAction;
 
+import com.symphony.bdk.gen.api.model.V4UserJoinedRoom;
+
 import org.apiguardian.api.API;
 
 import java.util.function.BiConsumer;
@@ -47,6 +49,21 @@ public class RealTimeEventsBinder {
 
       @Override
       public void onSymphonyElementsAction(V4Initiator initiator, V4SymphonyElementsAction event) {
+        target.accept(initiator, event);
+      }
+    });
+  }
+
+  /**
+   * Bind "onUserJoinedRoom" real-time event to a target method.
+   *
+   * @param subscriber The Datafeed real-time events subscriber.
+   * @param target Target method.
+   */
+  public static void bindOnUserJoinedRoom(Consumer<RealTimeEventListener> subscriber, BiConsumer<V4Initiator, V4UserJoinedRoom> target) {
+    subscriber.accept(new RealTimeEventListener() {
+      @Override
+      public void onUserJoinedRoom(V4Initiator initiator, V4UserJoinedRoom event) {
         target.accept(initiator, event);
       }
     });

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/room/TestUserJoinedRoomActivity.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/room/TestUserJoinedRoomActivity.java
@@ -1,0 +1,42 @@
+package com.symphony.bdk.core.activity.room;
+
+import com.symphony.bdk.core.activity.ActivityMatcher;
+import com.symphony.bdk.core.activity.model.ActivityInfo;
+
+import com.symphony.bdk.core.activity.model.ActivityType;
+
+import lombok.Setter;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class TestUserJoinedRoomActivity extends UserJoinedRoomActivity<UserJoinedRoomContext> {
+
+  @Setter
+  private Consumer<UserJoinedRoomContext> onActivity = c -> {};
+  @Setter
+  private Function<UserJoinedRoomContext, Boolean> matcher = c -> true;
+  @Setter
+  private Consumer<UserJoinedRoomContext> beforeMatcher = c -> {};
+
+  @Override
+  protected ActivityMatcher<UserJoinedRoomContext> matcher() {
+    return this.matcher::apply;
+  }
+
+  @Override
+  protected void onActivity(UserJoinedRoomContext context) {
+    this.onActivity.accept(context);
+  }
+
+  @Override
+  protected ActivityInfo info() {
+    return new ActivityInfo().type(ActivityType.USER_JOINED_ROOM);
+  }
+
+  @Override
+  protected void beforeMatcher(UserJoinedRoomContext context) {
+    super.beforeMatcher(context);
+    this.beforeMatcher.accept(context);
+  }
+}

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/room/UserJoinedRoomActivityTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/room/UserJoinedRoomActivityTest.java
@@ -1,0 +1,59 @@
+package com.symphony.bdk.core.activity.room;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.symphony.bdk.core.service.datafeed.DatafeedLoop;
+import com.symphony.bdk.gen.api.model.V4Initiator;
+import com.symphony.bdk.gen.api.model.V4Stream;
+import com.symphony.bdk.gen.api.model.V4User;
+import com.symphony.bdk.gen.api.model.V4UserJoinedRoom;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UserJoinedRoomActivityTest {
+
+  private TestUserJoinedRoomActivity activity;
+
+  @Mock DatafeedLoop datafeedLoop;
+
+  @BeforeEach
+  void setUp() {
+    activity = new TestUserJoinedRoomActivity();
+    activity.bindToRealTimeEventsSource(datafeedLoop::subscribe);
+  }
+
+  @Test
+  void testMatcher() {
+    activity.setMatcher(c -> c.getRoomId().equals("test-room-id") && c.getUserId() == 1234L);
+
+    final UserJoinedRoomContext context = createContext();
+
+    context.setRoomId("test-room-id");
+    context.setUserId(1234L);
+    assertTrue(activity.matcher().matches(context));
+  }
+
+  @Test
+  void testBeforeMatcher() {
+    final String roomId = "test-room-id";
+
+    final UserJoinedRoomContext context = createContext();
+    context.getSourceEvent().setStream(new V4Stream().streamId(roomId));
+    context.getSourceEvent().setAffectedUser(new V4User().userId(1234L));
+
+    activity.beforeMatcher(context);
+
+    assertEquals(context.getRoomId(), roomId);
+    assertEquals(context.getUserId(), 1234L);
+  }
+
+  private static UserJoinedRoomContext createContext() {
+    return new UserJoinedRoomContext(new V4Initiator(), new V4UserJoinedRoom());
+  }
+}

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/util/RealTimeEventsBinderTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/util/RealTimeEventsBinderTest.java
@@ -7,6 +7,8 @@ import com.symphony.bdk.gen.api.model.V4Initiator;
 import com.symphony.bdk.gen.api.model.V4MessageSent;
 import com.symphony.bdk.gen.api.model.V4SymphonyElementsAction;
 
+import com.symphony.bdk.gen.api.model.V4UserJoinedRoom;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,6 +49,15 @@ class RealTimeEventsBinderTest {
     final BiConsumer<V4Initiator, V4SymphonyElementsAction> methodToBind = (initiator, v4SymphonyElementsAction) -> methodCalled.set(true);
     RealTimeEventsBinder.bindOnSymphonyElementsAction(this.realTimeEventsProvider::setListener, methodToBind);
     this.realTimeEventsProvider.trigger(l -> l.onSymphonyElementsAction(new V4Initiator(), new V4SymphonyElementsAction()));
+    assertTrue(methodCalled.get());
+  }
+
+  @Test
+  void testBindOnUserJoinedRoom() {
+    final AtomicBoolean methodCalled = new AtomicBoolean(false);
+    final BiConsumer<V4Initiator, V4UserJoinedRoom> methodToBind = ((initiator, v4UserJoinedRoom) -> methodCalled.set(true));
+    RealTimeEventsBinder.bindOnUserJoinedRoom(this.realTimeEventsProvider::setListener, methodToBind);
+    this.realTimeEventsProvider.trigger(l -> l.onUserJoinedRoom(new V4Initiator(), new V4UserJoinedRoom()));
     assertTrue(methodCalled.get());
   }
 


### PR DESCRIPTION
### Ticket
[PLAT-10112](https://perzoinc.atlassian.net/browse/PLAT-10112)

### Description
UserJoinedRoomActivity class created to reacting to room created real-time events.

Created class UserJoinedRoomContext to be handled by the UserJoinedRoomActivity containing the information of the room Id and the user Id.

Created method RealTimeEventsBinder#bindOnUserJoinedRoom to bind the "onUserJoinedRoom" real-time event to a target method.

Added Unittest.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
