### PR TITLE
PLAT-10416 : listAuditTrail endpoint accepts pagination with some null fields 

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/user/UserService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/user/UserService.java
@@ -698,9 +698,9 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   public V1AuditTrailInitiatorList listAuditTrail(@Nonnull Long startTimestamp, Long endTimestamp,
       CursorPaginationAttribute pagination, Long initiatorId, String role) {
 
-    String before = pagination != null ? pagination.getBefore().toString() : null;
-    String after = pagination != null ? pagination.getAfter().toString() : null;
-    Integer limit = pagination != null ? pagination.getLimit() : null;
+    String before = (pagination != null && pagination.getBefore() != null) ? pagination.getBefore().toString() : null;
+    String after = (pagination != null && pagination.getAfter() != null) ? pagination.getAfter().toString() : null;
+    Integer limit = (pagination != null && pagination.getLimit() != null) ? pagination.getLimit() : null;
 
     return executeAndRetry("listAuditTrail",
         () -> auditTrailApi.v1AudittrailPrivilegeduserGet(authSession.getSessionToken(), authSession.getKeyManagerToken(),


### PR DESCRIPTION
### Ticket
[PLAT-10416](https://perzoinc.atlassian.net/browse/PLAT-10416)

### Description
[list-audit-trail-v1](https://developers.symphony.com/restapi/reference#list-audit-trail-v1) endpoint should accept pagination with only some fields set (only limit with before and after having null values for example).

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
