### PR TITLE
PLAT-10360: Remove Spring warning during startup

### DIFF
--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
@@ -142,7 +142,7 @@ public class SlashAnnotationProcessor implements BeanPostProcessor, ApplicationC
 
   private void registerSlashMethod(Object bean, Method method, Slash annotation) {
     if (this.registry == null) {
-      registry = applicationContext.getBeanFactory().getBean(ActivityRegistry.class);
+      this.registry = applicationContext.getBeanFactory().getBean(ActivityRegistry.class);
     }
     this.registry.register(
         SlashCommand.slash(annotation.value(), annotation.mentionBot(), createSlashCommandCallback(bean, method), annotation.description())

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
@@ -47,9 +47,10 @@ public class SlashAnnotationProcessor implements BeanPostProcessor, ApplicationC
   };
 
   /**
-   * The {@link ActivityRegistry} is used here to register the slash activities
+   * The {@link ActivityRegistry} is used here to register the slash activities.
+   * Lazy-loaded from application context to make sure the processor is registered first before starting to create beans.
    */
-  private final ActivityRegistry registry;
+  private ActivityRegistry registry;
 
   private ConfigurableApplicationContext applicationContext;
 
@@ -140,6 +141,9 @@ public class SlashAnnotationProcessor implements BeanPostProcessor, ApplicationC
   }
 
   private void registerSlashMethod(Object bean, Method method, Slash annotation) {
+    if (this.registry == null) {
+      registry = applicationContext.getBeanFactory().getBean(ActivityRegistry.class);
+    }
     this.registry.register(
         SlashCommand.slash(annotation.value(), annotation.mentionBot(), createSlashCommandCallback(bean, method), annotation.description())
     );

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkActivityConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkActivityConfig.java
@@ -43,7 +43,7 @@ public class BdkActivityConfig {
   }
 
   @Bean
-  public SlashAnnotationProcessor slashAnnotationProcessor(ActivityRegistry registry) {
-    return new SlashAnnotationProcessor(registry);
+  public static SlashAnnotationProcessor slashAnnotationProcessor() {
+    return new SlashAnnotationProcessor();
   }
 }


### PR DESCRIPTION
### Ticket
PLAT-10360

### Description
When Spring integration is used we could see messages such as:

2021-01-08 11:40:18.767  INFO 86263 --- [           main] trationDelegate$BeanPostProcessorChecker : Bean 'com.symphony.bdk.spring.config.BdkActivityConfig' of type [com.symphony.bdk.spring.config.BdkActivityConfig] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)

during startup.

This was caused because the BeanPostProcessor for slash commands has a
dependency on ActivityRegistry. This is a bean that has other beans as
dependencies too. So the processor is created after a few beans has
already been created and Spring warns us that those beans might not have
been processed.

We remove this dependency by not injecting the activity registry during
the processor's construction but by retrieving it only when needed (that
is when we start processing slash commands).

I relied on the existing tests and manual testing to check that the
warning is no longer printed.

### Dependencies
N/A

### Checklist
- [X] Referenced a ticket in the PR title and in the corresponding section
- [X] Filled properly the description and dependencies, if any
- [N/A] Unit tests updated or added
- [N/A] Javadoc added or updated
- [N/A] Updated the documentation in [docs folder](../docs)
