### PR TITLE
PLAT-10379: Run Snyk instead of Github integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,22 @@
-# Java Gradle CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-java/ for more details
-#
-version: 2
+version: 2.1
+
+workflows:
+  build-workflow:
+    jobs:
+      - build
+      - snyk:
+          context:
+            - devx
+          filters:
+            branches:
+              only: master
+
 jobs:
   build:
     docker:
       - image: cimg/openjdk:8.0
 
     working_directory: ~/repo
-
-    environment:
 
     steps:
       - checkout
@@ -23,7 +29,7 @@ jobs:
             - gradle-repo-v1-{{ .Branch }}-{{ checksum "build.gradle" }}
             - gradle-repo-v1-{{ .Branch }}-
             - gradle-repo-v1-
-          # run tests!
+
       - run:
           name: Build
           # Jacoco does not support incremental build so we don't run it automatically with check
@@ -66,3 +72,29 @@ jobs:
           paths:
             - ~/.gradle
           key: gradle-repo-v1-{{ .Branch }}-{{ checksum "build.gradle" }}
+
+  snyk:
+    docker:
+      - image: cimg/openjdk:8.0
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - restore_cache:
+          keys:
+            # when lock file changes, use increasingly general patterns to restore cache
+            - gradle-repo-v1-{{ .Branch }}-{{ checksum "build.gradle" }}
+            - gradle-repo-v1-{{ .Branch }}-
+            - gradle-repo-v1-
+
+      - run:
+          name: Snyk 2.0
+          command: ./gradlew snyk-test snyk-monitor
+
+      - run:
+          name: Snyk legacy
+          command: cd symphony-bdk-legacy && ./gradlew snyk-test snyk-monitor

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id "io.codearte.nexus-staging" version "0.22.0"
+    id "io.snyk.gradle.plugin.snykplugin" version "0.4"
+}
+
 ext.projectVersion = '2.1.0-SNAPSHOT'
 ext.isReleaseVersion = !ext.projectVersion.endsWith('SNAPSHOT')
 
@@ -35,108 +40,17 @@ allprojects {
     defaultTasks 'build'
 }
 
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0'
-    }
-}
-
-apply plugin: 'io.codearte.nexus-staging'
-
-subprojects {
-    apply plugin: 'signing'
-}
-
-tasks.withType(Sign) {
-    onlyIf { ext.isReleaseVersion }
-}
-
 nexusStaging {
     username = rootProject.ext.symphonyRepoUser
     password = rootProject.ext.symphonyRepoPassword
 }
 
-configure(subprojects.findAll { it.name != 'symphony-bdk-bom' }) {
-    apply plugin: 'java'
-    apply plugin: 'jacoco'
-    apply plugin: 'maven-publish'
-
-    repositories {
-        mavenCentral()
-    }
-
-    publishing {
-        publications {
-            maven(MavenPublication) {
-                from(components.java)
-                pom(rootProject.ext.pomDefinition)
-                pom.withXml {
-                    // otherwise project description is evaluated too early
-                    asNode().children().first().plus {
-                        setResolveStrategy(Closure.DELEGATE_FIRST)
-                        'name' project.name
-                        'description' project.description
-                    }
-                }
-            }
-        }
-    }
-
-    signing {
-        required { rootProject.isReleaseVersion }
-        sign publishing.publications.maven
-    }
-
-    sourceCompatibility = '1.8'
-
-    tasks.withType(JavaCompile) {
-        options.encoding = 'UTF-8'
-    }
-
-    javadoc {
-        options.encoding = 'UTF-8'
-        options.addStringOption('Xdoclint:none', '-quiet')
-    }
-
-    java {
-        withJavadocJar()
-        withSourcesJar()
-    }
-
-    jar {
-        manifest {
-            attributes("Implementation-Title": project.name,
-                    "Implementation-Version": project.version)
-        }
-    }
-
-    test {
-        useJUnitPlatform()
-    }
-
-    dependencies {
-        implementation platform(project(':symphony-bdk-bom'))
-        annotationProcessor platform(project(':symphony-bdk-bom'))
-        testAnnotationProcessor platform(project(':symphony-bdk-bom'))
-    }
+// Required for Snyk plugin to work (https://github.com/snyk/gradle-plugin/issues/1)
+repositories {
+    mavenCentral()
 }
 
-// do not publish example modules
-configure(subprojects.findAll { !it.name.contains('example') }) {
-    apply plugin: 'maven-publish'
-
-    publishing {
-        repositories {
-            maven {
-                credentials {
-                    username rootProject.ext.symphonyRepoUser
-                    password rootProject.ext.symphonyRepoPassword
-                }
-                url rootProject.ext.symphonyRepoUrl
-            }
-        }
-    }
+snyk {
+    arguments = '--all-sub-projects'
+    severity = 'high'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}
+
+repositories {
+    gradlePluginPortal()
+}

--- a/buildSrc/src/main/groovy/bdk.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bdk.java-common-conventions.gradle
@@ -1,0 +1,45 @@
+plugins {
+    id 'java'
+    id 'jacoco'
+}
+
+repositories {
+    mavenCentral()
+}
+
+sourceCompatibility = '1.8'
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+javadoc {
+    options.encoding = 'UTF-8'
+    options.addStringOption('Xdoclint:none', '-quiet')
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+jar {
+    manifest {
+        attributes("Implementation-Title": project.name,
+                "Implementation-Version": project.version)
+    }
+}
+
+test {
+    useJUnitPlatform()
+}
+
+dependencies {
+    implementation platform(project(':symphony-bdk-bom'))
+    annotationProcessor platform(project(':symphony-bdk-bom'))
+    testAnnotationProcessor platform(project(':symphony-bdk-bom'))
+}
+
+snyk {
+    severity = 'high'
+}

--- a/buildSrc/src/main/groovy/bdk.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/bdk.java-library-conventions.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'bdk.java-common-conventions'
+    id 'java-library'
+}

--- a/buildSrc/src/main/groovy/bdk.java-publish-conventions.gradle
+++ b/buildSrc/src/main/groovy/bdk.java-publish-conventions.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'maven-publish'
+    id 'signing'
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from(components.java)
+            pom(rootProject.ext.pomDefinition)
+            pom.withXml {
+                // otherwise project description is evaluated too early
+                asNode().children().first().plus {
+                    setResolveStrategy(Closure.DELEGATE_FIRST)
+                    'name' project.name
+                    'description' project.description
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            credentials {
+                username rootProject.ext.symphonyRepoUser
+                password rootProject.ext.symphonyRepoPassword
+            }
+            url rootProject.ext.symphonyRepoUrl
+        }
+    }
+}
+
+signing {
+    required { rootProject.isReleaseVersion }
+    sign publishing.publications.maven
+}

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'java-platform'
+    id 'maven-publish'
+    id 'signing'
 }
 
 description = 'Symphony Java BDK Bom (Bill Of Materials)'

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -1,8 +1,9 @@
 plugins {
+    id 'bdk.java-library-conventions'
+    id 'bdk.java-publish-conventions'
     // beta version provides incremental build support
-    id "org.openapi.generator" version "5.0.0-beta2"
-    id "de.undercouch.download" version "4.1.1"
-    id "java-library"
+    id 'org.openapi.generator' version '5.0.0-beta2'
+    id 'de.undercouch.download' version '4.1.1'
 }
 
 description = 'Symphony Java BDK Core'

--- a/symphony-bdk-examples/bdk-app-spring-boot-example/build.gradle
+++ b/symphony-bdk-examples/bdk-app-spring-boot-example/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'org.springframework.boot' version "2.3.4.RELEASE"
+    id 'bdk.java-common-conventions'
+    id 'org.springframework.boot' version "2.4.1"
 }
 
 description = 'Symphony Java BDK Examples for the SpringBoot integration'

--- a/symphony-bdk-examples/bdk-core-examples/build.gradle
+++ b/symphony-bdk-examples/bdk-core-examples/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'bdk.java-common-conventions'
+}
+
 description = 'Symphony Java BDK Examples - Core'
 
 dependencies {

--- a/symphony-bdk-examples/bdk-spring-boot-example/build.gradle
+++ b/symphony-bdk-examples/bdk-spring-boot-example/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'org.springframework.boot' version "2.3.3.RELEASE"
+    id 'bdk.java-common-conventions'
+    id 'org.springframework.boot' version "2.4.1"
 }
 
 description = 'Symphony Java BDK Examples for the SpringBoot integration'

--- a/symphony-bdk-http/symphony-bdk-http-api/build.gradle
+++ b/symphony-bdk-http/symphony-bdk-http-api/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id 'bdk.java-common-conventions'
+    id 'bdk.java-publish-conventions'
+}
+
 description = 'Symphony Java BDK Core Http API'
 
 dependencies {

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/build.gradle
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'java-library'
+    id 'bdk.java-library-conventions'
+    id 'bdk.java-publish-conventions'
 }
 
 description = 'Symphony Java BDK Core Http Jersey2'

--- a/symphony-bdk-http/symphony-bdk-http-webclient/build.gradle
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'java-library'
+    id 'bdk.java-library-conventions'
+    id 'bdk.java-publish-conventions'
 }
 
 description = 'Symphony Java BDK Core Http Spring WebClient'

--- a/symphony-bdk-legacy/.snyk
+++ b/symphony-bdk-legacy/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.14.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-LOG4J-572732:
+    - '*':
+        reason: Not applicable as this server component is not used
+        expires: 2121-01-01T00:00:00.000Z
+patch: {}

--- a/symphony-bdk-legacy/build.gradle
+++ b/symphony-bdk-legacy/build.gradle
@@ -40,17 +40,32 @@ allprojects {
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0'
+        classpath 'gradle.plugin.io.snyk.gradle.plugin:snyk:0.4'
     }
 }
 
 apply plugin: 'io.codearte.nexus-staging'
+apply plugin: 'io.snyk.gradle.plugin.snykplugin'
 
 nexusStaging {
     username = rootProject.ext.symphonyRepoUser
     password = rootProject.ext.symphonyRepoPassword
+}
+
+// Required for Snyk plugin to work (https://github.com/snyk/gradle-plugin/issues/1)
+repositories {
+    mavenCentral()
+}
+
+snyk {
+    arguments = '--all-sub-projects'
+    severity = 'high'
 }
 
 subprojects {

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/build.gradle
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'java-library'
+    id 'bdk.java-library-conventions'
+    id 'bdk.java-publish-conventions'
 }
 
 description = 'Spring Boot Starter that ease Application developments'
@@ -35,7 +36,7 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
-    testCompile project(':symphony-bdk-core').sourceSets.test.output
+    testImplementation project(':symphony-bdk-core').sourceSets.test.output
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
         exclude group: 'junit', module: 'junit'

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/build.gradle
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'java-library'
+    id 'bdk.java-library-conventions'
+    id 'bdk.java-publish-conventions'
 }
 
 description = 'Spring Boot Wrapper for the Symphony BDK Core module'
@@ -42,7 +43,7 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
-    testCompile project(':symphony-bdk-core').sourceSets.test.output
+    testImplementation project(':symphony-bdk-core').sourceSets.test.output
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }

--- a/symphony-bdk-template/symphony-bdk-template-api/build.gradle
+++ b/symphony-bdk-template/symphony-bdk-template-api/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id 'bdk.java-common-conventions'
+    id 'bdk.java-publish-conventions'
+}
+
 description = 'Symphony Java BDK Template API module'
 
 dependencies {

--- a/symphony-bdk-template/symphony-bdk-template-freemarker/build.gradle
+++ b/symphony-bdk-template/symphony-bdk-template-freemarker/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'java-library'
+    id 'bdk.java-library-conventions'
+    id 'bdk.java-publish-conventions'
 }
 
 description = 'Symphony Java BDK Template Freemarker Module'

--- a/symphony-bdk-template/symphony-bdk-template-handlebars/build.gradle
+++ b/symphony-bdk-template/symphony-bdk-template-handlebars/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'java-library'
+    id 'bdk.java-library-conventions'
+    id 'bdk.java-publish-conventions'
 }
 
 description = 'Symphony Java BDK Template Handlebars Module'


### PR DESCRIPTION
### Ticket
PLAT-10379

### Description

Two main changes described below.
I have not tested a release (a bit complex) so there a is risk for the next release that we discover issues only when actually releasing

---

CircleCI configuration for Snyk

We want to run Snyk only master branch to avoid exposing the SNYK_TOKEN
on any PR (as the project is OSS).
A separate job is defined for that purpose using the Gradle Snyk plugin.

The SNYK_TOKEN is set in a context that can be reused across DevX jobs.

Also configure an exclusion for log4j that we won't fix.

---

Run Snyk with Gradle + cleaner build …

The Gradle Snyk plugin is used, it adds 2 tasks:
- snyk-test
- snyk-monitor

The task is only configured at the root level and with the option to
look at subproject (it is faster than running it for each project).

Most of the changes for the build are to use convention plugin which is
a better approach to configure builds.

In buildSrc/ we define our own plugins with the common configuration and
we can better compose them by applying then where needed.

For instance we use the publish plugin only on the projects that are
published. The root build is much simpler to read and we avoid the magic
and filtering of subprojects{}

This has not been done for the legacy project as it is ... legacy ...

### Dependencies
N/A

### Checklist
- [X] Referenced a ticket in the PR title and in the corresponding section
