### PR TITLE
Improve managing <messageML> tag

### DIFF
--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/model/MessageTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/model/MessageTest.java
@@ -32,6 +32,23 @@ class MessageTest {
   }
 
   @Test
+  void checkMessageMLNotAppendedToContentIfSetWithSpaces() {
+    assertEquals("<messageML>hello</messageML>", Message.builder().content(" <messageML>hello</messageML> ").build().getContent());
+  }
+
+  @Test
+  void checkMessageMLWithoutClosingTagThrowsException() {
+    MessageCreationException exception = assertThrows(MessageCreationException.class, Message.builder().content("<messageML>hello")::build);
+    assertEquals("Malformed <messageML> tag. Missing closing tag", exception.getMessage());
+  }
+
+  @Test
+  void checkMessageMLWithoutOpeningTagThrowsException() {
+    MessageCreationException exception = assertThrows(MessageCreationException.class, Message.builder().content("hello</messageML>")::build);
+    assertEquals("Malformed <messageML> tag. Missing opening tag", exception.getMessage());
+  }
+
+  @Test
   void checkMessageSilentValueIfSet() {
     assertEquals(Boolean.FALSE, Message.builder().content("<messageML>hello</messageML>").silent(Boolean.FALSE).build().getSilent());
   }


### PR DESCRIPTION
### Description
In previous versions of the BDK, the wrapping check was less restrictive. The logic has recently been updated to a stricter implementation.

Previous
```java
  if (!this.content.startsWith("<messageML>") && !this.content.endsWith("</messageML>")) {
```

Current:
```java
   boolean isAlreadyWrapped = this.content.startsWith("<messageML") && this.content.endsWith("</messageML>");
```

The Issue: This change broke compatibility with existing template files that include trailing characters, such as a Carriage Return (CR) or newlines after the closing </messageML> tag. While technically a template formatting issue, the current check is too rigid for real-world production environments where IDEs or OS-specific line endings might be appended.

To restore backward compatibility and improve robustness, I have implemented a more tolerant check that ignores leading and trailing whitespace, while throwing also exception if only one tag is present