### PR TITLE
CAIP-302 Add includeInvisible agent datafeed parameter

### DIFF
--- a/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
+++ b/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
@@ -16,6 +16,9 @@ public class BdkDatafeedConfig {
   private String version = "v2";
   private String idFilePath;
   private BdkRetryConfig retry = new BdkRetryConfig(BdkRetryConfig.INFINITE_MAX_ATTEMPTS);
+  /**
+   * Agent 26.2.1 or later required to enable includeInvisible.
+   */
   private boolean includeInvisible = false;
   private String tag;
 

--- a/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
+++ b/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
@@ -16,6 +16,7 @@ public class BdkDatafeedConfig {
   private String version = "v2";
   private String idFilePath;
   private BdkRetryConfig retry = new BdkRetryConfig(BdkRetryConfig.INFINITE_MAX_ATTEMPTS);
+  private boolean includeInvisible = false;
 
   public void setVersion(String version) {
     if ("v1".equalsIgnoreCase(version)) {

--- a/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
+++ b/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
@@ -17,6 +17,7 @@ public class BdkDatafeedConfig {
   private String idFilePath;
   private BdkRetryConfig retry = new BdkRetryConfig(BdkRetryConfig.INFINITE_MAX_ATTEMPTS);
   private boolean includeInvisible = false;
+  private String tag;
 
   public void setVersion(String version) {
     if ("v1".equalsIgnoreCase(version)) {

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -76,7 +76,7 @@ dependencies {
 }
 
 // OpenAPI code generation
-def apiBaseUrl = "https://raw.githubusercontent.com/finos/symphony-api-spec/ee09734380226ac1109a1513156ceefac3bd5a1e"
+def apiBaseUrl = "https://raw.githubusercontent.com/finos/symphony-api-spec/5526c5e81cb2313c4aab18119b526534652ba98e"
 def generatedFolder = "$buildDir/generated/openapi"
 def apisToGenerate = [
         Agent: 'agent/agent-api-public-deprecated.yaml',

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
@@ -54,6 +54,8 @@ public class DatafeedLoopV2 extends AbstractAckIdEventLoop {
   private final RetryWithRecovery<V5Datafeed> createDatafeed;
   private final RetryWithRecovery<Void> deleteDatafeed;
 
+  private final V5DatafeedCreateBody datafeedCreateBody;
+
   private V5Datafeed datafeed;
 
   public DatafeedLoopV2(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config, UserV2 botInfo) {
@@ -87,6 +89,11 @@ public class DatafeedLoopV2 extends AbstractAckIdEventLoop {
         .supplier(this::doDeleteDatafeed)
         .ignoreException(ApiException::isClientError)
         .build();
+
+    datafeedCreateBody = new V5DatafeedCreateBody();
+    if(config.getDatafeed().isIncludeInvisible()) {
+      datafeedCreateBody.setIncludeInvisible(true);
+    }
   }
 
   @Override
@@ -108,7 +115,7 @@ public class DatafeedLoopV2 extends AbstractAckIdEventLoop {
     return this.datafeedApi.createDatafeed(
         this.authSession.getSessionToken(),
         this.authSession.getKeyManagerToken(),
-        new V5DatafeedCreateBody()
+        datafeedCreateBody
     );
   }
 

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
@@ -48,6 +48,7 @@ public class DatafeedLoopV2 extends AbstractAckIdEventLoop {
    * Datahose feeds are in the format *_p_*, e.g. "d25098517ec62f1fc65cd111667a8386_p_be940".
    */
   private static final Pattern FANOUT_FEED_PATTERN = Pattern.compile("^[^\\s_]+_f(_[^\\s_]+)?$");
+  private static final String FANOUT_TYPE = "fanout";
 
   private final RetryWithRecoveryBuilder<?> retryWithRecoveryBuilder;
   private final RetryWithRecovery<Void> readDatafeed;
@@ -135,7 +136,7 @@ public class DatafeedLoopV2 extends AbstractAckIdEventLoop {
   private boolean isMatchingFeed(V5Datafeed d) {
     if (this.datafeedCreateBody.getTag() != null) {
       if (this.datafeedCreateBody.getTag().equals(d.getId())
-          && "fanout".equals(d.getType())) {
+          && FANOUT_TYPE.equalsIgnoreCase(d.getType())) {
         return true;
       } else {
         return false;

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
@@ -128,6 +128,7 @@ class DatafeedLoopV2Test {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null))
         .thenReturn(Collections.singletonList(new V5Datafeed().id(invalidExistingFeedId)));
     when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id(DATAFEED_ID));
 
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
@@ -138,7 +139,7 @@ class DatafeedLoopV2Test {
 
     this.datafeedService.start();
 
-    V5DatafeedCreateBody datafeedCreateBody = new V5DatafeedCreateBody();
+    V5DatafeedCreateBody datafeedCreateBody = new V5DatafeedCreateBody().includeInvisible(true);
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
     verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, datafeedCreateBody);
     verify(datafeedApi, times(1)).readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId);
@@ -149,7 +150,7 @@ class DatafeedLoopV2Test {
   void testStartValidExistingFeeds(String validExistingFeedId) throws ApiException, AuthUnauthorizedException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null))
         .thenReturn(Collections.singletonList(new V5Datafeed().id(validExistingFeedId)));
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id(validExistingFeedId));
 
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
@@ -160,7 +161,7 @@ class DatafeedLoopV2Test {
 
     this.datafeedService.start();
 
-    V5DatafeedCreateBody datafeedCreateBody = new V5DatafeedCreateBody();
+    V5DatafeedCreateBody datafeedCreateBody = new V5DatafeedCreateBody().includeInvisible(true);
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
     verify(datafeedApi, times(0)).createDatafeed(TOKEN, TOKEN, datafeedCreateBody);
     verify(datafeedApi, times(1)).readDatafeed(validExistingFeedId, TOKEN, TOKEN, ackId);
@@ -337,7 +338,7 @@ class DatafeedLoopV2Test {
   @Test
   void testStartEmptyListDatafeed() throws ApiException, AuthUnauthorizedException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(Collections.emptyList());
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id(DATAFEED_ID));
     AckId initialAckId = new AckId().ackId("");
     final String secondAckId = "ack-id";
@@ -349,11 +350,11 @@ class DatafeedLoopV2Test {
     this.datafeedService.start();
 
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
-    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true));
     verify(datafeedApi, times(1)).readDatafeed(DATAFEED_ID, TOKEN, TOKEN, initialAckId);
     assertEquals(secondAckId, datafeedService.getAckId());
   }
-
+  
   @Test
   void testClientErrorTriggersDatafeedRecreation() throws ApiException, AuthUnauthorizedException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(
@@ -370,7 +371,7 @@ class DatafeedLoopV2Test {
         .thenThrow(new ApiException(400, ""));
     when(datafeedApi.deleteDatafeed(DATAFEED_ID, TOKEN, TOKEN)).thenReturn(null);
 
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id(secondDatafeedId));
     when(datafeedApi.readDatafeed(secondDatafeedId, TOKEN, TOKEN, initialAckId))
         .thenReturn(new V5EventList().addEventsItem(
@@ -470,35 +471,35 @@ class DatafeedLoopV2Test {
   @Test
   void testStartAuthErrorCreateDatafeed() throws ApiException, AuthUnauthorizedException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(Collections.emptyList());
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenThrow(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenThrow(
         new ApiException(401, "unauthorized-error"));
     doThrow(AuthUnauthorizedException.class).when(authSession).refresh();
 
     assertThrows(AuthUnauthorizedException.class, this.datafeedService::start);
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
-    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true));
   }
 
   @Test
   void testStartClientErrorCreateDatafeed() throws ApiException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(Collections.emptyList());
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenThrow(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenThrow(
         new ApiException(400, "client-error"));
 
     assertThrows(ApiException.class, this.datafeedService::start);
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
-    verify(datafeedApi, times(2)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+    verify(datafeedApi, times(2)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true));
   }
 
   @Test
   void testStartServerErrorCreateDatafeed() throws ApiException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(Collections.emptyList());
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenThrow(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenThrow(
         new ApiException(502, "server-error"));
 
     assertThrows(ApiException.class, this.datafeedService::start);
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
-    verify(datafeedApi, times(2)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+    verify(datafeedApi, times(2)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true));
   }
 
   @Test
@@ -506,7 +507,7 @@ class DatafeedLoopV2Test {
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(
         Collections.singletonList(new V5Datafeed().id(DATAFEED_ID)));
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody()))
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true)))
         .thenThrow(new ApiException(400, "ALB: No matching rule found"))
         .thenReturn(new V5Datafeed().id("recreate-df-id"));
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId)).thenThrow(new ApiException(400, "client-error"));
@@ -520,7 +521,7 @@ class DatafeedLoopV2Test {
     verify(datafeedApi, times(1)).readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId);
     verify(datafeedApi, times(1)).readDatafeed("recreate-df-id", TOKEN, TOKEN, ackId);
     verify(datafeedApi, times(1)).deleteDatafeed(DATAFEED_ID, TOKEN, TOKEN);
-    verify(datafeedApi, times(2)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+    verify(datafeedApi, times(2)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true));
   }
 
   @Test
@@ -613,7 +614,7 @@ class DatafeedLoopV2Test {
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(
         Collections.singletonList(new V5Datafeed().id(DATAFEED_ID)));
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id("recreate-df-id"));
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId)).thenThrow(new ApiException(400, "client-error"));
     when(datafeedApi.readDatafeed("recreate-df-id", TOKEN, TOKEN, ackId))
@@ -626,7 +627,7 @@ class DatafeedLoopV2Test {
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
     verify(datafeedApi, times(1)).readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId);
     verify(datafeedApi, times(1)).readDatafeed("recreate-df-id", TOKEN, TOKEN, ackId);
-    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true));
     verify(datafeedApi, times(1)).deleteDatafeed(DATAFEED_ID, TOKEN, TOKEN);
   }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
@@ -127,7 +127,6 @@ class DatafeedLoopV2Test {
   void testStartInvalidExistingFeeds(String invalidExistingFeedId) throws ApiException, AuthUnauthorizedException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null))
         .thenReturn(Collections.singletonList(new V5Datafeed().id(invalidExistingFeedId)));
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
     when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id(DATAFEED_ID));
 

--- a/symphony-bdk-core/src/test/resources/config/config.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config.yaml
@@ -20,6 +20,7 @@ app:
     path: /Users/local/conf/agent/privatekey.pem
 
 datafeed:
+  includeInvisible: true
   retry:
     maxAttempts: 2
 


### PR DESCRIPTION
### Description
By default, the agent filters out invisible room events from its data feeds. Add a configuration parameter to allow these events to be included (false by default).

Added also an optional configuration parameter to specify a datafeed tag to pick

