### PR TITLE
PLAT-10110 Catch exceptions on retry based on ApiClient

### DIFF
--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     implementation 'io.github.resilience4j:resilience4j-retry'
     implementation 'io.swagger:swagger-annotations'
     implementation 'com.google.code.findbugs:jsr305'
-    implementation 'org.glassfish.jersey.core:jersey-client'
 
     testImplementation project(':symphony-bdk-http:symphony-bdk-http-jersey2')
     testRuntimeOnly project(':symphony-bdk-template:symphony-bdk-template-freemarker')
@@ -60,6 +59,8 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
+    testImplementation 'org.glassfish.jersey.core:jersey-client'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
     testImplementation 'com.tngtech.archunit:archunit-junit5'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'ch.qos.logback:logback-classic'

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/AuthenticationRetry.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/AuthenticationRetry.java
@@ -13,7 +13,8 @@ import com.symphony.bdk.http.api.ApiRuntimeException;
 import lombok.extern.slf4j.Slf4j;
 import org.apiguardian.api.API;
 
-import javax.ws.rs.ProcessingException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 
 /**
  * Class used to implement the specific logic for authentication calls.
@@ -43,7 +44,7 @@ class AuthenticationRetry<T> {
 
   /**
    * Predicate to check if authentication call be retried,
-   * i.e. the throwable is a {@link ProcessingException} (e.g. network issues)
+   * i.e. the throwable is either a {@link SocketTimeoutException} or {@link ConnectException} (e.g. network issues)
    * or is an {@link ApiException} with status code 429 or strictly greater than 500.
    *
    * @param t the {@link Throwable} to be checked.
@@ -54,7 +55,7 @@ class AuthenticationRetry<T> {
       ApiException apiException = (ApiException) t;
       return apiException.isServerError() || apiException.isTooManyRequestsError();
     }
-    return t instanceof ProcessingException;
+    return t.getCause() instanceof SocketTimeoutException || t.getCause() instanceof ConnectException;
   }
 
   public AuthenticationRetry(BdkRetryConfig retryConfig) {

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/retry/RetryWithRecoveryBuilder.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/retry/RetryWithRecoveryBuilder.java
@@ -8,11 +8,11 @@ import com.symphony.bdk.http.api.ApiException;
 
 import org.apiguardian.api.API;
 
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
-
-import javax.ws.rs.ProcessingException;
 
 /**
  * Builder class to facilitate the instantiation of a {@link RetryWithRecovery}.
@@ -60,12 +60,12 @@ public class RetryWithRecoveryBuilder<T> {
   }
 
   /**
-   * Checks if a throwable is a {@link ProcessingException} or a {@link ApiException} minor error.
+   * Checks if a throwable is a network issue or a {@link ApiException} minor error.
    * This is the default function used in {@link RetryWithRecovery}
    * to check if a given exception thrown should lead to a retry.
    *
    * @param t the throwable to be checked.
-   * @return true if passed throwable is a {@link ProcessingException} (e.g. in case of a temporary network exception)
+   * @return true if passed throwable is either a {@link SocketTimeoutException} or {@link ConnectException}
    * or if it is a {@link ApiException} which {@link ApiException#isServerError()}
    * or {@link ApiException#isUnauthorized()} or {@link ApiException#isTooManyRequestsError()}.
    */
@@ -74,14 +74,14 @@ public class RetryWithRecoveryBuilder<T> {
       ApiException apiException = (ApiException) t;
       return apiException.isServerError() || apiException.isUnauthorized() || apiException.isTooManyRequestsError();
     }
-    return t instanceof ProcessingException;
+    return t.getCause() instanceof SocketTimeoutException || t.getCause() instanceof ConnectException;
   }
 
   /**
-   * Checks if a throwable is a {@link ProcessingException} or a {@link ApiException} minor error or client error.
+   * Checks if a throwable is a network issue or a {@link ApiException} minor error or client error.
    *
    * @param t the throwable to be checked.
-   * @return true if passed throwable is a {@link ProcessingException} (e.g. in case of a temporary network exception)
+   * @return true if passed throwable is either a {@link SocketTimeoutException} or {@link ConnectException}
    * or if it is a {@link ApiException} which {@link ApiException#isServerError()}
    * or {@link ApiException#isUnauthorized()} or {@link ApiException#isTooManyRequestsError()}
    * or {@link ApiException#isClientError()}.
@@ -92,7 +92,7 @@ public class RetryWithRecoveryBuilder<T> {
       return apiException.isServerError() || apiException.isUnauthorized() || apiException.isTooManyRequestsError()
           || apiException.isClientError();
     }
-    return t instanceof ProcessingException;
+    return t.getCause() instanceof SocketTimeoutException || t.getCause() instanceof ConnectException;
   }
 
   /**

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/AbstractBotAuthenticatorTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/AbstractBotAuthenticatorTest.java
@@ -22,6 +22,8 @@ import com.symphony.bdk.http.api.ApiRuntimeException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.net.SocketTimeoutException;
+
 import javax.annotation.Nonnull;
 import javax.ws.rs.ProcessingException;
 
@@ -93,7 +95,7 @@ class AbstractBotAuthenticatorTest {
     AbstractBotAuthenticator botAuthenticator = spy(new TestBotAuthenticator(ofMinimalInterval(4)));
     doThrow(new ApiException(429, ""))
         .doThrow(new ApiException(503, ""))
-        .doThrow(new ProcessingException(""))
+        .doThrow(new ProcessingException(new SocketTimeoutException()))
         .doReturn(token)
         .when(botAuthenticator).authenticateAndGetToken(any());
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/AbstractExtensionAppAuthenticatorTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/AbstractExtensionAppAuthenticatorTest.java
@@ -22,6 +22,9 @@ import com.symphony.bdk.http.api.ApiRuntimeException;
 
 import org.junit.jupiter.api.Test;
 
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+
 import javax.annotation.Nonnull;
 import javax.ws.rs.ProcessingException;
 
@@ -97,7 +100,7 @@ class AbstractExtensionAppAuthenticatorTest {
         spy(new TestExtAppAuthenticator(ofMinimalInterval()));
     doThrow(new ApiException(429, ""))
         .doThrow(new ApiException(503, ""))
-        .doThrow(new ProcessingException(""))
+        .doThrow(new ProcessingException(new SocketTimeoutException()))
         .doReturn(new PodCertificate().certificate(certificate))
         .when(authenticator).callGetPodCertificate();
 
@@ -158,7 +161,7 @@ class AbstractExtensionAppAuthenticatorTest {
         spy(new TestExtAppAuthenticator(ofMinimalInterval()));
     doThrow(new ApiException(429, ""))
         .doThrow(new ApiException(503, ""))
-        .doThrow(new ProcessingException(""))
+        .doThrow(new ProcessingException(new ConnectException()))
         .doReturn(extensionAppTokens)
         .when(authenticator).authenticateAndRetrieveTokens(anyString());
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/AbstractOboAuthenticatorTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/AbstractOboAuthenticatorTest.java
@@ -18,7 +18,13 @@ import com.symphony.bdk.core.config.model.BdkRetryConfig;
 import com.symphony.bdk.http.api.ApiException;
 import com.symphony.bdk.http.api.ApiRuntimeException;
 
+import io.netty.channel.ConnectTimeoutException;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 
 import javax.annotation.Nonnull;
 import javax.ws.rs.ProcessingException;
@@ -108,7 +114,7 @@ class AbstractOboAuthenticatorTest {
     doReturn("").when(authenticator).retrieveAppSessionToken();
     doThrow(new ApiException(429, ""))
         .doThrow(new ApiException(503, ""))
-        .doThrow(new ProcessingException(""))
+        .doThrow(new ProcessingException(new SocketTimeoutException()))
         .doReturn(token).when(authenticator).authenticateAndRetrieveOboSessionToken(anyString(), anyLong());
 
     assertEquals(token, authenticator.retrieveOboSessionTokenByUserId(0L));
@@ -169,7 +175,7 @@ class AbstractOboAuthenticatorTest {
     doReturn("").when(authenticator).retrieveAppSessionToken();
     doThrow(new ApiException(429, ""))
         .doThrow(new ApiException(503, ""))
-        .doThrow(new ProcessingException(""))
+        .doThrow(new WebClientRequestException(new ConnectTimeoutException(), HttpMethod.GET, null, null))
         .doReturn(token).when(authenticator).authenticateAndRetrieveOboSessionToken(anyString(), anyString());
 
     assertEquals(token, authenticator.retrieveOboSessionTokenByUsername(""));
@@ -224,7 +230,7 @@ class AbstractOboAuthenticatorTest {
     AbstractOboAuthenticator authenticator = spy(new TestAbstractOboAuthenticator(ofMinimalInterval()));
     doThrow(new ApiException(429, ""))
         .doThrow(new ApiException(503, ""))
-        .doThrow(new ProcessingException(""))
+        .doThrow(new ProcessingException(new ConnectException()))
         .doReturn(token).when(authenticator).authenticateAndRetrieveAppSessionToken();
 
     assertEquals(token, authenticator.retrieveAppSessionToken());

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/AuthenticationRetryTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/AuthenticationRetryTest.java
@@ -15,8 +15,10 @@ import com.symphony.bdk.http.api.ApiException;
 import com.symphony.bdk.http.api.ApiRuntimeException;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 
-import javax.ws.rs.ProcessingException;
+import java.net.SocketTimeoutException;
 
 class AuthenticationRetryTest {
 
@@ -61,7 +63,8 @@ class AuthenticationRetryTest {
     final String output = "output";
 
     SupplierWithApiException<String> supplier = mock(SupplierWithApiException.class);
-    when(supplier.get()).thenThrow(new ProcessingException("")).thenReturn(output);
+    when(supplier.get()).thenThrow(
+        new WebClientRequestException(new SocketTimeoutException(), HttpMethod.GET, null, null)).thenReturn(output);
 
     AuthenticationRetry<String> authenticationRetry = new AuthenticationRetry<>(ofMinimalInterval(2));
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/retry/resilience4j/Resilience4jRetryWithRecoveryTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/retry/resilience4j/Resilience4jRetryWithRecoveryTest.java
@@ -29,6 +29,8 @@ import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.Collections;
 
+import javax.ws.rs.ProcessingException;
+
 /**
  * Test class for {@link Resilience4jRetryWithRecovery}
  */
@@ -251,7 +253,8 @@ class Resilience4jRetryWithRecoveryTest {
     when(supplier.get()).thenThrow(new RuntimeException(new UnknownHostException("Unknown host")));
 
     try {
-      Resilience4jRetryWithRecovery.executeAndRetry(new RetryWithRecoveryBuilder<String>(), "test", "localhost.symphony.com", supplier);
+      Resilience4jRetryWithRecovery.executeAndRetry(new RetryWithRecoveryBuilder<String>(), "test",
+          "localhost.symphony.com", supplier);
     } catch (RuntimeException e){
       assertEquals("Network error occurred while trying to connect to the \"POD\" at the following address: "
           + "localhost.symphony.com. Your host is unknown, please check that the address is correct. Also consider "
@@ -262,10 +265,12 @@ class Resilience4jRetryWithRecoveryTest {
   @Test
   void testExecuteAndRetryShouldThrowRuntimeExceptionWhenConnectionTimeout() throws Throwable {
     SupplierWithApiException<String> supplier = mock(ConcreteSupplier.class);
-    when(supplier.get()).thenThrow(new RuntimeException(new SocketTimeoutException("Connection timeout")));
+    when(supplier.get()).thenThrow(new ProcessingException(new SocketTimeoutException("Connection timeout")));
 
     try {
-      Resilience4jRetryWithRecovery.executeAndRetry(new RetryWithRecoveryBuilder<String>(), "test", "localhost.symphony.com", supplier);
+      Resilience4jRetryWithRecovery.executeAndRetry(
+          new RetryWithRecoveryBuilder<String>().retryConfig(ofMinimalInterval(3)), "test", "localhost.symphony.com",
+          supplier);
     } catch (RuntimeException e){
       assertEquals("Timeout occurred while trying to connect to the \"POD\" at the following address: "
           + "localhost.symphony.com. Please check that the address is correct. Also consider checking your "
@@ -276,10 +281,12 @@ class Resilience4jRetryWithRecoveryTest {
   @Test
   void testExecuteAndRetryShouldThrowRuntimeExceptionWhenConnectionRefused() throws Throwable {
     SupplierWithApiException<String> supplier = mock(ConcreteSupplier.class);
-    when(supplier.get()).thenThrow(new RuntimeException(new ConnectException("Connection refused")));
+    when(supplier.get()).thenThrow(new ProcessingException(new ConnectException("Connection refused")));
 
     try {
-      Resilience4jRetryWithRecovery.executeAndRetry(new RetryWithRecoveryBuilder<String>(), "test", "localhost.symphony.com", supplier);
+      Resilience4jRetryWithRecovery.executeAndRetry(
+          new RetryWithRecoveryBuilder<String>().retryConfig(ofMinimalInterval(3)), "test", "localhost.symphony.com",
+          supplier);
     } catch (RuntimeException e){
       assertEquals("Connection refused while trying to connect to the \"POD\" at the following address: "
           + "localhost.symphony.com. Please check if this remote address/port is reachable. Also consider checking your "

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientWebClient.java
@@ -22,6 +22,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 
@@ -146,7 +147,9 @@ public class ApiClientWebClient implements ApiClient {
       if (unwrap instanceof ApiException) {
         throw (ApiException) unwrap;
       } if(e.getCause() instanceof ConnectTimeoutException){
-        throw new RuntimeException(new SocketTimeoutException(e.getMessage()));
+        WebClientRequestException exception = (WebClientRequestException) e;
+        throw new WebClientRequestException(new SocketTimeoutException(e.getMessage()), exception.getMethod(),
+            exception.getUri(), exception.getHeaders());
       } else {
         throw e;
       }

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientWebClient.java
@@ -146,7 +146,8 @@ public class ApiClientWebClient implements ApiClient {
       Throwable unwrap = Exceptions.unwrap(e);
       if (unwrap instanceof ApiException) {
         throw (ApiException) unwrap;
-      } if(e.getCause() instanceof ConnectTimeoutException){
+      }
+      if (e instanceof WebClientRequestException && e.getCause() instanceof ConnectTimeoutException) {
         WebClientRequestException exception = (WebClientRequestException) e;
         throw new WebClientRequestException(new SocketTimeoutException(e.getMessage()), exception.getMethod(),
             exception.getUri(), exception.getHeaders());


### PR DESCRIPTION
!!! **Update on last commit** !!!
When a proxy is configured the jersey client is throwing ProcessingException enclosing a ConnectTimeoutException so also in this case I transformed that into a SocketTimeoutException so that we trigger the retry.

### Ticket
https://perzoinc.atlassian.net/browse/PLAT-10110

### Description
Depending on the http client used, network issues can throw different kind of exceptions in case of "connection timeout" and "connection refused" :

**Jersey2 client**
- ProcessingException enclosing a ConnectException
- ProcessingException enclosing a SocketTimeoutException

**Webclient**
- WebClientRequestException enclosing a ConnectException
- WebClientRequestException enclosing a ConnectTimeoutException

This is a draft PR to get some feedbacks on my idea of instead of basing the timeout on the external exception (ProcessingException), to check directly the cause of it. In this case we can limit the retry to only these two conditions (timeout and connection refused).
Only "big change" is that in order to avoid catching two types of exceptions for the timeout (one of it being specific to netty package), inside the webclient I changed the type of the exception from ConnectTimeoutException to SocketTimeoutException and forward the latter. In this way we only deal with exceptions types: ConnectException and SocketTimeoutException.

### Dependencies
No dependency on other PRs

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
