### PR TITLE
#441 BDK config allows to configure default headers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,10 @@ connectionTimeout: 15000
 readTimeout: 60000
 connectionPoolMax: 20
 connectionPoolPerRoute: 20
-
+defaultHeaders:
+  Connection: Keep-Alive
+  Keep-Alive: timeout=5, max=1000
+    
 proxy:
   host: proxy.symphony.com
   port: 1234
@@ -81,7 +84,10 @@ agent:
 keyManager:
   host: dev-key.symphony.com
   port: 8444
-
+  defaultHeaders:
+    Connection: Keep-Alive
+    Keep-Alive: close
+        
 sessionAuth:
   host: dev-session.symphony.com
   port: 8444

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/ApiClientFactory.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/ApiClientFactory.java
@@ -39,7 +39,6 @@ public class ApiClientFactory {
   private final static String SESSIONAUTH_CONTEXT_PATH = "/sessionauth";
   private final static String KEYAUTH_CONTEXT_PATH = "/keyauth";
 
-
   private final BdkConfig config;
   private final ApiClientBuilderProvider apiClientBuilderProvider;
 
@@ -192,6 +191,10 @@ public class ApiClientFactory {
         .withConnectionTimeout(clientConfig.getConnectionTimeout())
         .withConnectionPoolMax(clientConfig.getConnectionPoolMax())
         .withConnectionPoolPerRoute(clientConfig.getConnectionPoolPerRoute());
+
+    if (clientConfig.getDefaultHeaders() != null) {
+      clientConfig.getDefaultHeaders().forEach(apiClientBuilder::withDefaultHeader);
+    }
 
     configureTruststore(apiClientBuilder);
     configureProxy(clientConfig.getProxy(), apiClientBuilder);

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkClientConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkClientConfig.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apiguardian.api.API;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
 @Getter
@@ -24,6 +25,7 @@ public class BdkClientConfig extends BdkServerConfig {
     this.readTimeout = null;
     this.connectionPoolMax = null;
     this.connectionPoolPerRoute = null;
+    this.defaultHeaders = null;
   }
 
   public BdkClientConfig(BdkConfig parentConfig) {
@@ -78,6 +80,11 @@ public class BdkClientConfig extends BdkServerConfig {
   @Override
   public BdkProxyConfig getProxy() {
     return thisOrParent(proxy, parentConfig::getProxy);
+  }
+
+  @Override
+  public Map<String, String> getDefaultHeaders() {
+    return thisOrParent(defaultHeaders, parentConfig::getDefaultHeaders);
   }
 
   private <T> T thisOrParent(T thisValue, Supplier<T> parentValue) {

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkServerConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkServerConfig.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apiguardian.api.API;
 
+import java.util.Map;
+
 @Getter
 @Setter
 @API(status = API.Status.STABLE)
@@ -22,6 +24,7 @@ public class BdkServerConfig {
   protected Integer readTimeout;
   protected Integer connectionPoolMax;
   protected Integer connectionPoolPerRoute;
+  protected Map<String, String> defaultHeaders;
 
   public String getBasePath() {
     return this.getScheme() + "://" + this.getHost() + this.getPortAsString() + this.getFormattedContext();

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigLoaderTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigLoaderTest.java
@@ -114,8 +114,12 @@ class BdkConfigLoaderTest {
     assertEquals(config.getPod().getReadTimeout(), 30000);
     assertEquals(config.getPod().getConnectionPoolMax(), 20);
     assertEquals(config.getPod().getConnectionPoolPerRoute(), 10);
+    assertEquals("Keep-Alive", config.getPod().getDefaultHeaders().get("Connection"));
+    assertEquals("close", config.getPod().getDefaultHeaders().get("Keep-Alive"));
 
     assertEquals(config.getScheme(), "https");
+    assertEquals("Keep-Alive", config.getDefaultHeaders().get("Connection"));
+    assertEquals("timeout=5, max=1000", config.getDefaultHeaders().get("Keep-Alive"));
 
     assertEquals(config.getAgent().getScheme(), "https");
     assertEquals(config.getAgent().getHost(), "devx1.symphony.com");
@@ -125,6 +129,8 @@ class BdkConfigLoaderTest {
     assertEquals(config.getAgent().getReadTimeout(), 60000);
     assertEquals(config.getAgent().getConnectionPoolMax(), 30);
     assertEquals(config.getAgent().getConnectionPoolPerRoute(), 20);
+    assertEquals("Keep-Alive", config.getAgent().getDefaultHeaders().get("Connection"));
+    assertEquals("timeout=5, max=1000", config.getAgent().getDefaultHeaders().get("Keep-Alive"));
 
     assertEquals(config.getKeyManager().getScheme(), "https");
     assertEquals(config.getKeyManager().getHost(), "devx1.symphony.com");
@@ -134,6 +140,8 @@ class BdkConfigLoaderTest {
     assertEquals(config.getKeyManager().getReadTimeout(), 30000);
     assertEquals(config.getKeyManager().getConnectionPoolMax(), 20);
     assertEquals(config.getKeyManager().getConnectionPoolPerRoute(), 10);
+    assertEquals("Keep-Alive", config.getKeyManager().getDefaultHeaders().get("Connection"));
+    assertEquals("timeout=5, max=1000", config.getKeyManager().getDefaultHeaders().get("Keep-Alive"));
 
     assertEquals(config.getSessionAuth().getScheme(), "http");
     assertEquals(config.getSessionAuth().getHost(), "devx1.symphony.com");
@@ -143,6 +151,8 @@ class BdkConfigLoaderTest {
     assertEquals(config.getSessionAuth().getReadTimeout(), 30000);
     assertEquals(config.getSessionAuth().getConnectionPoolMax(), 20);
     assertEquals(config.getSessionAuth().getConnectionPoolPerRoute(), 10);
+    assertEquals("Keep-Alive", config.getSessionAuth().getDefaultHeaders().get("Connection"));
+    assertEquals("timeout=5, max=1000", config.getSessionAuth().getDefaultHeaders().get("Keep-Alive"));
   }
 
 

--- a/symphony-bdk-core/src/test/resources/config/config_client_global.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config_client_global.yaml
@@ -5,10 +5,16 @@ connectionTimeout: 10000
 readTimeout: 30000
 connectionPoolMax: 20
 connectionPoolPerRoute: 10
+defaultHeaders:
+  Connection: Keep-Alive
+  Keep-Alive: timeout=5, max=1000
 
 pod:
   host: diff-pod.symphony.com
   port: 8443
+  defaultHeaders:
+    Connection: Keep-Alive
+    Keep-Alive: close
 
 agent:
   host: devx1.symphony.com

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientJersey2.java
@@ -119,6 +119,7 @@ public class ApiClientJersey2 implements ApiClient {
       }
     }
 
+    // apply default headers, that can be set from config.yaml
     for (Entry<String, String> entry : defaultHeaderMap.entrySet()) {
       String key = entry.getKey();
       if (!headerParams.containsKey(key)) {

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientWebClient.java
@@ -114,6 +114,7 @@ public class ApiClientWebClient implements ApiClient {
       }
     }
 
+    // apply default headers, that can be set from config.yaml
     for (Map.Entry<String, String> defaultHeaderParam : this.defaultHeaderMap.entrySet()) {
       String key = defaultHeaderParam.getKey();
       if (headerParams != null && !headerParams.containsKey(key)) {


### PR DESCRIPTION
### Ticket
Closes https://github.com/SymphonyPlatformSolutions/symphony-api-client-java/issues/441

### Description
`config.yaml` now allows to configure default headers: 
```yaml
host: acme.symphony.com
defaultHeaders:
  Connection: Keep-Alive
  Keep-Alive: timeout=5, max=1000

bot:
  username: mybot
  privateKey:
    path: /Users/user.name/.symphony/privatekey.pem
```

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
