### PR TITLE
Fixed overridden jersey2 dependencies

### DIFF
--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -60,10 +60,12 @@ dependencies {
         api 'org.openapitools:jackson-databind-nullable:0.2.1'
 
         api 'org.glassfish.jersey.core:jersey-client:2.34'
+        api 'org.glassfish.jersey.core:jersey-common:2.34'
         api 'org.glassfish.jersey.inject:jersey-hk2:2.34'
         api 'org.glassfish.jersey.media:jersey-media-multipart:2.34'
         api 'org.glassfish.jersey.media:jersey-media-json-jackson:2.34'
         api 'org.glassfish.jersey.connectors:jersey-apache-connector:2.34'
+        api 'org.glassfish.jersey.ext:jersey-entity-filtering:2.34'
 
         api 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
 


### PR DESCRIPTION
### Ticket
Closes #557 

### Description
Forced dependencies org.glassfish.jersey.core:jersey-common and org.glassfish.jersey.ext:jersey-entity-filtering in version 2.34
Tested locally, works ok.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [N/A] Unit tests updated or added
- [N/A] Javadoc added or updated
- [N/A] Updated the documentation in [docs folder](../docs)
