### PR TITLE
#427 FormReplyActivity throws NPE for unchecked checkboxes

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/form/FormReplyContext.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/form/FormReplyContext.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apiguardian.api.API;
 
+import javax.annotation.Nullable;
+
 /**
  * Default implementation of the {@link ActivityContext} handled by the {@link FormReplyActivity}.
  */
@@ -33,7 +35,14 @@ public class FormReplyContext extends ActivityContext<V4SymphonyElementsAction> 
     super(initiator, eventSource);
   }
 
-  @API(status = API.Status.EXPERIMENTAL)
+  /**
+   * Get the value of specified form field
+   *
+   * @param fieldName the form field name
+   * @return the form field value. If the form reply does not contain the specified field, it returns null
+   */
+  @API(status = API.Status.STABLE)
+  @Nullable
   public String getFormValue(String fieldName) {
     return this.formValues.has(fieldName) ?
         this.formValues.get(fieldName).asText() : null;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/form/FormReplyContext.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/form/FormReplyContext.java
@@ -35,6 +35,7 @@ public class FormReplyContext extends ActivityContext<V4SymphonyElementsAction> 
 
   @API(status = API.Status.EXPERIMENTAL)
   public String getFormValue(String fieldName) {
-    return this.formValues.get(fieldName).asText();
+    return this.formValues.has(fieldName) ?
+        this.formValues.get(fieldName).asText() : null;
   }
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/form/FormReplyActivityTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/form/FormReplyActivityTest.java
@@ -2,6 +2,7 @@ package com.symphony.bdk.core.activity.form;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.symphony.bdk.core.service.datafeed.DatafeedLoop;
@@ -61,6 +62,7 @@ class FormReplyActivityTest {
 
     assertEquals(context.getFormId(), formId);
     assertEquals("bar", context.getFormValue("foo"));
+    assertNull(context.getFormValue("not-existing"));
   }
 
   private static FormReplyContext createContext() {


### PR DESCRIPTION
### Ticket
https://github.com/SymphonyPlatformSolutions/symphony-api-client-java/issues/427 FormReplyActivity throws NPE for unchecked checkboxes

### Description
Sending an elements form with a checkbox, leaving it unchecked, then using FormReplyActivity to getFormValue throws a NullPointerException. Expectation: return null or false instead.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [N/A] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [N/A] Javadoc added or updated
- [N/A] Updated the documentation in [docs folder](../docs)
