### PR TITLE
#439 Removed Tomcat dependency from the CircleOfTrustController

### DIFF
--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/auth/CircleOfTrustController.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/auth/CircleOfTrustController.java
@@ -9,7 +9,6 @@ import com.symphony.bdk.app.spring.auth.service.CircleOfTrustService;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.tomcat.util.http.SameSiteCookies;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -69,7 +68,7 @@ public class CircleOfTrustController {
         .secure(true)
         .httpOnly(true)
         .path(path)
-        .sameSite(SameSiteCookies.NONE.getValue())
+        .sameSite("None") // Cookie is always sent in cross-site requests.
         .build();
   }
 

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/auth/CircleOfTrustControllerTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/auth/CircleOfTrustControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockCookie;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -132,10 +133,13 @@ public class CircleOfTrustControllerTest {
         .andExpect(status().isOk())
         .andReturn().getResponse();
 
+    assertEquals("None", ((MockCookie) response.getCookies()[0]).getSameSite());
+
     UserId id = objectMapper.readValue(response.getContentAsString(), UserId.class);
 
     assertEquals(HttpStatus.OK.value(), response.getStatus());
     assertEquals(id.getUserId(), 1234L);
+
   }
 
   @Test

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/auth/CircleOfTrustControllerTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/auth/CircleOfTrustControllerTest.java
@@ -1,6 +1,6 @@
 package com.symphony.bdk.app.spring.auth;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -133,7 +133,12 @@ public class CircleOfTrustControllerTest {
         .andExpect(status().isOk())
         .andReturn().getResponse();
 
-    assertEquals("None", ((MockCookie) response.getCookies()[0]).getSameSite());
+    final MockCookie cookie = (MockCookie) response.getCookie("userJwt");
+    assertNotNull(cookie);
+    assertEquals("None", cookie.getSameSite());
+    assertTrue(cookie.isHttpOnly());
+    assertTrue(cookie.getSecure());
+    assertEquals(this.appProperties.getAuth().getJwtCookie().getMaxAge().getSeconds(), cookie.getMaxAge());
 
     UserId id = objectMapper.readValue(response.getContentAsString(), UserId.class);
 

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/auth/CircleOfTrustControllerTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/auth/CircleOfTrustControllerTest.java
@@ -139,7 +139,6 @@ public class CircleOfTrustControllerTest {
 
     assertEquals(HttpStatus.OK.value(), response.getStatus());
     assertEquals(id.getUserId(), 1234L);
-
   }
 
   @Test


### PR DESCRIPTION
Removed Tomcat dependency from the CircleOfTrustController so that lib client can use another embedded server (Undertow for instance). 

### Ticket
Closes https://github.com/SymphonyPlatformSolutions/symphony-api-client-java/issues/439

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added