### PR TITLE
PLAT-10445: Upgrade Mapstruct to latest version (1.4.1)

### DIFF
--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -36,8 +36,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    implementation 'org.mapstruct:mapstruct:1.3.1.Final'
-    annotationProcessor 'org.mapstruct:mapstruct-processor:1.3.1.Final'
+    implementation 'org.mapstruct:mapstruct:1.4.1.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.1.Final'
 
     api 'org.apiguardian:apiguardian-api'
     implementation 'org.slf4j:slf4j-api'

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/JwtHelperTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/JwtHelperTest.java
@@ -108,7 +108,7 @@ class JwtHelperTest {
   @SneakyThrows
   private static String generatePkcs8RsaPrivateKey() {
     final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-    kpg.initialize(4096);
+    kpg.initialize(1024);
     final KeyPair kp = kpg.generateKeyPair();
     return "-----BEGIN PRIVATE KEY-----\n" +
         Base64.encodeToString(kp.getPrivate().getEncoded(), true) +
@@ -118,7 +118,7 @@ class JwtHelperTest {
   @SneakyThrows
   private static String generatePkcs1RsaPrivateKey() {
     final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-    kpg.initialize(4096);
+    kpg.initialize(1024);
     final KeyPair kp = kpg.generateKeyPair();
 
     final PrivateKeyInfo pkInfo = PrivateKeyInfo.getInstance(kp.getPrivate().getEncoded());


### PR DESCRIPTION
### Ticket
PLAT-10445

### Description
We are facing the issue
https://github.com/mapstruct/mapstruct/issues/2215 with the latest
version of IDEA (NPE when building from IDEA), upgrading to latest
version fixes it.

Also make the unit test faster by generating smaller RSA keys (saving a
few seconds).

### Dependencies
N/A

### Checklist
- [X] Referenced a ticket in the PR title and in the corresponding section
- [X] Filled properly the description and dependencies, if any
- [-] Unit tests updated or added
- [-] Javadoc added or updated
- [-] Updated the documentation in [docs folder](../docs)
