### PR TITLE
Update Docker base image in examples

### DIFF
--- a/symphony-bdk-examples/bdk-multi-instances-example/Dockerfile
+++ b/symphony-bdk-examples/bdk-multi-instances-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:15-ea-21-oracle
 ENV BOT_PK=/data/privatekey.pem
 ARG JAR_FILE=build/libs/\*-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar


### PR DESCRIPTION
Use the image recommended by Snyk that has no known vulnerabilities.