### PR TITLE
EIS-5432: bump spring-boot version to 3.3.12

### DIFF
--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     // import Spring Boot's BOM
-    api platform('org.springframework.boot:spring-boot-dependencies:3.3.7')
+    api platform('org.springframework.boot:spring-boot-dependencies:3.3.12')
     // import Jackson's BOM
     api platform('com.fasterxml.jackson:jackson-bom:2.18.2')
     // import Jersey's BOM


### PR DESCRIPTION
## Ticket
[EIS-5432](https://perzoinc.atlassian.net/browse/EIS-5432)

### Description
I'd like to bump spring boot version to 3.3.12

### Checklist
- [x] Referenced an issue in the PR title or description
- [x] Filled properly the description and dependencies, if any
- [x] Unit/Integration tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
