### PR TITLE
feat: Add beta mode support to Message builder

### DIFF
--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/model/MessageTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/model/MessageTest.java
@@ -1,7 +1,9 @@
 package com.symphony.bdk.core.service.message.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.symphony.bdk.core.service.message.exception.MessageCreationException;
 
@@ -37,5 +39,44 @@ class MessageTest {
   @Test
   void checkMessageSilentDefaultValue() {
     assertEquals(Boolean.TRUE, Message.builder().content("<messageML>hello</messageML>").build().getSilent());
+  }
+
+  @Test
+  void checkBetaModeNotAddedByDefault() {
+    Message message = Message.builder().content("hello").build();
+    assertEquals("<messageML>hello</messageML>", message.getContent());
+    assertNull(message.getBeta());
+  }
+
+  @Test
+  void checkBetaModeAddedWhenTrue() {
+    Message message = Message.builder().content("hello").beta(true).build();
+    assertEquals("<messageML beta=\"true\">hello</messageML>", message.getContent());
+    assertEquals(Boolean.TRUE, message.getBeta());
+  }
+
+  @Test
+  void checkBetaModeNotAddedWhenFalse() {
+    Message message = Message.builder().content("hello").beta(false).build();
+    assertEquals("<messageML>hello</messageML>", message.getContent());
+    assertEquals(Boolean.FALSE, message.getBeta());
+  }
+
+  @Test
+  void checkBetaTrueWithPreWrappedContentThrowsException() {
+    MessageCreationException exception = assertThrows(
+        MessageCreationException.class,
+        () -> Message.builder().content("<messageML>hello</messageML>").beta(true).build()
+    );
+    assertTrue(exception.getMessage().contains("Cannot set beta=true when content is already wrapped"));
+  }
+
+  @Test
+  void checkBetaTrueWithPreWrappedBetaContentAllowed() {
+    Message message = Message.builder()
+        .content("<messageML beta=\"true\">hello</messageML>")
+        .beta(true)
+        .build();
+    assertEquals("<messageML beta=\"true\">hello</messageML>", message.getContent());
   }
 }


### PR DESCRIPTION
## Summary

- Add support for the `beta` attribute on the `<messageML>` tag, as introduced in [messageml-utils PR #421](https://github.com/finos/messageml-utils/pull/421)
- This enables experimental features like `<sym-ai-context>` for Symphony AI integration
- When `beta=true`, messages are wrapped with `<messageML beta="true">` instead of `<messageML>`

## Test plan

- [x] `checkBetaModeNotAddedByDefault()` - verifies default behavior has no beta attribute
- [x] `checkBetaModeAddedWhenTrue()` - verifies `beta="true"` is added when set
- [x] `checkBetaModeNotAddedWhenFalse()` - verifies no beta attribute when explicitly set to false
- [x] `checkBetaTrueWithPreWrappedContentThrowsException()` - verifies exception when beta=true but content already wrapped without beta
- [x] `checkBetaTrueWithPreWrappedBetaContentAllowed()` - verifies content with `<messageML beta="true">` is accepted

## Usage Example

```java
Message message = Message.builder()
    .content("<sym-ai-context>...</sym-ai-context>")
    .beta(true)
    .build();
// Results in: <messageML beta="true"><sym-ai-context>...</sym-ai-context></messageML>
```